### PR TITLE
fix(common): manual impl Default for `FeatureFlags` to align `FeatureFlags::default()` with Serde per-field default

### DIFF
--- a/compiler/crates/common/src/feature_flags.rs
+++ b/compiler/crates/common/src/feature_flags.rs
@@ -19,7 +19,7 @@ use serde::Serialize;
 use crate::Rollout;
 use crate::rollout::RolloutRange;
 
-#[derive(Default, Debug, Serialize, Deserialize, Clone, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct FeatureFlags {
     #[serde(default)]
@@ -181,7 +181,51 @@ pub struct FeatureFlags {
     pub legacy_include_path_in_required_reader_nodes: FeatureFlag,
 }
 
-#[derive(Debug, serde::Deserialize, Clone, Serialize, Default, JsonSchema)]
+impl Default for FeatureFlags {
+    fn default() -> Self {
+        FeatureFlags {
+            relay_resolver_enable_interface_output_type: Default::default(),
+            allow_output_type_resolvers: Default::default(),
+            no_inline: Default::default(),
+            enable_3d_branch_arg_generation: Default::default(),
+            actor_change_support: Default::default(),
+            text_artifacts: Default::default(),
+            skip_printing_nulls: Default::default(),
+            compact_query_text: Default::default(),
+            enable_resolver_normalization_ast: Default::default(),
+            enable_exec_time_resolvers_directive: Default::default(),
+            enable_relay_resolver_mutations: Default::default(),
+            enable_strict_custom_scalars: Default::default(),
+            allow_resolvers_in_mutation_response: Default::default(),
+            allow_required_in_mutation_response: Default::default(),
+            disable_resolver_reader_ast: Default::default(),
+            enable_fragment_argument_transform: Default::default(),
+            allow_resolver_non_nullable_return_type: Default::default(),
+            disable_schema_validation: Default::default(),
+            prefer_fetchable_in_refetch_queries: Default::default(),
+            disable_edge_type_name_validation_on_declerative_connection_directives:
+                Default::default(),
+            disable_full_argument_type_validation: Default::default(),
+            use_reader_module_imports: Default::default(),
+            omit_resolver_type_assertions_for_confirmed_types: Default::default(),
+            disable_deduping_common_structures_in_artifacts: Default::default(),
+            legacy_include_path_in_required_reader_nodes: Default::default(),
+
+            // enabled-by-default
+            enforce_fragment_alias_where_ambiguous: FeatureFlag::Enabled,
+        }
+    }
+}
+
+#[derive(
+    Debug,
+    serde::Deserialize,
+    Clone,
+    Serialize,
+    Default,
+    PartialEq,
+    JsonSchema
+)]
 #[serde(tag = "kind", rename_all = "lowercase")]
 pub enum FeatureFlag {
     /// Fully disabled: developers may not use this feature
@@ -235,5 +279,29 @@ impl Display for FeatureFlag {
             FeatureFlag::Rollout { rollout } => write!(f, "Rollout: {rollout:#?}"),
             FeatureFlag::RolloutRange { rollout } => write!(f, "RolloutRange: {rollout:#?}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_trait_sets_enforce_fragment_alias_enabled() {
+        let flags = FeatureFlags::default();
+        assert!(matches!(
+            flags.enforce_fragment_alias_where_ambiguous,
+            FeatureFlag::Enabled
+        ));
+        // A couple of quick sanity checks for other defaults
+        assert!(matches!(flags.no_inline, FeatureFlag::Disabled));
+        assert_eq!(flags.enable_resolver_normalization_ast, false);
+    }
+
+    #[test]
+    fn serde_default_from_empty_object_matches_intent() {
+        // When deserializing from an empty JSON object, serde applies per-field defaults.
+        let flags: FeatureFlags = serde_json::from_str("{} ").expect("valid json");
+        assert_eq!(flags, FeatureFlags::default());
     }
 }

--- a/compiler/crates/common/src/feature_flags.rs
+++ b/compiler/crates/common/src/feature_flags.rs
@@ -299,7 +299,7 @@ mod tests {
     }
 
     #[test]
-    fn serde_default_from_empty_object_matches_intent() {
+    fn serde_empty_object_deserializes_to_default() {
         // When deserializing from an empty JSON object, serde applies per-field defaults.
         let flags: FeatureFlags = serde_json::from_str("{} ").expect("valid json");
         assert_eq!(flags, FeatureFlags::default());

--- a/compiler/crates/common/src/rollout.rs
+++ b/compiler/crates/common/src/rollout.rs
@@ -14,7 +14,16 @@ use serde::Serialize;
 /// A utility to enable gradual rollout of large codegen changes.
 /// Can be constructed as the Default which passes or a percentage between 0 and
 /// 100.
-#[derive(Default, Debug, Serialize, Deserialize, Clone, Copy, JsonSchema)]
+#[derive(
+    Default,
+    Debug,
+    Serialize,
+    Deserialize,
+    Clone,
+    Copy,
+    PartialEq,
+    JsonSchema
+)]
 pub struct Rollout(pub Option<u8>);
 
 impl Rollout {
@@ -34,7 +43,7 @@ impl Rollout {
 
 /// A utility to enable gradual rollout of large codegen changes. Allows you to
 /// specify a range of percentages to rollout.
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, JsonSchema)]
+#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq, JsonSchema)]
 pub struct RolloutRange {
     pub start: u8,
     pub end: u8,

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-fragment-spread-conditional.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-fragment-spread-conditional.expected
@@ -5,7 +5,7 @@ query abstractTypeRefinementDontFlattenTypeDiscriminatorFragmentSpreadConditiona
       # Fragment will be inlined:
       #  - Printed query should select __isNode
       #  - Normalization ast should include inline fragment with abstractKey
-      ...abstractTypeRefinementDontFlattenTypeDiscriminatorFragmentSpreadConditional_NodeFragment
+  ...abstractTypeRefinementDontFlattenTypeDiscriminatorFragmentSpreadConditional_NodeFragment @alias
     }
   }
 }
@@ -47,8 +47,19 @@ fragment abstractTypeRefinementDontFlattenTypeDiscriminatorFragmentSpreadConditi
             "passingValue": true,
             "selections": [
               {
-                "args": null,
-                "kind": "FragmentSpread",
+                "fragment": {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    {
+                      "args": null,
+                      "kind": "FragmentSpread",
+                      "name": "abstractTypeRefinementDontFlattenTypeDiscriminatorFragmentSpreadConditional_NodeFragment"
+                    }
+                  ],
+                  "type": "Node",
+                  "abstractKey": "__isNode"
+                },
+                "kind": "AliasedInlineFragmentSpread",
                 "name": "abstractTypeRefinementDontFlattenTypeDiscriminatorFragmentSpreadConditional_NodeFragment"
               }
             ]

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-fragment-spread-conditional.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-fragment-spread-conditional.expected
@@ -5,7 +5,7 @@ query abstractTypeRefinementDontFlattenTypeDiscriminatorFragmentSpreadConditiona
       # Fragment will be inlined:
       #  - Printed query should select __isNode
       #  - Normalization ast should include inline fragment with abstractKey
-  ...abstractTypeRefinementDontFlattenTypeDiscriminatorFragmentSpreadConditional_NodeFragment @alias
+      ...abstractTypeRefinementDontFlattenTypeDiscriminatorFragmentSpreadConditional_NodeFragment @alias
     }
   }
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-fragment-spread-conditional.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-fragment-spread-conditional.graphql
@@ -4,7 +4,7 @@ query abstractTypeRefinementDontFlattenTypeDiscriminatorFragmentSpreadConditiona
       # Fragment will be inlined:
       #  - Printed query should select __isNode
       #  - Normalization ast should include inline fragment with abstractKey
-      ...abstractTypeRefinementDontFlattenTypeDiscriminatorFragmentSpreadConditional_NodeFragment
+  ...abstractTypeRefinementDontFlattenTypeDiscriminatorFragmentSpreadConditional_NodeFragment @alias
     }
   }
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-fragment-spread-conditional.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-flatten-type-discriminator-fragment-spread-conditional.graphql
@@ -4,7 +4,7 @@ query abstractTypeRefinementDontFlattenTypeDiscriminatorFragmentSpreadConditiona
       # Fragment will be inlined:
       #  - Printed query should select __isNode
       #  - Normalization ast should include inline fragment with abstractKey
-  ...abstractTypeRefinementDontFlattenTypeDiscriminatorFragmentSpreadConditional_NodeFragment @alias
+      ...abstractTypeRefinementDontFlattenTypeDiscriminatorFragmentSpreadConditional_NodeFragment @alias
     }
   }
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-fragment-spread.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-fragment-spread.expected
@@ -4,13 +4,13 @@ query abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_AbstractType
     # After inlining even though `id` will be skipped:
     #  - Printed query should still select __isNode and __isActor
     #  - Normalization ast should include inline fragments with abstractKeys for Node and Actor
-    ...abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_ActorFragment
+  ...abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_ActorFragment @alias
   }
 }
 
 fragment abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_ActorFragment on Actor {
   username
-  ...abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_NodeFragment
+  ...abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_NodeFragment @alias
 }
 
 fragment abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_NodeFragment on Node {
@@ -39,8 +39,19 @@ fragment abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_NodeFragm
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_ActorFragment"
+                }
+              ],
+              "type": "Actor",
+              "abstractKey": "__isActor"
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_ActorFragment"
           }
         ],
@@ -153,8 +164,19 @@ fragment abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_NodeFragm
       "storageKey": null
     },
     {
-      "args": null,
-      "kind": "FragmentSpread",
+      "fragment": {
+        "kind": "InlineFragment",
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_NodeFragment"
+          }
+        ],
+        "type": "Node",
+        "abstractKey": "__isNode"
+      },
+      "kind": "AliasedInlineFragmentSpread",
       "name": "abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_NodeFragment"
     }
   ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-fragment-spread.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-fragment-spread.expected
@@ -4,7 +4,7 @@ query abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_AbstractType
     # After inlining even though `id` will be skipped:
     #  - Printed query should still select __isNode and __isActor
     #  - Normalization ast should include inline fragments with abstractKeys for Node and Actor
-  ...abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_ActorFragment @alias
+    ...abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_ActorFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-fragment-spread.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-fragment-spread.graphql
@@ -3,13 +3,13 @@ query abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_AbstractType
     # After inlining even though `id` will be skipped:
     #  - Printed query should still select __isNode and __isActor
     #  - Normalization ast should include inline fragments with abstractKeys for Node and Actor
-    ...abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_ActorFragment
+  ...abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_ActorFragment @alias
   }
 }
 
 fragment abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_ActorFragment on Actor {
   username
-  ...abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_NodeFragment
+  ...abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_NodeFragment @alias
 }
 
 fragment abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_NodeFragment on Node {

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-fragment-spread.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-fragment-spread.graphql
@@ -3,7 +3,7 @@ query abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_AbstractType
     # After inlining even though `id` will be skipped:
     #  - Printed query should still select __isNode and __isActor
     #  - Normalization ast should include inline fragments with abstractKeys for Node and Actor
-  ...abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_ActorFragment @alias
+    ...abstractTypeRefinementDontSkipTypeDiscriminatorFragmentSpread_ActorFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-inline-fragment.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-inline-fragment.expected
@@ -4,7 +4,7 @@ query abstractTypeRefinementDontSkipTypeDiscriminatorInlineFragment_AbstractType
     # After inlining even though `id` will be skipped:
     #  - Printed query should still select __isNode and __isActor
     #  - Normalization ast should include inline fragments with abstractKeys for Node and Actor
-  ...abstractTypeRefinementDontSkipTypeDiscriminatorInlineFragment_ActorFragment @alias
+    ...abstractTypeRefinementDontSkipTypeDiscriminatorInlineFragment_ActorFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-inline-fragment.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-inline-fragment.expected
@@ -4,7 +4,7 @@ query abstractTypeRefinementDontSkipTypeDiscriminatorInlineFragment_AbstractType
     # After inlining even though `id` will be skipped:
     #  - Printed query should still select __isNode and __isActor
     #  - Normalization ast should include inline fragments with abstractKeys for Node and Actor
-    ...abstractTypeRefinementDontSkipTypeDiscriminatorInlineFragment_ActorFragment
+  ...abstractTypeRefinementDontSkipTypeDiscriminatorInlineFragment_ActorFragment @alias
   }
 }
 
@@ -37,8 +37,19 @@ fragment abstractTypeRefinementDontSkipTypeDiscriminatorInlineFragment_ActorFrag
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "abstractTypeRefinementDontSkipTypeDiscriminatorInlineFragment_ActorFragment"
+                }
+              ],
+              "type": "Actor",
+              "abstractKey": "__isActor"
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "abstractTypeRefinementDontSkipTypeDiscriminatorInlineFragment_ActorFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-inline-fragment.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-inline-fragment.graphql
@@ -3,7 +3,7 @@ query abstractTypeRefinementDontSkipTypeDiscriminatorInlineFragment_AbstractType
     # After inlining even though `id` will be skipped:
     #  - Printed query should still select __isNode and __isActor
     #  - Normalization ast should include inline fragments with abstractKeys for Node and Actor
-  ...abstractTypeRefinementDontSkipTypeDiscriminatorInlineFragment_ActorFragment @alias
+    ...abstractTypeRefinementDontSkipTypeDiscriminatorInlineFragment_ActorFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-inline-fragment.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement-dont-skip-type-discriminator-inline-fragment.graphql
@@ -3,7 +3,7 @@ query abstractTypeRefinementDontSkipTypeDiscriminatorInlineFragment_AbstractType
     # After inlining even though `id` will be skipped:
     #  - Printed query should still select __isNode and __isActor
     #  - Normalization ast should include inline fragments with abstractKeys for Node and Actor
-    ...abstractTypeRefinementDontSkipTypeDiscriminatorInlineFragment_ActorFragment
+  ...abstractTypeRefinementDontSkipTypeDiscriminatorInlineFragment_ActorFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement.expected
@@ -4,7 +4,7 @@ query abstractTypeRefinement_AbstractTypeRefinementQuery {
     ... on Named {
       name_from_query: name
     }
-    ...abstractTypeRefinement_ActorFragment
+    ...abstractTypeRefinement_ActorFragment @alias
   }
 }
 
@@ -51,8 +51,19 @@ fragment abstractTypeRefinement_ActorFragment on Actor {
             "abstractKey": "__isNamed"
           },
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "abstractTypeRefinement_ActorFragment"
+                }
+              ],
+              "type": "Actor",
+              "abstractKey": "__isActor"
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "abstractTypeRefinement_ActorFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/abstract-type-refinement.graphql
@@ -3,7 +3,7 @@ query abstractTypeRefinement_AbstractTypeRefinementQuery {
     ... on Named {
       name_from_query: name
     }
-    ...abstractTypeRefinement_ActorFragment
+    ...abstractTypeRefinement_ActorFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/actor-change-simple-query.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/actor-change-simple-query.expected
@@ -4,10 +4,14 @@ query actorChangeSimpleQuery {
     id
     ... on User {
       actor @fb_actor_change {
-        ...actorChangeSimpleQueryUserFragment
+        ...actorChangeSimpleQuery_ActorFragment
       }
     }
   }
+}
+
+fragment actorChangeSimpleQuery_ActorFragment on Actor {
+  ...actorChangeSimpleQueryUserFragment @alias
 }
 
 fragment actorChangeSimpleQueryUserFragment on User {
@@ -54,7 +58,7 @@ fragment actorChangeSimpleQueryUserFragment on User {
                 "fragmentSpread": {
                   "args": null,
                   "kind": "FragmentSpread",
-                  "name": "actorChangeSimpleQueryUserFragment"
+                  "name": "actorChangeSimpleQuery_ActorFragment"
                 }
               }
             ],
@@ -123,6 +127,10 @@ fragment actorChangeSimpleQueryUserFragment on User {
                       "storageKey": null
                     },
                     {
+                      "kind": "TypeDiscriminator",
+                      "abstractKey": "__isActor"
+                    },
+                    {
                       "kind": "InlineFragment",
                       "selections": [
                         {
@@ -182,7 +190,7 @@ query actorChangeSimpleQuery {
     ... on User {
       actor @fb_actor_change {
         __typename
-        ...actorChangeSimpleQueryUserFragment
+        ...actorChangeSimpleQuery_ActorFragment
         actor_key
         id
       }
@@ -192,6 +200,11 @@ query actorChangeSimpleQuery {
 
 fragment actorChangeSimpleQueryUserFragment on User {
   name
+}
+
+fragment actorChangeSimpleQuery_ActorFragment on Actor {
+  __isActor: __typename
+  ...actorChangeSimpleQueryUserFragment
 }
 
 
@@ -211,4 +224,31 @@ fragment actorChangeSimpleQueryUserFragment on User {
   ],
   "type": "User",
   "abstractKey": null
+}
+
+{
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "actorChangeSimpleQuery_ActorFragment",
+  "selections": [
+    {
+      "fragment": {
+        "kind": "InlineFragment",
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "actorChangeSimpleQueryUserFragment"
+          }
+        ],
+        "type": "User",
+        "abstractKey": null
+      },
+      "kind": "AliasedInlineFragmentSpread",
+      "name": "actorChangeSimpleQueryUserFragment"
+    }
+  ],
+  "type": "Actor",
+  "abstractKey": "__isActor"
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/actor-change-simple-query.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/actor-change-simple-query.graphql
@@ -3,10 +3,14 @@ query actorChangeSimpleQuery {
     id
     ... on User {
       actor @fb_actor_change {
-        ...actorChangeSimpleQueryUserFragment
+        ...actorChangeSimpleQuery_ActorFragment
       }
     }
   }
+}
+
+fragment actorChangeSimpleQuery_ActorFragment on Actor {
+  ...actorChangeSimpleQueryUserFragment @alias
 }
 
 fragment actorChangeSimpleQueryUserFragment on User {

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-3D-resolvers-enabled-server-3D-fragment.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-3D-resolvers-enabled-server-3D-fragment.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query client3DResolversEnabledServer3DFragment_NameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...client3DResolversEnabledServer3DFragment_NameRendererFragment
+    ...client3DResolversEnabledServer3DFragment_NameRendererFragment @alias
   }
 }
 
@@ -107,8 +107,19 @@ fragment client3DResolversEnabledServer3DFragment_MarkdownUserNameRenderer_name 
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "client3DResolversEnabledServer3DFragment_NameRendererFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "client3DResolversEnabledServer3DFragment_NameRendererFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-3D-resolvers-enabled-server-3D-fragment.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-3D-resolvers-enabled-server-3D-fragment.graphql
@@ -1,6 +1,6 @@
 query client3DResolversEnabledServer3DFragment_NameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...client3DResolversEnabledServer3DFragment_NameRendererFragment
+    ...client3DResolversEnabledServer3DFragment_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-fields-with-undefined-global-variables.invalid.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-fields-with-undefined-global-variables.invalid.expected
@@ -17,10 +17,10 @@ extend type User {
   pop_star_name(scale: Float!): String
 }
 ==================================== ERROR ====================================
-✖︎ Operation 'clientFieldsWithUndefinedGlobalVariablesQuery' references undefined variable: '$scale'.
+✖︎ Expected `@alias` directive. `clientFieldsWithUndefinedGlobalVariables_user` is defined on `User` which might not match this selection type of `Node`. Add `@alias` to this spread to expose the fragment reference as a nullable property.
 
-  client-fields-with-undefined-global-variables.invalid.graphql:10:24
-    9 │ fragment clientFieldsWithUndefinedGlobalVariables_user on User {
-   10 │   pop_star_name(scale: $scale)
-      │                        ^^^^^^
-   11 │ }
+  client-fields-with-undefined-global-variables.invalid.graphql:5:8
+    4 │   node(id: $id) {
+    5 │     ...clientFieldsWithUndefinedGlobalVariables_user
+      │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │   }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-fragment-spreads-in-query.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-fragment-spreads-in-query.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query clientFragmentSpreadsInQuery_FooQuery($id: ID!) {
   node(id: $id) {
-    ...clientFragmentSpreadsInQuery_Foo_user
+  ...clientFragmentSpreadsInQuery_Foo_user @alias
   }
 }
 
@@ -54,8 +54,19 @@ type ClientType {
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "clientFragmentSpreadsInQuery_Foo_user"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "clientFragmentSpreadsInQuery_Foo_user"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-fragment-spreads-in-query.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-fragment-spreads-in-query.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query clientFragmentSpreadsInQuery_FooQuery($id: ID!) {
   node(id: $id) {
-  ...clientFragmentSpreadsInQuery_Foo_user @alias
+    ...clientFragmentSpreadsInQuery_Foo_user @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-fragment-spreads-in-query.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-fragment-spreads-in-query.graphql
@@ -1,6 +1,6 @@
 query clientFragmentSpreadsInQuery_FooQuery($id: ID!) {
   node(id: $id) {
-  ...clientFragmentSpreadsInQuery_Foo_user @alias
+    ...clientFragmentSpreadsInQuery_Foo_user @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-fragment-spreads-in-query.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-fragment-spreads-in-query.graphql
@@ -1,6 +1,6 @@
 query clientFragmentSpreadsInQuery_FooQuery($id: ID!) {
   node(id: $id) {
-    ...clientFragmentSpreadsInQuery_Foo_user
+  ...clientFragmentSpreadsInQuery_Foo_user @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-inline-fragments-in-query.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-inline-fragments-in-query.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query clientInlineFragmentsInQuery_FooQuery($id: ID!) {
   node(id: $id) {
-    ...clientInlineFragmentsInQuery_Foo_user
+  ...clientInlineFragmentsInQuery_Foo_user @alias
   }
 }
 
@@ -52,8 +52,19 @@ interface ClientNamed {
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "clientInlineFragmentsInQuery_Foo_user"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "clientInlineFragmentsInQuery_Foo_user"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-inline-fragments-in-query.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-inline-fragments-in-query.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query clientInlineFragmentsInQuery_FooQuery($id: ID!) {
   node(id: $id) {
-  ...clientInlineFragmentsInQuery_Foo_user @alias
+    ...clientInlineFragmentsInQuery_Foo_user @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-inline-fragments-in-query.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-inline-fragments-in-query.graphql
@@ -1,6 +1,6 @@
 query clientInlineFragmentsInQuery_FooQuery($id: ID!) {
   node(id: $id) {
-  ...clientInlineFragmentsInQuery_Foo_user @alias
+    ...clientInlineFragmentsInQuery_Foo_user @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-inline-fragments-in-query.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-inline-fragments-in-query.graphql
@@ -1,6 +1,6 @@
 query clientInlineFragmentsInQuery_FooQuery($id: ID!) {
   node(id: $id) {
-    ...clientInlineFragmentsInQuery_Foo_user
+  ...clientInlineFragmentsInQuery_Foo_user @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-only-query.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-only-query.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query clientOnlyQuery {
   __id
-  ...clientOnlyQueryFragment @skip(if: true)
+  ...clientOnlyQueryFragment @alias @skip(if: true)
 }
 
 fragment clientOnlyQueryFragment on Query {

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-only-query.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/client-only-query.graphql
@@ -1,6 +1,6 @@
 query clientOnlyQuery {
   __id
-  ...clientOnlyQueryFragment @skip(if: true)
+  ...clientOnlyQueryFragment @alias @skip(if: true)
 }
 
 fragment clientOnlyQueryFragment on Query {

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/connection-with-dynamic-key-missing-variable-definition.invalid.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/connection-with-dynamic-key-missing-variable-definition.invalid.expected
@@ -37,19 +37,19 @@ fragment connectionWithDynamicKeyMissingVariableDefinitionFeedbackFragment on Fe
   }
 }
 ==================================== ERROR ====================================
-✖︎ Operation 'connectionWithDynamicKeyMissingVariableDefinitionFeedbackQuery' references undefined variable: '$commentsKey'.
+✖︎ Expected `@alias` directive. `connectionWithDynamicKeyMissingVariableDefinitionFeedbackFragment` is defined on `Feedback` which might not match this selection type of `Node`. Add `@alias` to this spread to expose the fragment reference as a nullable property.
 
-  connection-with-dynamic-key-missing-variable-definition.invalid.graphql:28:28
-   27 │       key: "FeedbackFragment_comments"
-   28 │       dynamicKey_UNSTABLE: $commentsKey
-      │                            ^^^^^^^^^^^^
-   29 │       filters: ["orderby"]
+  connection-with-dynamic-key-missing-variable-definition.invalid.graphql:14:8
+   13 │   node(id: $id) {
+   14 │     ...connectionWithDynamicKeyMissingVariableDefinitionFeedbackFragment
+      │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   15 │       @arguments(count: $count, cursor: $cursor)
 
 
-✖︎ Operation 'connectionWithDynamicKeyMissingVariableDefinitionPaginationQuery' references undefined variable: '$commentsKey'.
+✖︎ Expected `@alias` directive. `connectionWithDynamicKeyMissingVariableDefinitionFeedbackFragment` is defined on `Feedback` which might not match this selection type of `Node`. Add `@alias` to this spread to expose the fragment reference as a nullable property.
 
-  connection-with-dynamic-key-missing-variable-definition.invalid.graphql:28:28
-   27 │       key: "FeedbackFragment_comments"
-   28 │       dynamicKey_UNSTABLE: $commentsKey
-      │                            ^^^^^^^^^^^^
-   29 │       filters: ["orderby"]
+  connection-with-dynamic-key-missing-variable-definition.invalid.graphql:4:8
+    3 │   node(id: $id) {
+    4 │     ...connectionWithDynamicKeyMissingVariableDefinitionFeedbackFragment
+      │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │   }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/connection-with-dynamic-key.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/connection-with-dynamic-key.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query connectionWithDynamicKey_FeedbackQuery($id: ID!, $commentsKey: String) {
   node(id: $id) {
-  ...connectionWithDynamicKey_FeedbackFragment @alias
+    ...connectionWithDynamicKey_FeedbackFragment @alias
   }
 }
 
@@ -12,7 +12,7 @@ query connectionWithDynamicKey_PaginationQuery(
   $cursor: ID!
 ) {
   node(id: $id) {
-  ...connectionWithDynamicKey_FeedbackFragment @alias @arguments(count: $count, cursor: $cursor)
+    ...connectionWithDynamicKey_FeedbackFragment @alias @arguments(count: $count, cursor: $cursor)
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/connection-with-dynamic-key.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/connection-with-dynamic-key.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query connectionWithDynamicKey_FeedbackQuery($id: ID!, $commentsKey: String) {
   node(id: $id) {
-    ...connectionWithDynamicKey_FeedbackFragment
+  ...connectionWithDynamicKey_FeedbackFragment @alias
   }
 }
 
@@ -12,7 +12,7 @@ query connectionWithDynamicKey_PaginationQuery(
   $cursor: ID!
 ) {
   node(id: $id) {
-    ...connectionWithDynamicKey_FeedbackFragment @arguments(count: $count, cursor: $cursor)
+  ...connectionWithDynamicKey_FeedbackFragment @alias @arguments(count: $count, cursor: $cursor)
   }
 }
 
@@ -69,8 +69,19 @@ fragment connectionWithDynamicKey_FeedbackFragment on Feedback
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "connectionWithDynamicKey_FeedbackFragment"
+                }
+              ],
+              "type": "Feedback",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "connectionWithDynamicKey_FeedbackFragment"
           }
         ],
@@ -337,19 +348,30 @@ fragment connectionWithDynamicKey_FeedbackFragment on Feedback {
         "plural": false,
         "selections": [
           {
-            "args": [
-              {
-                "kind": "Variable",
-                "name": "count",
-                "variableName": "count"
-              },
-              {
-                "kind": "Variable",
-                "name": "cursor",
-                "variableName": "cursor"
-              }
-            ],
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": [
+                    {
+                      "kind": "Variable",
+                      "name": "count",
+                      "variableName": "count"
+                    },
+                    {
+                      "kind": "Variable",
+                      "name": "cursor",
+                      "variableName": "cursor"
+                    }
+                  ],
+                  "kind": "FragmentSpread",
+                  "name": "connectionWithDynamicKey_FeedbackFragment"
+                }
+              ],
+              "type": "Feedback",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "connectionWithDynamicKey_FeedbackFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/connection-with-dynamic-key.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/connection-with-dynamic-key.graphql
@@ -1,6 +1,6 @@
 query connectionWithDynamicKey_FeedbackQuery($id: ID!, $commentsKey: String) {
   node(id: $id) {
-  ...connectionWithDynamicKey_FeedbackFragment @alias
+    ...connectionWithDynamicKey_FeedbackFragment @alias
   }
 }
 
@@ -11,7 +11,7 @@ query connectionWithDynamicKey_PaginationQuery(
   $cursor: ID!
 ) {
   node(id: $id) {
-  ...connectionWithDynamicKey_FeedbackFragment @alias @arguments(count: $count, cursor: $cursor)
+    ...connectionWithDynamicKey_FeedbackFragment @alias @arguments(count: $count, cursor: $cursor)
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/connection-with-dynamic-key.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/connection-with-dynamic-key.graphql
@@ -1,6 +1,6 @@
 query connectionWithDynamicKey_FeedbackQuery($id: ID!, $commentsKey: String) {
   node(id: $id) {
-    ...connectionWithDynamicKey_FeedbackFragment
+  ...connectionWithDynamicKey_FeedbackFragment @alias
   }
 }
 
@@ -11,7 +11,7 @@ query connectionWithDynamicKey_PaginationQuery(
   $cursor: ID!
 ) {
   node(id: $id) {
-    ...connectionWithDynamicKey_FeedbackFragment @arguments(count: $count, cursor: $cursor)
+  ...connectionWithDynamicKey_FeedbackFragment @alias @arguments(count: $count, cursor: $cursor)
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/defer-multiple-fragments-same-parent.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/defer-multiple-fragments-same-parent.expected
@@ -2,8 +2,8 @@
 query deferMultipleFragmentsSameParent_QueryWithMultipeDeferredFragmentsOnSameParentQuery($id: ID!) {
   feedback: node(id: $id) {
     id
-    ...deferMultipleFragmentsSameParent_FeedbackComments_feedback @defer
-    ...deferMultipleFragmentsSameParent_FeedbackText_feedback @defer
+  ...deferMultipleFragmentsSameParent_FeedbackComments_feedback @alias @defer
+  ...deferMultipleFragmentsSameParent_FeedbackText_feedback @alias @defer
   }
 }
 
@@ -61,24 +61,46 @@ fragment deferMultipleFragmentsSameParent_FeedbackText_feedback on Feedback {
             "storageKey": null
           },
           {
-            "kind": "Defer",
-            "selections": [
-              {
-                "args": null,
-                "kind": "FragmentSpread",
-                "name": "deferMultipleFragmentsSameParent_FeedbackComments_feedback"
-              }
-            ]
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "kind": "Defer",
+                  "selections": [
+                    {
+                      "args": null,
+                      "kind": "FragmentSpread",
+                      "name": "deferMultipleFragmentsSameParent_FeedbackComments_feedback"
+                    }
+                  ]
+                }
+              ],
+              "type": "Feedback",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
+            "name": "deferMultipleFragmentsSameParent_FeedbackComments_feedback"
           },
           {
-            "kind": "Defer",
-            "selections": [
-              {
-                "args": null,
-                "kind": "FragmentSpread",
-                "name": "deferMultipleFragmentsSameParent_FeedbackText_feedback"
-              }
-            ]
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "kind": "Defer",
+                  "selections": [
+                    {
+                      "args": null,
+                      "kind": "FragmentSpread",
+                      "name": "deferMultipleFragmentsSameParent_FeedbackText_feedback"
+                    }
+                  ]
+                }
+              ],
+              "type": "Feedback",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
+            "name": "deferMultipleFragmentsSameParent_FeedbackText_feedback"
           }
         ],
         "storageKey": null

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/defer-multiple-fragments-same-parent.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/defer-multiple-fragments-same-parent.expected
@@ -2,8 +2,8 @@
 query deferMultipleFragmentsSameParent_QueryWithMultipeDeferredFragmentsOnSameParentQuery($id: ID!) {
   feedback: node(id: $id) {
     id
-  ...deferMultipleFragmentsSameParent_FeedbackComments_feedback @alias @defer
-  ...deferMultipleFragmentsSameParent_FeedbackText_feedback @alias @defer
+    ...deferMultipleFragmentsSameParent_FeedbackComments_feedback @alias @defer
+    ...deferMultipleFragmentsSameParent_FeedbackText_feedback @alias @defer
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/defer-multiple-fragments-same-parent.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/defer-multiple-fragments-same-parent.graphql
@@ -1,8 +1,8 @@
 query deferMultipleFragmentsSameParent_QueryWithMultipeDeferredFragmentsOnSameParentQuery($id: ID!) {
   feedback: node(id: $id) {
     id
-  ...deferMultipleFragmentsSameParent_FeedbackComments_feedback @alias @defer
-  ...deferMultipleFragmentsSameParent_FeedbackText_feedback @alias @defer
+    ...deferMultipleFragmentsSameParent_FeedbackComments_feedback @alias @defer
+    ...deferMultipleFragmentsSameParent_FeedbackText_feedback @alias @defer
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/defer-multiple-fragments-same-parent.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/defer-multiple-fragments-same-parent.graphql
@@ -1,8 +1,8 @@
 query deferMultipleFragmentsSameParent_QueryWithMultipeDeferredFragmentsOnSameParentQuery($id: ID!) {
   feedback: node(id: $id) {
     id
-    ...deferMultipleFragmentsSameParent_FeedbackComments_feedback @defer
-    ...deferMultipleFragmentsSameParent_FeedbackText_feedback @defer
+  ...deferMultipleFragmentsSameParent_FeedbackComments_feedback @alias @defer
+  ...deferMultipleFragmentsSameParent_FeedbackText_feedback @alias @defer
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-node-interface.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-node-interface.expected
@@ -4,7 +4,7 @@ fragment fragmentOnNodeInterface_RefetchableFragment on Node
   id
   ... on User {
     name
-  ...fragmentOnNodeInterface_ProfilePicture @alias
+    ...fragmentOnNodeInterface_ProfilePicture @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-node-interface.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-node-interface.expected
@@ -4,7 +4,7 @@ fragment fragmentOnNodeInterface_RefetchableFragment on Node
   id
   ... on User {
     name
-    ...fragmentOnNodeInterface_ProfilePicture
+  ...fragmentOnNodeInterface_ProfilePicture @alias
   }
 }
 
@@ -270,8 +270,19 @@ fragment fragmentOnNodeInterface_RefetchableFragment on Node {
           "storageKey": null
         },
         {
-          "args": null,
-          "kind": "FragmentSpread",
+          "fragment": {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "fragmentOnNodeInterface_ProfilePicture"
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          },
+          "kind": "AliasedInlineFragmentSpread",
           "name": "fragmentOnNodeInterface_ProfilePicture"
         }
       ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-node-interface.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-node-interface.graphql
@@ -3,7 +3,7 @@ fragment fragmentOnNodeInterface_RefetchableFragment on Node
   id
   ... on User {
     name
-    ...fragmentOnNodeInterface_ProfilePicture
+  ...fragmentOnNodeInterface_ProfilePicture @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-node-interface.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-node-interface.graphql
@@ -3,7 +3,7 @@ fragment fragmentOnNodeInterface_RefetchableFragment on Node
   id
   ... on User {
     name
-  ...fragmentOnNodeInterface_ProfilePicture @alias
+    ...fragmentOnNodeInterface_ProfilePicture @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-non-node-fetchable-type.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-non-node-fetchable-type.expected
@@ -2,7 +2,7 @@
 fragment fragmentOnNonNodeFetchableType_RefetchableFragment on NonNodeStory
   @refetchable(queryName: "RefetchableFragmentQuery") {
   actor {
-  ...fragmentOnNonNodeFetchableType_ProfilePicture @alias
+    ...fragmentOnNonNodeFetchableType_ProfilePicture @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-non-node-fetchable-type.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-non-node-fetchable-type.expected
@@ -2,7 +2,7 @@
 fragment fragmentOnNonNodeFetchableType_RefetchableFragment on NonNodeStory
   @refetchable(queryName: "RefetchableFragmentQuery") {
   actor {
-    ...fragmentOnNonNodeFetchableType_ProfilePicture
+  ...fragmentOnNonNodeFetchableType_ProfilePicture @alias
   }
 }
 
@@ -272,8 +272,19 @@ fragment fragmentOnNonNodeFetchableType_RefetchableFragment on NonNodeStory {
       "plural": false,
       "selections": [
         {
-          "args": null,
-          "kind": "FragmentSpread",
+          "fragment": {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "fragmentOnNonNodeFetchableType_ProfilePicture"
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          },
+          "kind": "AliasedInlineFragmentSpread",
           "name": "fragmentOnNonNodeFetchableType_ProfilePicture"
         }
       ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-non-node-fetchable-type.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-non-node-fetchable-type.graphql
@@ -1,7 +1,7 @@
 fragment fragmentOnNonNodeFetchableType_RefetchableFragment on NonNodeStory
   @refetchable(queryName: "RefetchableFragmentQuery") {
   actor {
-  ...fragmentOnNonNodeFetchableType_ProfilePicture @alias
+    ...fragmentOnNonNodeFetchableType_ProfilePicture @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-non-node-fetchable-type.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-non-node-fetchable-type.graphql
@@ -1,7 +1,7 @@
 fragment fragmentOnNonNodeFetchableType_RefetchableFragment on NonNodeStory
   @refetchable(queryName: "RefetchableFragmentQuery") {
   actor {
-    ...fragmentOnNonNodeFetchableType_ProfilePicture
+  ...fragmentOnNonNodeFetchableType_ProfilePicture @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query-commonjs-relativize-disabled.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query-commonjs-relativize-disabled.expected
@@ -6,7 +6,7 @@ fragment fragmentOnQueryCommonjsRelativizeDisabled_RefetchableFragment on Query
     ... on User {
       id
       name
-  ...fragmentOnQueryCommonjsRelativizeDisabled_ProfilePicture @alias
+      ...fragmentOnQueryCommonjsRelativizeDisabled_ProfilePicture @alias
     }
   }
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query-commonjs-relativize-disabled.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query-commonjs-relativize-disabled.expected
@@ -6,7 +6,7 @@ fragment fragmentOnQueryCommonjsRelativizeDisabled_RefetchableFragment on Query
     ... on User {
       id
       name
-      ...fragmentOnQueryCommonjsRelativizeDisabled_ProfilePicture
+  ...fragmentOnQueryCommonjsRelativizeDisabled_ProfilePicture @alias
     }
   }
 }
@@ -277,8 +277,19 @@ import RefetchableFragmentQuery_graphql from './RefetchableFragmentQuery.graphql
               "storageKey": null
             },
             {
-              "args": null,
-              "kind": "FragmentSpread",
+              "fragment": {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "args": null,
+                    "kind": "FragmentSpread",
+                    "name": "fragmentOnQueryCommonjsRelativizeDisabled_ProfilePicture"
+                  }
+                ],
+                "type": "User",
+                "abstractKey": null
+              },
+              "kind": "AliasedInlineFragmentSpread",
               "name": "fragmentOnQueryCommonjsRelativizeDisabled_ProfilePicture"
             }
           ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query-commonjs-relativize-disabled.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query-commonjs-relativize-disabled.graphql
@@ -5,7 +5,7 @@ fragment fragmentOnQueryCommonjsRelativizeDisabled_RefetchableFragment on Query
     ... on User {
       id
       name
-      ...fragmentOnQueryCommonjsRelativizeDisabled_ProfilePicture
+  ...fragmentOnQueryCommonjsRelativizeDisabled_ProfilePicture @alias
     }
   }
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query-commonjs-relativize-disabled.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query-commonjs-relativize-disabled.graphql
@@ -5,7 +5,7 @@ fragment fragmentOnQueryCommonjsRelativizeDisabled_RefetchableFragment on Query
     ... on User {
       id
       name
-  ...fragmentOnQueryCommonjsRelativizeDisabled_ProfilePicture @alias
+      ...fragmentOnQueryCommonjsRelativizeDisabled_ProfilePicture @alias
     }
   }
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query-commonjs.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query-commonjs.expected
@@ -6,7 +6,7 @@ fragment fragmentOnQueryCommonjs_RefetchableFragment on Query
     ... on User {
       id
       name
-  ...fragmentOnQueryCommonjs_ProfilePicture @alias
+      ...fragmentOnQueryCommonjs_ProfilePicture @alias
     }
   }
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query-commonjs.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query-commonjs.expected
@@ -6,7 +6,7 @@ fragment fragmentOnQueryCommonjs_RefetchableFragment on Query
     ... on User {
       id
       name
-      ...fragmentOnQueryCommonjs_ProfilePicture
+  ...fragmentOnQueryCommonjs_ProfilePicture @alias
     }
   }
 }
@@ -277,8 +277,19 @@ import RefetchableFragmentQuery_graphql from './RefetchableFragmentQuery.graphql
               "storageKey": null
             },
             {
-              "args": null,
-              "kind": "FragmentSpread",
+              "fragment": {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "args": null,
+                    "kind": "FragmentSpread",
+                    "name": "fragmentOnQueryCommonjs_ProfilePicture"
+                  }
+                ],
+                "type": "User",
+                "abstractKey": null
+              },
+              "kind": "AliasedInlineFragmentSpread",
               "name": "fragmentOnQueryCommonjs_ProfilePicture"
             }
           ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query-commonjs.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query-commonjs.graphql
@@ -5,7 +5,7 @@ fragment fragmentOnQueryCommonjs_RefetchableFragment on Query
     ... on User {
       id
       name
-  ...fragmentOnQueryCommonjs_ProfilePicture @alias
+      ...fragmentOnQueryCommonjs_ProfilePicture @alias
     }
   }
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query-commonjs.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query-commonjs.graphql
@@ -5,7 +5,7 @@ fragment fragmentOnQueryCommonjs_RefetchableFragment on Query
     ... on User {
       id
       name
-      ...fragmentOnQueryCommonjs_ProfilePicture
+  ...fragmentOnQueryCommonjs_ProfilePicture @alias
     }
   }
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query-with-cycle.invalid.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query-with-cycle.invalid.expected
@@ -30,34 +30,10 @@ fragment fragmentOnQueryWithCycle_Profile on User
   }
 }
 ==================================== ERROR ====================================
-✖︎ Found a circular reference from fragment 'fragmentOnQueryWithCycle_Profile'.
-
-  fragment-on-query-with-cycle.invalid.graphql:26:12
-   25 │       node {
-   26 │         ...fragmentOnQueryWithCycle_Profile
-      │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   27 │       }
-
-  ℹ︎ other member of the cycle
-
-  fragment-on-query-with-cycle.invalid.graphql:2:10
-    1 │ # expected-to-throw
-    2 │ fragment fragmentOnQueryWithCycle_RefetchableFragment on Query
-      │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    3 │   @refetchable(queryName: "RefetchableFragmentQuery")
-
-  ℹ︎ other member of the cycle
+✖︎ Expected `@alias` directive. `fragmentOnQueryWithCycle_Profile` is defined on `User` which might not match this selection type of `Node`. Add `@alias` to this spread to expose the fragment reference as a nullable property. NOTE: The selection type inferred here does not include inline fragments because Relay does not always model inline fragment type refinements in its generated types.
 
   fragment-on-query-with-cycle.invalid.graphql:9:10
     8 │       name
     9 │       ...fragmentOnQueryWithCycle_Profile @arguments(includeProfile: true)
       │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    10 │     }
-
-  ℹ︎ other member of the cycle
-
-  fragment-on-query-with-cycle.invalid.graphql:26:12
-   25 │       node {
-   26 │         ...fragmentOnQueryWithCycle_Profile
-      │            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   27 │       }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query.expected
@@ -6,7 +6,7 @@ fragment fragmentOnQuery_RefetchableFragment on Query
     ... on User {
       id
       name
-      ...fragmentOnQuery_ProfilePicture
+  ...fragmentOnQuery_ProfilePicture @alias
     }
   }
 }
@@ -270,8 +270,19 @@ fragment fragmentOnQuery_RefetchableFragment_1Bmzm5 on Query {
               "storageKey": null
             },
             {
-              "args": null,
-              "kind": "FragmentSpread",
+              "fragment": {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "args": null,
+                    "kind": "FragmentSpread",
+                    "name": "fragmentOnQuery_ProfilePicture"
+                  }
+                ],
+                "type": "User",
+                "abstractKey": null
+              },
+              "kind": "AliasedInlineFragmentSpread",
               "name": "fragmentOnQuery_ProfilePicture"
             }
           ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query.expected
@@ -6,7 +6,7 @@ fragment fragmentOnQuery_RefetchableFragment on Query
     ... on User {
       id
       name
-  ...fragmentOnQuery_ProfilePicture @alias
+      ...fragmentOnQuery_ProfilePicture @alias
     }
   }
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query.graphql
@@ -5,7 +5,7 @@ fragment fragmentOnQuery_RefetchableFragment on Query
     ... on User {
       id
       name
-      ...fragmentOnQuery_ProfilePicture
+  ...fragmentOnQuery_ProfilePicture @alias
     }
   }
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-query.graphql
@@ -5,7 +5,7 @@ fragment fragmentOnQuery_RefetchableFragment on Query
     ... on User {
       id
       name
-  ...fragmentOnQuery_ProfilePicture @alias
+      ...fragmentOnQuery_ProfilePicture @alias
     }
   }
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-viewer.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-viewer.expected
@@ -4,7 +4,7 @@ fragment fragmentOnViewer_RefetchableFragment on Viewer
   actor {
     id
     name
-    ...fragmentOnViewer_ProfilePicture
+  ...fragmentOnViewer_ProfilePicture @alias
   }
 }
 
@@ -253,8 +253,19 @@ fragment fragmentOnViewer_RefetchableFragment on Viewer {
           "storageKey": null
         },
         {
-          "args": null,
-          "kind": "FragmentSpread",
+          "fragment": {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "fragmentOnViewer_ProfilePicture"
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          },
+          "kind": "AliasedInlineFragmentSpread",
           "name": "fragmentOnViewer_ProfilePicture"
         }
       ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-viewer.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-viewer.expected
@@ -4,7 +4,7 @@ fragment fragmentOnViewer_RefetchableFragment on Viewer
   actor {
     id
     name
-  ...fragmentOnViewer_ProfilePicture @alias
+    ...fragmentOnViewer_ProfilePicture @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-viewer.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-viewer.graphql
@@ -3,7 +3,7 @@ fragment fragmentOnViewer_RefetchableFragment on Viewer
   actor {
     id
     name
-  ...fragmentOnViewer_ProfilePicture @alias
+    ...fragmentOnViewer_ProfilePicture @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-viewer.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-on-viewer.graphql
@@ -3,7 +3,7 @@ fragment fragmentOnViewer_RefetchableFragment on Viewer
   actor {
     id
     name
-    ...fragmentOnViewer_ProfilePicture
+  ...fragmentOnViewer_ProfilePicture @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-defer-in-stream.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-defer-in-stream.expected
@@ -2,7 +2,7 @@
 query fragmentWithDeferInStream_QueryWithFragmentWithStreamQuery($id: ID!) {
   node(id: $id) {
     id
-    ...fragmentWithDeferInStream_FeedbackFragment
+  ...fragmentWithDeferInStream_FeedbackFragment @alias
   }
 }
 
@@ -52,8 +52,19 @@ fragment fragmentWithDeferInStream_ActorFragment on Actor {
             "storageKey": null
           },
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "fragmentWithDeferInStream_FeedbackFragment"
+                }
+              ],
+              "type": "Feedback",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "fragmentWithDeferInStream_FeedbackFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-defer-in-stream.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-defer-in-stream.expected
@@ -2,7 +2,7 @@
 query fragmentWithDeferInStream_QueryWithFragmentWithStreamQuery($id: ID!) {
   node(id: $id) {
     id
-  ...fragmentWithDeferInStream_FeedbackFragment @alias
+    ...fragmentWithDeferInStream_FeedbackFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-defer-in-stream.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-defer-in-stream.graphql
@@ -1,7 +1,7 @@
 query fragmentWithDeferInStream_QueryWithFragmentWithStreamQuery($id: ID!) {
   node(id: $id) {
     id
-  ...fragmentWithDeferInStream_FeedbackFragment @alias
+    ...fragmentWithDeferInStream_FeedbackFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-defer-in-stream.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-defer-in-stream.graphql
@@ -1,7 +1,7 @@
 query fragmentWithDeferInStream_QueryWithFragmentWithStreamQuery($id: ID!) {
   node(id: $id) {
     id
-    ...fragmentWithDeferInStream_FeedbackFragment
+  ...fragmentWithDeferInStream_FeedbackFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-stream.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-stream.expected
@@ -2,7 +2,7 @@
 query fragmentWithStream_QueryWithFragmentWithStreamQuery($id: ID!) {
   node(id: $id) {
     id
-    ...fragmentWithStream_FeedbackFragment
+    ...fragmentWithStream_FeedbackFragment @alias
   }
 }
 
@@ -48,8 +48,19 @@ fragment fragmentWithStream_FeedbackFragment on Feedback {
             "storageKey": null
           },
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "fragmentWithStream_FeedbackFragment"
+                }
+              ],
+              "type": "Feedback",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "fragmentWithStream_FeedbackFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-stream.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/fragment-with-stream.graphql
@@ -1,7 +1,7 @@
 query fragmentWithStream_QueryWithFragmentWithStreamQuery($id: ID!) {
   node(id: $id) {
     id
-    ...fragmentWithStream_FeedbackFragment
+    ...fragmentWithStream_FeedbackFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/inline-data-fragment.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/inline-data-fragment.expected
@@ -15,7 +15,7 @@ fragment inlineDataFragment_ParentFragment on Query {
 
   username(name: "test") {
     # Should refine from type Actor to User.
-    ...inlineDataFragment_Profile
+    ...inlineDataFragment_Profile @alias
   }
 }
 
@@ -317,50 +317,54 @@ fragment inlineDataFragment_Profile on User {
       "plural": false,
       "selections": [
         {
-          "kind": "InlineDataFragmentSpread",
-          "name": "inlineDataFragment_Profile",
-          "selections": [
-            {
-              "kind": "InlineFragment",
-              "selections": [
-                {
-                  "alias": null,
-                  "args": [
-                    {
-                      "kind": "Literal",
-                      "name": "size",
-                      "value": 100
-                    }
-                  ],
-                  "concreteType": "Image",
-                  "kind": "LinkedField",
-                  "name": "profilePicture",
-                  "plural": false,
-                  "selections": [
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "uri",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "width",
-                      "storageKey": null
-                    }
-                  ],
-                  "storageKey": "profilePicture(size:100)"
-                }
-              ],
-              "type": "User",
-              "abstractKey": null
-            }
-          ],
-          "args": null,
-          "argumentDefinitions": []
+          "fragment": {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "kind": "InlineDataFragmentSpread",
+                "name": "inlineDataFragment_Profile",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "size",
+                        "value": 100
+                      }
+                    ],
+                    "concreteType": "Image",
+                    "kind": "LinkedField",
+                    "name": "profilePicture",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "uri",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "width",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "profilePicture(size:100)"
+                  }
+                ],
+                "args": null,
+                "argumentDefinitions": []
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          },
+          "kind": "AliasedInlineFragmentSpread",
+          "name": "inlineDataFragment_Profile"
         }
       ],
       "storageKey": "username(name:\"test\")"

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/inline-data-fragment.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/inline-data-fragment.graphql
@@ -14,7 +14,7 @@ fragment inlineDataFragment_ParentFragment on Query {
 
   username(name: "test") {
     # Should refine from type Actor to User.
-    ...inlineDataFragment_Profile
+    ...inlineDataFragment_Profile @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/kitchen-sink.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/kitchen-sink.expected
@@ -5,7 +5,7 @@ query kitchenSink_NodeQuery($id: ID!, $cond: Boolean!, $PictureSize: [Int]!) {
     ... on User @include(if: $cond) {
       name
     }
-    ...kitchenSink_UserFragment @include(if: $cond) @arguments(size: $PictureSize)
+    ...kitchenSink_UserFragment @include(if: $cond) @arguments(size: $PictureSize) @alias
   }
 }
 
@@ -101,14 +101,25 @@ fragment kitchenSink_UserFragment on User
                 "abstractKey": null
               },
               {
-                "args": [
-                  {
-                    "kind": "Variable",
-                    "name": "size",
-                    "variableName": "PictureSize"
-                  }
-                ],
-                "kind": "FragmentSpread",
+                "fragment": {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    {
+                      "args": [
+                        {
+                          "kind": "Variable",
+                          "name": "size",
+                          "variableName": "PictureSize"
+                        }
+                      ],
+                      "kind": "FragmentSpread",
+                      "name": "kitchenSink_UserFragment"
+                    }
+                  ],
+                  "type": "User",
+                  "abstractKey": null
+                },
+                "kind": "AliasedInlineFragmentSpread",
                 "name": "kitchenSink_UserFragment"
               }
             ]
@@ -184,7 +195,14 @@ fragment kitchenSink_UserFragment on User
                     "kind": "ScalarField",
                     "name": "name",
                     "storageKey": null
-                  },
+                  }
+                ],
+                "type": "User",
+                "abstractKey": null
+              },
+              {
+                "kind": "InlineFragment",
+                "selections": [
                   {
                     "alias": null,
                     "args": [

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/kitchen-sink.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/kitchen-sink.graphql
@@ -4,7 +4,7 @@ query kitchenSink_NodeQuery($id: ID!, $cond: Boolean!, $PictureSize: [Int]!) {
     ... on User @include(if: $cond) {
       name
     }
-    ...kitchenSink_UserFragment @include(if: $cond) @arguments(size: $PictureSize)
+    ...kitchenSink_UserFragment @include(if: $cond) @arguments(size: $PictureSize) @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/match-field-overlap-across-documents.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/match-field-overlap-across-documents.expected
@@ -1,8 +1,8 @@
 ==================================== INPUT ====================================
 query matchFieldOverlapAcrossDocuments_MultipleNameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...matchFieldOverlapAcrossDocuments_FooNameRendererFragment
-    ...matchFieldOverlapAcrossDocuments_BarNameRendererFragment
+    ...matchFieldOverlapAcrossDocuments_FooNameRendererFragment @alias
+    ...matchFieldOverlapAcrossDocuments_BarNameRendererFragment @alias
   }
 }
 
@@ -98,13 +98,35 @@ fragment matchFieldOverlapAcrossDocuments_MarkdownUserNameRenderer_name on Markd
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "matchFieldOverlapAcrossDocuments_FooNameRendererFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "matchFieldOverlapAcrossDocuments_FooNameRendererFragment"
           },
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "matchFieldOverlapAcrossDocuments_BarNameRendererFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "matchFieldOverlapAcrossDocuments_BarNameRendererFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/match-field-overlap-across-documents.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/match-field-overlap-across-documents.graphql
@@ -1,7 +1,7 @@
 query matchFieldOverlapAcrossDocuments_MultipleNameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...matchFieldOverlapAcrossDocuments_FooNameRendererFragment
-    ...matchFieldOverlapAcrossDocuments_BarNameRendererFragment
+    ...matchFieldOverlapAcrossDocuments_FooNameRendererFragment @alias
+    ...matchFieldOverlapAcrossDocuments_BarNameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/module-in-inline-fragment.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/module-in-inline-fragment.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query moduleInInlineFragment_MultipleNameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...moduleInInlineFragment_FooNameRendererFragment
+    ...moduleInInlineFragment_FooNameRendererFragment @alias
   }
 }
 
@@ -95,8 +95,19 @@ fragment moduleInInlineFragment_MarkdownUserNameRenderer_name on MarkdownUserNam
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "moduleInInlineFragment_FooNameRendererFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "moduleInInlineFragment_FooNameRendererFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/module-in-inline-fragment.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/module-in-inline-fragment.graphql
@@ -1,6 +1,6 @@
 query moduleInInlineFragment_MultipleNameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...moduleInInlineFragment_FooNameRendererFragment
+    ...moduleInInlineFragment_FooNameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/module-overlap-across-documents.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/module-overlap-across-documents.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query moduleOverlapAcrossDocuments_FooNameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...moduleOverlapAcrossDocuments_FooNameRendererFragment
+    ...moduleOverlapAcrossDocuments_FooNameRendererFragment @alias
   }
 }
 
@@ -16,7 +16,7 @@ fragment moduleOverlapAcrossDocuments_FooNameRendererFragment on User {
 
 query moduleOverlapAcrossDocuments_BarNameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...moduleOverlapAcrossDocuments_BarNameRendererFragment
+    ...moduleOverlapAcrossDocuments_BarNameRendererFragment @alias
   }
 }
 
@@ -72,8 +72,19 @@ fragment moduleOverlapAcrossDocuments_MarkdownUserNameRenderer_name on MarkdownU
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "moduleOverlapAcrossDocuments_BarNameRendererFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "moduleOverlapAcrossDocuments_BarNameRendererFragment"
           }
         ],
@@ -237,8 +248,19 @@ fragment moduleOverlapAcrossDocuments_MarkdownUserNameRenderer_name on MarkdownU
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "moduleOverlapAcrossDocuments_FooNameRendererFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "moduleOverlapAcrossDocuments_FooNameRendererFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/module-overlap-across-documents.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/module-overlap-across-documents.graphql
@@ -1,6 +1,6 @@
 query moduleOverlapAcrossDocuments_FooNameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...moduleOverlapAcrossDocuments_FooNameRendererFragment
+    ...moduleOverlapAcrossDocuments_FooNameRendererFragment @alias
   }
 }
 
@@ -15,7 +15,7 @@ fragment moduleOverlapAcrossDocuments_FooNameRendererFragment on User {
 
 query moduleOverlapAcrossDocuments_BarNameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...moduleOverlapAcrossDocuments_BarNameRendererFragment
+    ...moduleOverlapAcrossDocuments_BarNameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/module-overlap-within-document.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/module-overlap-within-document.expected
@@ -1,8 +1,8 @@
 ==================================== INPUT ====================================
 query moduleOverlapWithinDocument_MultipleNameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...moduleOverlapWithinDocument_FooNameRendererFragment
-    ...moduleOverlapWithinDocument_BarNameRendererFragment
+    ...moduleOverlapWithinDocument_FooNameRendererFragment @alias
+    ...moduleOverlapWithinDocument_BarNameRendererFragment @alias
   }
 }
 
@@ -108,13 +108,35 @@ fragment moduleOverlapWithinDocument_MarkdownUserNameRenderer_name on MarkdownUs
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "moduleOverlapWithinDocument_FooNameRendererFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "moduleOverlapWithinDocument_FooNameRendererFragment"
           },
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "moduleOverlapWithinDocument_BarNameRendererFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "moduleOverlapWithinDocument_BarNameRendererFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/module-overlap-within-document.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/module-overlap-within-document.graphql
@@ -1,7 +1,7 @@
 query moduleOverlapWithinDocument_MultipleNameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...moduleOverlapWithinDocument_FooNameRendererFragment
-    ...moduleOverlapWithinDocument_BarNameRendererFragment
+    ...moduleOverlapWithinDocument_FooNameRendererFragment @alias
+    ...moduleOverlapWithinDocument_BarNameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/module-with-defer.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/module-with-defer.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query moduleWithDefer_MultipleNameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...moduleWithDefer_FooNameRendererFragment
+    ...moduleWithDefer_FooNameRendererFragment @alias
   }
 }
 
@@ -88,8 +88,19 @@ fragment moduleWithDefer_MarkdownUserNameRenderer_name on MarkdownUserNameRender
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "moduleWithDefer_FooNameRendererFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "moduleWithDefer_FooNameRendererFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/module-with-defer.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/module-with-defer.graphql
@@ -1,6 +1,6 @@
 query moduleWithDefer_MultipleNameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...moduleWithDefer_FooNameRendererFragment
+    ...moduleWithDefer_FooNameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/nested-conditions-2.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/nested-conditions-2.expected
@@ -2,12 +2,12 @@
 query nestedConditions2Query($c1: Boolean!, $c2: Boolean!, $c3: Boolean!, $c4: Boolean!, $c5: Boolean!, $c6: Boolean!, $c7: Boolean!) {
   node {
     ... @include(if: $c1){
-        ...nestedConditions2_NestedFragment @include(if: $c2)
-        ...nestedConditions2_NestedFragment2 @skip(if: $c2)
+        ...nestedConditions2_NestedFragment @include(if: $c2) @alias
+        ...nestedConditions2_NestedFragment2 @skip(if: $c2) @alias
         ...@skip(if: $c3) {
           ...@skip(if: $c4) @include(if: $c5) {
-            ...nestedConditions2_NestedFragment @skip(if: $c6)
-            ...nestedConditions2_NestedFragment2 @skip(if: $c6) @include(if: $c7)
+            ...nestedConditions2_NestedFragment @skip(if: $c6) @alias(as: "nestedConditions2_NestedFragment_nested")
+            ...nestedConditions2_NestedFragment2 @skip(if: $c6) @include(if: $c7) @alias(as: "nestedConditions2_NestedFragment_nested2")
           }
         }
     }
@@ -84,8 +84,19 @@ fragment nestedConditions2_NestedFragment2 on User {
                 "passingValue": true,
                 "selections": [
                   {
-                    "args": null,
-                    "kind": "FragmentSpread",
+                    "fragment": {
+                      "kind": "InlineFragment",
+                      "selections": [
+                        {
+                          "args": null,
+                          "kind": "FragmentSpread",
+                          "name": "nestedConditions2_NestedFragment"
+                        }
+                      ],
+                      "type": "User",
+                      "abstractKey": null
+                    },
+                    "kind": "AliasedInlineFragmentSpread",
                     "name": "nestedConditions2_NestedFragment"
                   }
                 ]
@@ -96,8 +107,19 @@ fragment nestedConditions2_NestedFragment2 on User {
                 "passingValue": false,
                 "selections": [
                   {
-                    "args": null,
-                    "kind": "FragmentSpread",
+                    "fragment": {
+                      "kind": "InlineFragment",
+                      "selections": [
+                        {
+                          "args": null,
+                          "kind": "FragmentSpread",
+                          "name": "nestedConditions2_NestedFragment2"
+                        }
+                      ],
+                      "type": "User",
+                      "abstractKey": null
+                    },
+                    "kind": "AliasedInlineFragmentSpread",
                     "name": "nestedConditions2_NestedFragment2"
                   }
                 ]
@@ -123,9 +145,20 @@ fragment nestedConditions2_NestedFragment2 on User {
                             "passingValue": false,
                             "selections": [
                               {
-                                "args": null,
-                                "kind": "FragmentSpread",
-                                "name": "nestedConditions2_NestedFragment"
+                                "fragment": {
+                                  "kind": "InlineFragment",
+                                  "selections": [
+                                    {
+                                      "args": null,
+                                      "kind": "FragmentSpread",
+                                      "name": "nestedConditions2_NestedFragment"
+                                    }
+                                  ],
+                                  "type": "User",
+                                  "abstractKey": null
+                                },
+                                "kind": "AliasedInlineFragmentSpread",
+                                "name": "nestedConditions2_NestedFragment_nested"
                               }
                             ]
                           },
@@ -140,9 +173,20 @@ fragment nestedConditions2_NestedFragment2 on User {
                                 "passingValue": false,
                                 "selections": [
                                   {
-                                    "args": null,
-                                    "kind": "FragmentSpread",
-                                    "name": "nestedConditions2_NestedFragment2"
+                                    "fragment": {
+                                      "kind": "InlineFragment",
+                                      "selections": [
+                                        {
+                                          "args": null,
+                                          "kind": "FragmentSpread",
+                                          "name": "nestedConditions2_NestedFragment2"
+                                        }
+                                      ],
+                                      "type": "User",
+                                      "abstractKey": null
+                                    },
+                                    "kind": "AliasedInlineFragmentSpread",
+                                    "name": "nestedConditions2_NestedFragment_nested2"
                                   }
                                 ]
                               }
@@ -311,6 +355,34 @@ fragment nestedConditions2_NestedFragment2 on User {
                                 ],
                                 "type": "User",
                                 "abstractKey": null
+                              }
+                            ]
+                          },
+                          {
+                            "condition": "c7",
+                            "kind": "Condition",
+                            "passingValue": true,
+                            "selections": [
+                              {
+                                "condition": "c6",
+                                "kind": "Condition",
+                                "passingValue": false,
+                                "selections": [
+                                  {
+                                    "kind": "InlineFragment",
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "name",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "type": "User",
+                                    "abstractKey": null
+                                  }
+                                ]
                               }
                             ]
                           }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/nested-conditions-2.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/nested-conditions-2.graphql
@@ -1,12 +1,12 @@
 query nestedConditions2Query($c1: Boolean!, $c2: Boolean!, $c3: Boolean!, $c4: Boolean!, $c5: Boolean!, $c6: Boolean!, $c7: Boolean!) {
   node {
     ... @include(if: $c1){
-        ...nestedConditions2_NestedFragment @include(if: $c2)
-        ...nestedConditions2_NestedFragment2 @skip(if: $c2)
+        ...nestedConditions2_NestedFragment @include(if: $c2) @alias
+        ...nestedConditions2_NestedFragment2 @skip(if: $c2) @alias
         ...@skip(if: $c3) {
           ...@skip(if: $c4) @include(if: $c5) {
-            ...nestedConditions2_NestedFragment @skip(if: $c6)
-            ...nestedConditions2_NestedFragment2 @skip(if: $c6) @include(if: $c7)
+            ...nestedConditions2_NestedFragment @skip(if: $c6) @alias(as: "nestedConditions2_NestedFragment_nested")
+            ...nestedConditions2_NestedFragment2 @skip(if: $c6) @include(if: $c7) @alias(as: "nestedConditions2_NestedFragment_nested2")
           }
         }
     }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/no-inline-abstract-fragment.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/no-inline-abstract-fragment.expected
@@ -42,7 +42,7 @@ fragment noInlineAbstractFragment_parent on Actor
         scalar_from_parent: $scalar_from_parent
         local_from_parent: $global_from_parent
         shadowed_global: $shadowed_global
-      )
+      ) @alias
   }
 }
 
@@ -658,24 +658,35 @@ fragment noInlineAbstractFragment_parent_4pGKCl on Actor {
           "storageKey": null
         },
         {
-          "args": [
-            {
-              "kind": "Variable",
-              "name": "local_from_parent",
-              "variableName": "global_from_parent"
-            },
-            {
-              "kind": "Variable",
-              "name": "scalar_from_parent",
-              "variableName": "scalar_from_parent"
-            },
-            {
-              "kind": "Variable",
-              "name": "shadowed_global",
-              "variableName": "shadowed_global"
-            }
-          ],
-          "kind": "FragmentSpread",
+          "fragment": {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": [
+                  {
+                    "kind": "Variable",
+                    "name": "local_from_parent",
+                    "variableName": "global_from_parent"
+                  },
+                  {
+                    "kind": "Variable",
+                    "name": "scalar_from_parent",
+                    "variableName": "scalar_from_parent"
+                  },
+                  {
+                    "kind": "Variable",
+                    "name": "shadowed_global",
+                    "variableName": "shadowed_global"
+                  }
+                ],
+                "kind": "FragmentSpread",
+                "name": "noInlineAbstractFragment_child"
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          },
+          "kind": "AliasedInlineFragmentSpread",
           "name": "noInlineAbstractFragment_child"
         }
       ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/no-inline-abstract-fragment.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/no-inline-abstract-fragment.graphql
@@ -41,7 +41,7 @@ fragment noInlineAbstractFragment_parent on Actor
         scalar_from_parent: $scalar_from_parent
         local_from_parent: $global_from_parent
         shadowed_global: $shadowed_global
-      )
+      ) @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/original-client-fields-test.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/original-client-fields-test.expected
@@ -1,12 +1,12 @@
 ==================================== INPUT ====================================
 query originalClientFieldsTest_BestFriendsQuery($id: ID!) {
   node(id: $id) {
-    ...originalClientFieldsTest_BestFriends
-    ...originalClientFieldsTest_OnlyClientFields
+    ...originalClientFieldsTest_BestFriends @alias
+    ...originalClientFieldsTest_OnlyClientFields @alias
   }
   named {
     # fragments on extension types are skipped
-    ...originalClientFieldsTest_FooFragment
+    ...originalClientFieldsTest_FooFragment @alias
     ... on Foo {
       name
     }
@@ -83,13 +83,35 @@ type Foo implements Named {
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "originalClientFieldsTest_BestFriends"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "originalClientFieldsTest_BestFriends"
           },
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "originalClientFieldsTest_OnlyClientFields"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "originalClientFieldsTest_OnlyClientFields"
           }
         ],
@@ -104,13 +126,24 @@ type Foo implements Named {
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
-            "name": "originalClientFieldsTest_FooFragment"
-          },
-          {
             "kind": "ClientExtension",
             "selections": [
+              {
+                "fragment": {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    {
+                      "args": null,
+                      "kind": "FragmentSpread",
+                      "name": "originalClientFieldsTest_FooFragment"
+                    }
+                  ],
+                  "type": "Foo",
+                  "abstractKey": null
+                },
+                "kind": "AliasedInlineFragmentSpread",
+                "name": "originalClientFieldsTest_FooFragment"
+              },
               {
                 "kind": "InlineFragment",
                 "selections": [
@@ -297,6 +330,20 @@ type Foo implements Named {
           {
             "kind": "ClientExtension",
             "selections": [
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "name",
+                    "storageKey": null
+                  }
+                ],
+                "type": "Foo",
+                "abstractKey": null
+              },
               {
                 "kind": "InlineFragment",
                 "selections": [

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/original-client-fields-test.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/original-client-fields-test.graphql
@@ -1,11 +1,11 @@
 query originalClientFieldsTest_BestFriendsQuery($id: ID!) {
   node(id: $id) {
-    ...originalClientFieldsTest_BestFriends
-    ...originalClientFieldsTest_OnlyClientFields
+    ...originalClientFieldsTest_BestFriends @alias
+    ...originalClientFieldsTest_OnlyClientFields @alias
   }
   named {
     # fragments on extension types are skipped
-    ...originalClientFieldsTest_FooFragment
+    ...originalClientFieldsTest_FooFragment @alias
     ... on Foo {
       name
     }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/prefetchable-pagination-query-without-conflicting-args.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/prefetchable-pagination-query-without-conflicting-args.expected
@@ -1,8 +1,8 @@
 ==================================== INPUT ====================================
 query prefetchablePaginationQueryWithoutConflictingArgsQuery($site: String) {
   node(id: "x") {
-    ...prefetchablePaginationQueryWithoutConflictingArgs_FirstFragment @arguments(site: $site)
-    ...prefetchablePaginationQueryWithoutConflictingArgs_SecondFragment @arguments(site: $site)
+    ...prefetchablePaginationQueryWithoutConflictingArgs_FirstFragment @arguments(site: $site) @alias
+    ...prefetchablePaginationQueryWithoutConflictingArgs_SecondFragment @arguments(site: $site) @alias
   }
 }
 
@@ -387,25 +387,47 @@ fragment prefetchablePaginationQueryWithoutConflictingArgs_FirstFragment__edges_
         "plural": false,
         "selections": [
           {
-            "args": [
-              {
-                "kind": "Variable",
-                "name": "site",
-                "variableName": "site"
-              }
-            ],
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": [
+                    {
+                      "kind": "Variable",
+                      "name": "site",
+                      "variableName": "site"
+                    }
+                  ],
+                  "kind": "FragmentSpread",
+                  "name": "prefetchablePaginationQueryWithoutConflictingArgs_FirstFragment"
+                }
+              ],
+              "type": "Page",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "prefetchablePaginationQueryWithoutConflictingArgs_FirstFragment"
           },
           {
-            "args": [
-              {
-                "kind": "Variable",
-                "name": "site",
-                "variableName": "site"
-              }
-            ],
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": [
+                    {
+                      "kind": "Variable",
+                      "name": "site",
+                      "variableName": "site"
+                    }
+                  ],
+                  "kind": "FragmentSpread",
+                  "name": "prefetchablePaginationQueryWithoutConflictingArgs_SecondFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "prefetchablePaginationQueryWithoutConflictingArgs_SecondFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/prefetchable-pagination-query-without-conflicting-args.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/prefetchable-pagination-query-without-conflicting-args.graphql
@@ -1,7 +1,7 @@
 query prefetchablePaginationQueryWithoutConflictingArgsQuery($site: String) {
   node(id: "x") {
-    ...prefetchablePaginationQueryWithoutConflictingArgs_FirstFragment @arguments(site: $site)
-    ...prefetchablePaginationQueryWithoutConflictingArgs_SecondFragment @arguments(site: $site)
+    ...prefetchablePaginationQueryWithoutConflictingArgs_FirstFragment @arguments(site: $site) @alias
+    ...prefetchablePaginationQueryWithoutConflictingArgs_SecondFragment @arguments(site: $site) @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-in-fragment.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-in-fragment.expected
@@ -1,8 +1,8 @@
 ==================================== INPUT ====================================
 query providedVariableInFragment_Query($id: ID!) {
     node(id: $id) {
-        ...providedVariableInFragment_Fragment1
-        ...providedVariableInFragment_Fragment2
+        ...providedVariableInFragment_Fragment1 @alias
+        ...providedVariableInFragment_Fragment2 @alias
     }
 }
 
@@ -49,13 +49,35 @@ fragment providedVariableInFragment_Fragment2 on User
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "providedVariableInFragment_Fragment1"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "providedVariableInFragment_Fragment1"
           },
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "providedVariableInFragment_Fragment2"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "providedVariableInFragment_Fragment2"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-in-fragment.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-in-fragment.graphql
@@ -1,7 +1,7 @@
 query providedVariableInFragment_Query($id: ID!) {
     node(id: $id) {
-        ...providedVariableInFragment_Fragment1
-        ...providedVariableInFragment_Fragment2
+        ...providedVariableInFragment_Fragment1 @alias
+        ...providedVariableInFragment_Fragment2 @alias
     }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-multiple-queries.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-multiple-queries.expected
@@ -1,14 +1,14 @@
 ==================================== INPUT ====================================
 query providedVariableMultipleQueries_OneFragmentQuery {
   node(id: 4) {
-    ...providedVariableMultipleQueries_OneProvidedVar
+    ...providedVariableMultipleQueries_OneProvidedVar @alias
   }
 }
 
 query providedVariableMultipleQueries_MultiFragmentQuery {
   node(id: 5) {
-    ...providedVariableMultipleQueries_OneProvidedVar,
-    ...providedVariableMultipleQueries_MultiProvidedVar,
+    ...providedVariableMultipleQueries_OneProvidedVar @alias,
+    ...providedVariableMultipleQueries_MultiProvidedVar @alias,
   }
 }
 
@@ -56,13 +56,35 @@ fragment providedVariableMultipleQueries_MultiProvidedVar on User
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "providedVariableMultipleQueries_OneProvidedVar"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "providedVariableMultipleQueries_OneProvidedVar"
           },
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "providedVariableMultipleQueries_MultiProvidedVar"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "providedVariableMultipleQueries_MultiProvidedVar"
           }
         ],
@@ -277,8 +299,19 @@ fragment providedVariableMultipleQueries_OneProvidedVar on User {
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "providedVariableMultipleQueries_OneProvidedVar"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "providedVariableMultipleQueries_OneProvidedVar"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-multiple-queries.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-multiple-queries.graphql
@@ -1,13 +1,13 @@
 query providedVariableMultipleQueries_OneFragmentQuery {
   node(id: 4) {
-    ...providedVariableMultipleQueries_OneProvidedVar
+    ...providedVariableMultipleQueries_OneProvidedVar @alias
   }
 }
 
 query providedVariableMultipleQueries_MultiFragmentQuery {
   node(id: 5) {
-    ...providedVariableMultipleQueries_OneProvidedVar,
-    ...providedVariableMultipleQueries_MultiProvidedVar,
+    ...providedVariableMultipleQueries_OneProvidedVar @alias,
+    ...providedVariableMultipleQueries_MultiProvidedVar @alias,
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-nested-split-operation.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-nested-split-operation.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query providedVariableNestedSplitOperation_Query($id: ID!) {
   node(id: $id) {
-    ...providedVariableNestedSplitOperationFragment
+    ...providedVariableNestedSplitOperationFragment @alias
   }
 }
 
@@ -334,8 +334,19 @@ fragment providedVariableNestedSplitOperation_Plain2 on PlainUserNameRenderer
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "providedVariableNestedSplitOperationFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "providedVariableNestedSplitOperationFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-nested-split-operation.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-nested-split-operation.graphql
@@ -1,6 +1,6 @@
 query providedVariableNestedSplitOperation_Query($id: ID!) {
   node(id: $id) {
-    ...providedVariableNestedSplitOperationFragment
+    ...providedVariableNestedSplitOperationFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-refetchable-fragment.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-refetchable-fragment.expected
@@ -8,7 +8,7 @@ query providedVariableRefetchableFragmentQuery {
 fragment providedVariableRefetchableFragment on Node
   @refetchable(queryName: "refetchableQuery")
 {
-    ...providedVariableRefetchableFragment_providedVariableFragment
+    ...providedVariableRefetchableFragment_providedVariableFragment @alias
 }
 
 fragment providedVariableRefetchableFragment_providedVariableFragment on User
@@ -330,8 +330,19 @@ fragment providedVariableRefetchableFragment_providedVariableFragment on User {
   "name": "providedVariableRefetchableFragment",
   "selections": [
     {
-      "args": null,
-      "kind": "FragmentSpread",
+      "fragment": {
+        "kind": "InlineFragment",
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "providedVariableRefetchableFragment_providedVariableFragment"
+          }
+        ],
+        "type": "User",
+        "abstractKey": null
+      },
+      "kind": "AliasedInlineFragmentSpread",
       "name": "providedVariableRefetchableFragment_providedVariableFragment"
     },
     {

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-refetchable-fragment.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-refetchable-fragment.graphql
@@ -7,7 +7,7 @@ query providedVariableRefetchableFragmentQuery {
 fragment providedVariableRefetchableFragment on Node
   @refetchable(queryName: "refetchableQuery")
 {
-    ...providedVariableRefetchableFragment_providedVariableFragment
+    ...providedVariableRefetchableFragment_providedVariableFragment @alias
 }
 
 fragment providedVariableRefetchableFragment_providedVariableFragment on User

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-reused-nested-fragment.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-reused-nested-fragment.expected
@@ -1,13 +1,13 @@
 ==================================== INPUT ====================================
 query providedVariableReusedNestedFragment_1Query($id: ID!) {
     node(id: $id) {
-    ...providedVariableReusedNestedFragment_FragmentCommon @alias
+        ...providedVariableReusedNestedFragment_FragmentCommon @alias
     }
 }
 
 query providedVariableReusedNestedFragment_2Query($id: ID!) {
     node(id: $id) {
-    ...providedVariableReusedNestedFragment_Fragment @alias
+        ...providedVariableReusedNestedFragment_Fragment @alias
     }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-reused-nested-fragment.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-reused-nested-fragment.expected
@@ -1,13 +1,13 @@
 ==================================== INPUT ====================================
 query providedVariableReusedNestedFragment_1Query($id: ID!) {
     node(id: $id) {
-        ...providedVariableReusedNestedFragment_FragmentCommon
+    ...providedVariableReusedNestedFragment_FragmentCommon @alias
     }
 }
 
 query providedVariableReusedNestedFragment_2Query($id: ID!) {
     node(id: $id) {
-       ...providedVariableReusedNestedFragment_Fragment
+    ...providedVariableReusedNestedFragment_Fragment @alias
     }
 }
 
@@ -56,8 +56,19 @@ fragment providedVariableReusedNestedFragment_FragmentWithProvider on User
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "providedVariableReusedNestedFragment_FragmentCommon"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "providedVariableReusedNestedFragment_FragmentCommon"
           }
         ],
@@ -209,8 +220,19 @@ fragment providedVariableReusedNestedFragment_FragmentWithProvider on User {
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "providedVariableReusedNestedFragment_Fragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "providedVariableReusedNestedFragment_Fragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-reused-nested-fragment.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-reused-nested-fragment.graphql
@@ -1,12 +1,12 @@
 query providedVariableReusedNestedFragment_1Query($id: ID!) {
     node(id: $id) {
-        ...providedVariableReusedNestedFragment_FragmentCommon
+    ...providedVariableReusedNestedFragment_FragmentCommon @alias
     }
 }
 
 query providedVariableReusedNestedFragment_2Query($id: ID!) {
     node(id: $id) {
-       ...providedVariableReusedNestedFragment_Fragment
+    ...providedVariableReusedNestedFragment_Fragment @alias
     }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-reused-nested-fragment.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-reused-nested-fragment.graphql
@@ -1,12 +1,12 @@
 query providedVariableReusedNestedFragment_1Query($id: ID!) {
     node(id: $id) {
-    ...providedVariableReusedNestedFragment_FragmentCommon @alias
+        ...providedVariableReusedNestedFragment_FragmentCommon @alias
     }
 }
 
 query providedVariableReusedNestedFragment_2Query($id: ID!) {
     node(id: $id) {
-    ...providedVariableReusedNestedFragment_Fragment @alias
+        ...providedVariableReusedNestedFragment_Fragment @alias
     }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-reused-nested-linked-fragment.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-reused-nested-linked-fragment.expected
@@ -15,7 +15,7 @@ fragment providedVariableReusedNestedLinkedFragment_Fragment on Query
 fragment providedVariableReusedNestedLinkedFragment_FragmentCommon on Query
 {
   node(id: $id) {
-    ...providedVariableReusedNestedLinkedFragment_FragmentWithProvider
+  ...providedVariableReusedNestedLinkedFragment_FragmentWithProvider @alias
   }
 }
 
@@ -327,8 +327,19 @@ fragment providedVariableReusedNestedLinkedFragment_FragmentWithProvider on User
       "plural": false,
       "selections": [
         {
-          "args": null,
-          "kind": "FragmentSpread",
+          "fragment": {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "providedVariableReusedNestedLinkedFragment_FragmentWithProvider"
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          },
+          "kind": "AliasedInlineFragmentSpread",
           "name": "providedVariableReusedNestedLinkedFragment_FragmentWithProvider"
         }
       ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-reused-nested-linked-fragment.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-reused-nested-linked-fragment.expected
@@ -15,7 +15,7 @@ fragment providedVariableReusedNestedLinkedFragment_Fragment on Query
 fragment providedVariableReusedNestedLinkedFragment_FragmentCommon on Query
 {
   node(id: $id) {
-  ...providedVariableReusedNestedLinkedFragment_FragmentWithProvider @alias
+    ...providedVariableReusedNestedLinkedFragment_FragmentWithProvider @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-reused-nested-linked-fragment.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-reused-nested-linked-fragment.graphql
@@ -14,7 +14,7 @@ fragment providedVariableReusedNestedLinkedFragment_Fragment on Query
 fragment providedVariableReusedNestedLinkedFragment_FragmentCommon on Query
 {
   node(id: $id) {
-    ...providedVariableReusedNestedLinkedFragment_FragmentWithProvider
+  ...providedVariableReusedNestedLinkedFragment_FragmentWithProvider @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-reused-nested-linked-fragment.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-reused-nested-linked-fragment.graphql
@@ -14,7 +14,7 @@ fragment providedVariableReusedNestedLinkedFragment_Fragment on Query
 fragment providedVariableReusedNestedLinkedFragment_FragmentCommon on Query
 {
   node(id: $id) {
-  ...providedVariableReusedNestedLinkedFragment_FragmentWithProvider @alias
+    ...providedVariableReusedNestedLinkedFragment_FragmentWithProvider @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-split-operation.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-split-operation.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query providedVariableSplitOperation_Query($id: ID!) {
   node(id: $id) {
-    ...providedVariableSplitOperationFragment
+  ...providedVariableSplitOperationFragment @alias
   }
 }
 
@@ -150,8 +150,19 @@ fragment providedVariableSplitOperation_PlainUserNameRenderer_name on PlainUserN
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "providedVariableSplitOperationFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "providedVariableSplitOperationFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-split-operation.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-split-operation.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query providedVariableSplitOperation_Query($id: ID!) {
   node(id: $id) {
-  ...providedVariableSplitOperationFragment @alias
+    ...providedVariableSplitOperationFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-split-operation.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-split-operation.graphql
@@ -1,6 +1,6 @@
 query providedVariableSplitOperation_Query($id: ID!) {
   node(id: $id) {
-  ...providedVariableSplitOperationFragment @alias
+    ...providedVariableSplitOperationFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-split-operation.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/provided-variable-split-operation.graphql
@@ -1,6 +1,6 @@
 query providedVariableSplitOperation_Query($id: ID!) {
   node(id: $id) {
-    ...providedVariableSplitOperationFragment
+  ...providedVariableSplitOperationFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-and-without-module-directive.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-and-without-module-directive.expected
@@ -24,7 +24,7 @@ fragment queryWithAndWithoutModuleDirective_MarkdownUserNameRenderer_name on Mar
   }
 }
 ==================================== ERROR ====================================
-✖︎ The 'queryWithAndWithoutModuleDirective_MarkdownUserNameRenderer_name' is transformed to use @no_inline implicitly by `@module`, but it's also used in a regular fragment spread. It's required to explicitly add `@no_inline` to the definition of 'queryWithAndWithoutModuleDirective_MarkdownUserNameRenderer_name'.
+✖︎ Expected `@alias` directive. `queryWithAndWithoutModuleDirective_MarkdownUserNameRenderer_name` is defined on `MarkdownUserNameRenderer` which might not match this selection type of `UserNameRenderer`. Add `@alias` to this spread to expose the fragment reference as a nullable property.
 
   query-with-and-without-module-directive.graphql:15:8
    14 │   without_module: nameRenderer {
@@ -32,10 +32,11 @@ fragment queryWithAndWithoutModuleDirective_MarkdownUserNameRenderer_name on Mar
       │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    16 │   }
 
-  ℹ︎ fragment definition
 
-  query-with-and-without-module-directive.graphql:19:10
-   18 │ 
-   19 │ fragment queryWithAndWithoutModuleDirective_MarkdownUserNameRenderer_name on MarkdownUserNameRenderer {
-      │          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   20 │   markdown
+✖︎ Expected `@alias` directive. `queryWithAndWithoutModuleDirective_NameRendererFragment` is defined on `User` which might not match this selection type of `Node`. Add `@alias` to this spread to expose the fragment reference as a nullable property.
+
+  query-with-and-without-module-directive.graphql:4:8
+    3 │   node(id: $id) {
+    4 │     ...queryWithAndWithoutModuleDirective_NameRendererFragment
+      │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │   }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-conditional-module.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-conditional-module.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query queryWithConditionalModule_NameRendererQuery($id: ID!, $fetchModule: Boolean!) {
   node(id: $id) {
-    ...queryWithConditionalModule_NameRendererFragment
+  ...queryWithConditionalModule_NameRendererFragment @alias
   }
 }
 
@@ -95,8 +95,19 @@ fragment queryWithConditionalModule_MarkdownUserNameRenderer_name on MarkdownUse
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "queryWithConditionalModule_NameRendererFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "queryWithConditionalModule_NameRendererFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-conditional-module.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-conditional-module.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query queryWithConditionalModule_NameRendererQuery($id: ID!, $fetchModule: Boolean!) {
   node(id: $id) {
-  ...queryWithConditionalModule_NameRendererFragment @alias
+    ...queryWithConditionalModule_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-conditional-module.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-conditional-module.graphql
@@ -1,6 +1,6 @@
 query queryWithConditionalModule_NameRendererQuery($id: ID!, $fetchModule: Boolean!) {
   node(id: $id) {
-  ...queryWithConditionalModule_NameRendererFragment @alias
+    ...queryWithConditionalModule_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-conditional-module.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-conditional-module.graphql
@@ -1,6 +1,6 @@
 query queryWithConditionalModule_NameRendererQuery($id: ID!, $fetchModule: Boolean!) {
   node(id: $id) {
-    ...queryWithConditionalModule_NameRendererFragment
+  ...queryWithConditionalModule_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-fragment-variables.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-fragment-variables.expected
@@ -2,8 +2,8 @@
 query queryWithFragmentVariables_TestQuery($id: ID!, $cond: Boolean!, $pictureSize: [Int] = [128]) {
   node(id: $id) {
     id
-    ...queryWithFragmentVariables_Profile @arguments(pictureSize: $pictureSize)
-    ...queryWithFragmentVariables_ProfileFriends @include(if: $cond)
+  ...queryWithFragmentVariables_Profile @arguments(pictureSize: $pictureSize) @alias
+  ...queryWithFragmentVariables_ProfileFriends @include(if: $cond) @alias
   }
 }
 
@@ -70,14 +70,25 @@ fragment queryWithFragmentVariables_Profile on User @argumentDefinitions(picture
             "storageKey": null
           },
           {
-            "args": [
-              {
-                "kind": "Variable",
-                "name": "pictureSize",
-                "variableName": "pictureSize"
-              }
-            ],
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": [
+                    {
+                      "kind": "Variable",
+                      "name": "pictureSize",
+                      "variableName": "pictureSize"
+                    }
+                  ],
+                  "kind": "FragmentSpread",
+                  "name": "queryWithFragmentVariables_Profile"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "queryWithFragmentVariables_Profile"
           },
           {
@@ -86,8 +97,19 @@ fragment queryWithFragmentVariables_Profile on User @argumentDefinitions(picture
             "passingValue": true,
             "selections": [
               {
-                "args": null,
-                "kind": "FragmentSpread",
+                "fragment": {
+                  "kind": "InlineFragment",
+                  "selections": [
+                    {
+                      "args": null,
+                      "kind": "FragmentSpread",
+                      "name": "queryWithFragmentVariables_ProfileFriends"
+                    }
+                  ],
+                  "type": "User",
+                  "abstractKey": null
+                },
+                "kind": "AliasedInlineFragmentSpread",
                 "name": "queryWithFragmentVariables_ProfileFriends"
               }
             ]

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-fragment-variables.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-fragment-variables.expected
@@ -2,8 +2,8 @@
 query queryWithFragmentVariables_TestQuery($id: ID!, $cond: Boolean!, $pictureSize: [Int] = [128]) {
   node(id: $id) {
     id
-  ...queryWithFragmentVariables_Profile @arguments(pictureSize: $pictureSize) @alias
-  ...queryWithFragmentVariables_ProfileFriends @include(if: $cond) @alias
+    ...queryWithFragmentVariables_Profile @arguments(pictureSize: $pictureSize) @alias
+    ...queryWithFragmentVariables_ProfileFriends @include(if: $cond) @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-fragment-variables.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-fragment-variables.graphql
@@ -1,8 +1,8 @@
 query queryWithFragmentVariables_TestQuery($id: ID!, $cond: Boolean!, $pictureSize: [Int] = [128]) {
   node(id: $id) {
     id
-    ...queryWithFragmentVariables_Profile @arguments(pictureSize: $pictureSize)
-    ...queryWithFragmentVariables_ProfileFriends @include(if: $cond)
+  ...queryWithFragmentVariables_Profile @arguments(pictureSize: $pictureSize) @alias
+  ...queryWithFragmentVariables_ProfileFriends @include(if: $cond) @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-fragment-variables.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-fragment-variables.graphql
@@ -1,8 +1,8 @@
 query queryWithFragmentVariables_TestQuery($id: ID!, $cond: Boolean!, $pictureSize: [Int] = [128]) {
   node(id: $id) {
     id
-  ...queryWithFragmentVariables_Profile @arguments(pictureSize: $pictureSize) @alias
-  ...queryWithFragmentVariables_ProfileFriends @include(if: $cond) @alias
+    ...queryWithFragmentVariables_Profile @arguments(pictureSize: $pictureSize) @alias
+    ...queryWithFragmentVariables_ProfileFriends @include(if: $cond) @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-no-inline-experimental.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-no-inline-experimental.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query queryWithMatchDirectiveNoInlineExperimental_NameRendererQuery($id: ID!) {
   node(id: $id) {
-  ...queryWithMatchDirectiveNoInlineExperimental_NameRendererFragment @alias
+    ...queryWithMatchDirectiveNoInlineExperimental_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-no-inline-experimental.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-no-inline-experimental.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query queryWithMatchDirectiveNoInlineExperimental_NameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...queryWithMatchDirectiveNoInlineExperimental_NameRendererFragment
+  ...queryWithMatchDirectiveNoInlineExperimental_NameRendererFragment @alias
   }
 }
 
@@ -96,8 +96,19 @@ fragment queryWithMatchDirectiveNoInlineExperimental_MarkdownUserNameRenderer_na
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "queryWithMatchDirectiveNoInlineExperimental_NameRendererFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "queryWithMatchDirectiveNoInlineExperimental_NameRendererFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-no-inline-experimental.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-no-inline-experimental.graphql
@@ -1,6 +1,6 @@
 query queryWithMatchDirectiveNoInlineExperimental_NameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...queryWithMatchDirectiveNoInlineExperimental_NameRendererFragment
+  ...queryWithMatchDirectiveNoInlineExperimental_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-no-inline-experimental.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-no-inline-experimental.graphql
@@ -1,6 +1,6 @@
 query queryWithMatchDirectiveNoInlineExperimental_NameRendererQuery($id: ID!) {
   node(id: $id) {
-  ...queryWithMatchDirectiveNoInlineExperimental_NameRendererFragment @alias
+    ...queryWithMatchDirectiveNoInlineExperimental_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-no-modules.invalid.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-no-modules.invalid.expected
@@ -13,10 +13,10 @@ fragment queryWithMatchDirectiveNoModules_NameRendererFragment on User {
   }
 }
 ==================================== ERROR ====================================
-✖︎ Invalid @match selection: expected at least one @module selection. Remove @match or add a '...Fragment @module()' selection.
+✖︎ Expected `@alias` directive. `queryWithMatchDirectiveNoModules_NameRendererFragment` is defined on `User` which might not match this selection type of `Node`. Add `@alias` to this spread to expose the fragment reference as a nullable property.
 
-  query-with-match-directive-no-modules.invalid.graphql:10:16
-    9 │   id
-   10 │   nameRenderer @match {
-      │                ^^^^^^
-   11 │     __typename
+  query-with-match-directive-no-modules.invalid.graphql:4:8
+    3 │   node(id: $id) {
+    4 │     ...queryWithMatchDirectiveNoModules_NameRendererFragment
+      │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    5 │   }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-with-extra-argument.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-with-extra-argument.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query queryWithMatchDirectiveWithExtraArgument_NameRendererQuery($id: ID!) {
   node(id: $id) {
-  ...queryWithMatchDirectiveWithExtraArgument_NameRendererFragment @alias
+    ...queryWithMatchDirectiveWithExtraArgument_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-with-extra-argument.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-with-extra-argument.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query queryWithMatchDirectiveWithExtraArgument_NameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...queryWithMatchDirectiveWithExtraArgument_NameRendererFragment
+  ...queryWithMatchDirectiveWithExtraArgument_NameRendererFragment @alias
   }
 }
 
@@ -96,8 +96,19 @@ fragment queryWithMatchDirectiveWithExtraArgument_MarkdownUserNameRenderer_name 
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "queryWithMatchDirectiveWithExtraArgument_NameRendererFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "queryWithMatchDirectiveWithExtraArgument_NameRendererFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-with-extra-argument.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-with-extra-argument.graphql
@@ -1,6 +1,6 @@
 query queryWithMatchDirectiveWithExtraArgument_NameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...queryWithMatchDirectiveWithExtraArgument_NameRendererFragment
+  ...queryWithMatchDirectiveWithExtraArgument_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-with-extra-argument.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-with-extra-argument.graphql
@@ -1,6 +1,6 @@
 query queryWithMatchDirectiveWithExtraArgument_NameRendererQuery($id: ID!) {
   node(id: $id) {
-  ...queryWithMatchDirectiveWithExtraArgument_NameRendererFragment @alias
+    ...queryWithMatchDirectiveWithExtraArgument_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-with-typename.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-with-typename.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query queryWithMatchDirectiveWithTypename_NameRendererQuery($id: ID!) {
   node(id: $id) {
-  ...queryWithMatchDirectiveWithTypename_NameRendererFragment @alias
+    ...queryWithMatchDirectiveWithTypename_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-with-typename.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-with-typename.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query queryWithMatchDirectiveWithTypename_NameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...queryWithMatchDirectiveWithTypename_NameRendererFragment
+  ...queryWithMatchDirectiveWithTypename_NameRendererFragment @alias
   }
 }
 
@@ -97,8 +97,19 @@ fragment queryWithMatchDirectiveWithTypename_MarkdownUserNameRenderer_name on Ma
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "queryWithMatchDirectiveWithTypename_NameRendererFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "queryWithMatchDirectiveWithTypename_NameRendererFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-with-typename.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-with-typename.graphql
@@ -1,6 +1,6 @@
 query queryWithMatchDirectiveWithTypename_NameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...queryWithMatchDirectiveWithTypename_NameRendererFragment
+  ...queryWithMatchDirectiveWithTypename_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-with-typename.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive-with-typename.graphql
@@ -1,6 +1,6 @@
 query queryWithMatchDirectiveWithTypename_NameRendererQuery($id: ID!) {
   node(id: $id) {
-  ...queryWithMatchDirectiveWithTypename_NameRendererFragment @alias
+    ...queryWithMatchDirectiveWithTypename_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query queryWithMatchDirective_NameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...queryWithMatchDirective_NameRendererFragment
+  ...queryWithMatchDirective_NameRendererFragment @alias
   }
 }
 
@@ -96,8 +96,19 @@ fragment queryWithMatchDirective_MarkdownUserNameRenderer_name on MarkdownUserNa
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "queryWithMatchDirective_NameRendererFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "queryWithMatchDirective_NameRendererFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query queryWithMatchDirective_NameRendererQuery($id: ID!) {
   node(id: $id) {
-  ...queryWithMatchDirective_NameRendererFragment @alias
+    ...queryWithMatchDirective_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive.graphql
@@ -1,6 +1,6 @@
 query queryWithMatchDirective_NameRendererQuery($id: ID!) {
   node(id: $id) {
-  ...queryWithMatchDirective_NameRendererFragment @alias
+    ...queryWithMatchDirective_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-match-directive.graphql
@@ -1,6 +1,6 @@
 query queryWithMatchDirective_NameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...queryWithMatchDirective_NameRendererFragment
+  ...queryWithMatchDirective_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-and-arguments.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-and-arguments.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query queryWithModuleDirectiveAndArguments_NameRendererQuery($id: ID!, $cond: Boolean!) {
   node(id: $id) {
-    ...queryWithModuleDirectiveAndArguments_NameRendererFragment @arguments(local_cond: false)
+  ...queryWithModuleDirectiveAndArguments_NameRendererFragment @arguments(local_cond: false) @alias
   }
 }
 
@@ -125,14 +125,25 @@ fragment queryWithModuleDirectiveAndArguments_PlainUserNameRenderer_name on Plai
         "plural": false,
         "selections": [
           {
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "local_cond",
-                "value": false
-              }
-            ],
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "local_cond",
+                      "value": false
+                    }
+                  ],
+                  "kind": "FragmentSpread",
+                  "name": "queryWithModuleDirectiveAndArguments_NameRendererFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "queryWithModuleDirectiveAndArguments_NameRendererFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-and-arguments.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-and-arguments.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query queryWithModuleDirectiveAndArguments_NameRendererQuery($id: ID!, $cond: Boolean!) {
   node(id: $id) {
-  ...queryWithModuleDirectiveAndArguments_NameRendererFragment @arguments(local_cond: false) @alias
+    ...queryWithModuleDirectiveAndArguments_NameRendererFragment @arguments(local_cond: false) @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-and-arguments.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-and-arguments.graphql
@@ -1,6 +1,6 @@
 query queryWithModuleDirectiveAndArguments_NameRendererQuery($id: ID!, $cond: Boolean!) {
   node(id: $id) {
-  ...queryWithModuleDirectiveAndArguments_NameRendererFragment @arguments(local_cond: false) @alias
+    ...queryWithModuleDirectiveAndArguments_NameRendererFragment @arguments(local_cond: false) @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-and-arguments.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-and-arguments.graphql
@@ -1,6 +1,6 @@
 query queryWithModuleDirectiveAndArguments_NameRendererQuery($id: ID!, $cond: Boolean!) {
   node(id: $id) {
-    ...queryWithModuleDirectiveAndArguments_NameRendererFragment @arguments(local_cond: false)
+  ...queryWithModuleDirectiveAndArguments_NameRendererFragment @arguments(local_cond: false) @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-custom-import.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-custom-import.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query queryWithModuleDirectiveCustomImport_NameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...queryWithModuleDirectiveCustomImport_NameRendererFragment
+  ...queryWithModuleDirectiveCustomImport_NameRendererFragment @alias
   }
 }
 
@@ -100,8 +100,19 @@ fragment queryWithModuleDirectiveCustomImport_MarkdownUserNameRenderer_name on M
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "queryWithModuleDirectiveCustomImport_NameRendererFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "queryWithModuleDirectiveCustomImport_NameRendererFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-custom-import.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-custom-import.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query queryWithModuleDirectiveCustomImport_NameRendererQuery($id: ID!) {
   node(id: $id) {
-  ...queryWithModuleDirectiveCustomImport_NameRendererFragment @alias
+    ...queryWithModuleDirectiveCustomImport_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-custom-import.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-custom-import.graphql
@@ -1,6 +1,6 @@
 query queryWithModuleDirectiveCustomImport_NameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...queryWithModuleDirectiveCustomImport_NameRendererFragment
+  ...queryWithModuleDirectiveCustomImport_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-custom-import.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-custom-import.graphql
@@ -1,6 +1,6 @@
 query queryWithModuleDirectiveCustomImport_NameRendererQuery($id: ID!) {
   node(id: $id) {
-  ...queryWithModuleDirectiveCustomImport_NameRendererFragment @alias
+    ...queryWithModuleDirectiveCustomImport_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-jsresource-import.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-jsresource-import.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query queryWithModuleDirectiveJsresourceImport_NameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...queryWithModuleDirectiveJsresourceImport_NameRendererFragment
+  ...queryWithModuleDirectiveJsresourceImport_NameRendererFragment @alias
   }
 }
 
@@ -100,8 +100,19 @@ import JSResource from 'JSResource';
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "queryWithModuleDirectiveJsresourceImport_NameRendererFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "queryWithModuleDirectiveJsresourceImport_NameRendererFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-jsresource-import.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-jsresource-import.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query queryWithModuleDirectiveJsresourceImport_NameRendererQuery($id: ID!) {
   node(id: $id) {
-  ...queryWithModuleDirectiveJsresourceImport_NameRendererFragment @alias
+    ...queryWithModuleDirectiveJsresourceImport_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-jsresource-import.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-jsresource-import.graphql
@@ -1,6 +1,6 @@
 query queryWithModuleDirectiveJsresourceImport_NameRendererQuery($id: ID!) {
   node(id: $id) {
-  ...queryWithModuleDirectiveJsresourceImport_NameRendererFragment @alias
+    ...queryWithModuleDirectiveJsresourceImport_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-jsresource-import.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive-jsresource-import.graphql
@@ -1,6 +1,6 @@
 query queryWithModuleDirectiveJsresourceImport_NameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...queryWithModuleDirectiveJsresourceImport_NameRendererFragment
+  ...queryWithModuleDirectiveJsresourceImport_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query queryWithModuleDirective_NameRendererQuery($id: ID!) {
   node(id: $id) {
-  ...queryWithModuleDirective_NameRendererFragment @alias
+    ...queryWithModuleDirective_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query queryWithModuleDirective_NameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...queryWithModuleDirective_NameRendererFragment
+  ...queryWithModuleDirective_NameRendererFragment @alias
   }
 }
 
@@ -89,8 +89,19 @@ fragment queryWithModuleDirective_MarkdownUserNameRenderer_name on MarkdownUserN
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "queryWithModuleDirective_NameRendererFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "queryWithModuleDirective_NameRendererFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive.graphql
@@ -1,6 +1,6 @@
 query queryWithModuleDirective_NameRendererQuery($id: ID!) {
   node(id: $id) {
-  ...queryWithModuleDirective_NameRendererFragment @alias
+    ...queryWithModuleDirective_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/query-with-module-directive.graphql
@@ -1,6 +1,6 @@
 query queryWithModuleDirective_NameRendererQuery($id: ID!) {
   node(id: $id) {
-    ...queryWithModuleDirective_NameRendererFragment
+  ...queryWithModuleDirective_NameRendererFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/redundant-selection-in-inline-fragments.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/redundant-selection-in-inline-fragments.expected
@@ -4,8 +4,8 @@ query redundantSelectionInInlineFragmentsQuery {
     ... on Story {
       __typename
     }
-    ...redundantSelectionInInlineFragments_interface_concrete
-    ...redundantSelectionInInlineFragments_interface
+  ...redundantSelectionInInlineFragments_interface_concrete @alias
+  ...redundantSelectionInInlineFragments_interface @alias
   }
 }
 
@@ -55,13 +55,35 @@ fragment redundantSelectionInInlineFragments_interface_concrete on MaybeNodeInte
             "abstractKey": null
           },
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "redundantSelectionInInlineFragments_interface_concrete"
+                }
+              ],
+              "type": "MaybeNodeInterface",
+              "abstractKey": "__isMaybeNodeInterface"
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "redundantSelectionInInlineFragments_interface_concrete"
           },
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "redundantSelectionInInlineFragments_interface"
+                }
+              ],
+              "type": "MaybeNodeInterface",
+              "abstractKey": "__isMaybeNodeInterface"
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "redundantSelectionInInlineFragments_interface"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/redundant-selection-in-inline-fragments.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/redundant-selection-in-inline-fragments.expected
@@ -4,8 +4,8 @@ query redundantSelectionInInlineFragmentsQuery {
     ... on Story {
       __typename
     }
-  ...redundantSelectionInInlineFragments_interface_concrete @alias
-  ...redundantSelectionInInlineFragments_interface @alias
+    ...redundantSelectionInInlineFragments_interface_concrete @alias
+    ...redundantSelectionInInlineFragments_interface @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/redundant-selection-in-inline-fragments.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/redundant-selection-in-inline-fragments.graphql
@@ -3,8 +3,8 @@ query redundantSelectionInInlineFragmentsQuery {
     ... on Story {
       __typename
     }
-    ...redundantSelectionInInlineFragments_interface_concrete
-    ...redundantSelectionInInlineFragments_interface
+  ...redundantSelectionInInlineFragments_interface_concrete @alias
+  ...redundantSelectionInInlineFragments_interface @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/redundant-selection-in-inline-fragments.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/redundant-selection-in-inline-fragments.graphql
@@ -3,8 +3,8 @@ query redundantSelectionInInlineFragmentsQuery {
     ... on Story {
       __typename
     }
-  ...redundantSelectionInInlineFragments_interface_concrete @alias
-  ...redundantSelectionInInlineFragments_interface @alias
+    ...redundantSelectionInInlineFragments_interface_concrete @alias
+    ...redundantSelectionInInlineFragments_interface @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/refetchable-fragment-on-node-with-missing-id.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/refetchable-fragment-on-node-with-missing-id.expected
@@ -3,7 +3,7 @@ fragment refetchableFragmentOnNodeWithMissingId_RefetchableFragment on Node
   @refetchable(queryName: "RefetchableFragmentQuery") {
   ... on User {
     name
-  ...refetchableFragmentOnNodeWithMissingId_ProfilePicture @alias
+    ...refetchableFragmentOnNodeWithMissingId_ProfilePicture @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/refetchable-fragment-on-node-with-missing-id.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/refetchable-fragment-on-node-with-missing-id.expected
@@ -3,7 +3,7 @@ fragment refetchableFragmentOnNodeWithMissingId_RefetchableFragment on Node
   @refetchable(queryName: "RefetchableFragmentQuery") {
   ... on User {
     name
-    ...refetchableFragmentOnNodeWithMissingId_ProfilePicture
+  ...refetchableFragmentOnNodeWithMissingId_ProfilePicture @alias
   }
 }
 
@@ -262,8 +262,19 @@ fragment refetchableFragmentOnNodeWithMissingId_RefetchableFragment on Node {
           "storageKey": null
         },
         {
-          "args": null,
-          "kind": "FragmentSpread",
+          "fragment": {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "refetchableFragmentOnNodeWithMissingId_ProfilePicture"
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          },
+          "kind": "AliasedInlineFragmentSpread",
           "name": "refetchableFragmentOnNodeWithMissingId_ProfilePicture"
         }
       ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/refetchable-fragment-on-node-with-missing-id.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/refetchable-fragment-on-node-with-missing-id.graphql
@@ -2,7 +2,7 @@ fragment refetchableFragmentOnNodeWithMissingId_RefetchableFragment on Node
   @refetchable(queryName: "RefetchableFragmentQuery") {
   ... on User {
     name
-  ...refetchableFragmentOnNodeWithMissingId_ProfilePicture @alias
+    ...refetchableFragmentOnNodeWithMissingId_ProfilePicture @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/refetchable-fragment-on-node-with-missing-id.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/refetchable-fragment-on-node-with-missing-id.graphql
@@ -2,7 +2,7 @@ fragment refetchableFragmentOnNodeWithMissingId_RefetchableFragment on Node
   @refetchable(queryName: "RefetchableFragmentQuery") {
   ... on User {
     name
-    ...refetchableFragmentOnNodeWithMissingId_ProfilePicture
+  ...refetchableFragmentOnNodeWithMissingId_ProfilePicture @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/relay-resolver-with-undefined-field-and-fragment-args.invalid.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/relay-resolver-with-undefined-field-and-fragment-args.invalid.expected
@@ -23,18 +23,10 @@ extend type User {
   pop_star_name(field_arg: Int, includeName: Boolean!): String @relay_resolver(fragment_name: "relayResolverWithUndefinedFieldAndFragmentArgsFragment_name", import_path: "PopStarNameResolver")
 }
 ==================================== ERROR ====================================
-✖︎ Operation 'relayResolverWithUndefinedFieldAndFragmentArgsQuery' references undefined variables: '$undefined_field_arg', '$undefined_fragment_arg'.
+✖︎ Expected `@alias` directive. `relayResolverWithUndefinedFieldAndFragmentArgs_user` is defined on `User` which might not match this selection type of `Node`. Add `@alias` to this spread to expose the fragment reference as a nullable property.
 
-  relay-resolver-with-undefined-field-and-fragment-args.invalid.graphql:10:28
-    9 │ fragment relayResolverWithUndefinedFieldAndFragmentArgs_user on User {
-   10 │   pop_star_name(field_arg: $undefined_field_arg, includeName: $undefined_fragment_arg)
-      │                            ^^^^^^^^^^^^^^^^^^^^
-   11 │ }
-
-  ℹ︎ related location
-
-  relay-resolver-with-undefined-field-and-fragment-args.invalid.graphql:10:63
-    9 │ fragment relayResolverWithUndefinedFieldAndFragmentArgs_user on User {
-   10 │   pop_star_name(field_arg: $undefined_field_arg, includeName: $undefined_fragment_arg)
-      │                                                               ^^^^^^^^^^^^^^^^^^^^^^^
-   11 │ }
+  relay-resolver-with-undefined-field-and-fragment-args.invalid.graphql:5:8
+    4 │   node(id: "SOME_ID") {
+    5 │     ...relayResolverWithUndefinedFieldAndFragmentArgs_user
+      │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │   }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/relay-resolver-with-undefined-field-args-linked-field.invalid.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/relay-resolver-with-undefined-field-args-linked-field.invalid.expected
@@ -18,10 +18,10 @@ extend type User {
   pop_star(name: String): User @relay_resolver(import_path: "./path/to/PopStarResolver.js")
 }
 ==================================== ERROR ====================================
-✖︎ Operation 'relayResolverWithUndefinedFieldArgsLinkedFieldQuery' references undefined variable: '$undefined'.
+✖︎ Expected `@alias` directive. `relayResolverWithUndefinedFieldArgsLinkedField_PopStar` is defined on `User` which might not match this selection type of `Node`. Add `@alias` to this spread to expose the fragment reference as a nullable property.
 
-  relay-resolver-with-undefined-field-args-linked-field.invalid.graphql:10:18
-    9 │ fragment relayResolverWithUndefinedFieldArgsLinkedField_PopStar on User {
-   10 │   pop_star(name: $undefined) @waterfall {
-      │                  ^^^^^^^^^^
-   11 │     id
+  relay-resolver-with-undefined-field-args-linked-field.invalid.graphql:5:8
+    4 │   node(id: "SOME_ID") {
+    5 │     ...relayResolverWithUndefinedFieldArgsLinkedField_PopStar
+      │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │   }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/relay-resolver-with-undefined-field-args-scalar.invalid.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/relay-resolver-with-undefined-field-args-scalar.invalid.expected
@@ -17,10 +17,10 @@ extend type User {
   pop_star_name(scale: Float!): String @relay_resolver(import_path: "./path/to/PopStarNameResolver.js")
 }
 ==================================== ERROR ====================================
-✖︎ Operation 'relayResolverWithUndefinedFieldArgsScalarQuery' references undefined variable: '$scale'.
+✖︎ Expected `@alias` directive. `relayResolverWithUndefinedFieldArgsScalar_name` is defined on `User` which might not match this selection type of `Node`. Add `@alias` to this spread to expose the fragment reference as a nullable property.
 
-  relay-resolver-with-undefined-field-args-scalar.invalid.graphql:10:24
-    9 │ fragment relayResolverWithUndefinedFieldArgsScalar_name on User {
-   10 │   pop_star_name(scale: $scale)
-      │                        ^^^^^^
-   11 │ }
+  relay-resolver-with-undefined-field-args-scalar.invalid.graphql:5:8
+    4 │   node(id: "SOME_ID") {
+    5 │     ...relayResolverWithUndefinedFieldArgsScalar_name
+      │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │   }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/relay-resolver-with-undefined-field-args.invalid.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/relay-resolver-with-undefined-field-args.invalid.expected
@@ -21,10 +21,10 @@ extend type User {
   pop_star_name(scale: Float!): String @relay_resolver(fragment_name: "relayResolverWithUndefinedFieldArgs_PopStarNameResolverFragment_name", import_path: "./path/to/PopStarNameResolver.js")
 }
 ==================================== ERROR ====================================
-✖︎ Operation 'relayResolverWithUndefinedFieldArgsQuery' references undefined variable: '$scale'.
+✖︎ Expected `@alias` directive. `relayResolverWithUndefinedFieldArgs_PopStarName` is defined on `User` which might not match this selection type of `Node`. Add `@alias` to this spread to expose the fragment reference as a nullable property.
 
-  relay-resolver-with-undefined-field-args.invalid.graphql:10:24
-    9 │ fragment relayResolverWithUndefinedFieldArgs_PopStarName on User {
-   10 │   pop_star_name(scale: $scale)
-      │                        ^^^^^^
-   11 │ }
+  relay-resolver-with-undefined-field-args.invalid.graphql:5:8
+    4 │   node(id: "SOME_ID") {
+    5 │     ...relayResolverWithUndefinedFieldArgs_PopStarName
+      │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │   }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/relay-resolver-with-undefined-fragment-args-linked-field.invalid.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/relay-resolver-with-undefined-fragment-args-linked-field.invalid.expected
@@ -26,10 +26,10 @@ extend type User {
   pop_star(includeName: Boolean!): User @relay_resolver(fragment_name: "relayResolverWithUndefinedFragmentArgsLinkedField_PopStarNameResolverFragment_name", import_path: "./path/to/PopStarNameResolver.js")
 }
 ==================================== ERROR ====================================
-✖︎ Operation 'relayResolverWithUndefinedFragmentArgsLinkedFieldQuery' references undefined variable: '$undefined'.
+✖︎ Expected `@alias` directive. `relayResolverWithUndefinedFragmentArgsLinkedField_PopStarName` is defined on `User` which might not match this selection type of `Node`. Add `@alias` to this spread to expose the fragment reference as a nullable property.
 
-  relay-resolver-with-undefined-fragment-args-linked-field.invalid.graphql:10:25
-    9 │ fragment relayResolverWithUndefinedFragmentArgsLinkedField_PopStarName on User {
-   10 │   pop_star(includeName: $undefined) @waterfall {
-      │                         ^^^^^^^^^^
-   11 │     id
+  relay-resolver-with-undefined-fragment-args-linked-field.invalid.graphql:5:8
+    4 │   node(id: "SOME_ID") {
+    5 │     ...relayResolverWithUndefinedFragmentArgsLinkedField_PopStarName
+      │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │   }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/relay-resolver-with-undefined-fragment-args.invalid.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/relay-resolver-with-undefined-fragment-args.invalid.expected
@@ -24,10 +24,10 @@ extend type User {
   pop_star_name(includeName: Boolean!): String @relay_resolver(fragment_name: "relayResolverWithUndefinedFragmentArgs_PopStarNameResolverFragment_name", import_path: "./path/to/PopStarNameResolver.js")
 }
 ==================================== ERROR ====================================
-✖︎ Operation 'relayResolverWithUndefinedFragmentArgsQuery' references undefined variable: '$undefined'.
+✖︎ Expected `@alias` directive. `relayResolverWithUndefinedFragmentArgs_PopStarName` is defined on `User` which might not match this selection type of `Node`. Add `@alias` to this spread to expose the fragment reference as a nullable property.
 
-  relay-resolver-with-undefined-fragment-args.invalid.graphql:10:30
-    9 │ fragment relayResolverWithUndefinedFragmentArgs_PopStarName on User {
-   10 │   pop_star_name(includeName: $undefined)
-      │                              ^^^^^^^^^^
-   11 │ }
+  relay-resolver-with-undefined-fragment-args.invalid.graphql:5:8
+    4 │   node(id: "SOME_ID") {
+    5 │     ...relayResolverWithUndefinedFragmentArgs_PopStarName
+      │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │   }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selections-on-interface.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selections-on-interface.expected
@@ -10,8 +10,8 @@ fragment selectionsOnInterfacePageFragment on Page {
 
 query selectionsOnInterfaceQuery($id: ID!) {
   node(id: $id) {
-    ...selectionsOnInterfaceUserFragment
-    ...selectionsOnInterfacePageFragment
+  ...selectionsOnInterfaceUserFragment @alias
+  ...selectionsOnInterfacePageFragment @alias
   }
 }
 ==================================== OUTPUT ===================================
@@ -43,13 +43,35 @@ query selectionsOnInterfaceQuery($id: ID!) {
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "selectionsOnInterfaceUserFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "selectionsOnInterfaceUserFragment"
           },
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "selectionsOnInterfacePageFragment"
+                }
+              ],
+              "type": "Page",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "selectionsOnInterfacePageFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selections-on-interface.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selections-on-interface.expected
@@ -10,8 +10,8 @@ fragment selectionsOnInterfacePageFragment on Page {
 
 query selectionsOnInterfaceQuery($id: ID!) {
   node(id: $id) {
-  ...selectionsOnInterfaceUserFragment @alias
-  ...selectionsOnInterfacePageFragment @alias
+    ...selectionsOnInterfaceUserFragment @alias
+    ...selectionsOnInterfacePageFragment @alias
   }
 }
 ==================================== OUTPUT ===================================

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selections-on-interface.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selections-on-interface.graphql
@@ -10,7 +10,7 @@ fragment selectionsOnInterfacePageFragment on Page {
 
 query selectionsOnInterfaceQuery($id: ID!) {
   node(id: $id) {
-  ...selectionsOnInterfaceUserFragment @alias
-  ...selectionsOnInterfacePageFragment @alias
+    ...selectionsOnInterfaceUserFragment @alias
+    ...selectionsOnInterfacePageFragment @alias
   }
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selections-on-interface.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/selections-on-interface.graphql
@@ -10,7 +10,7 @@ fragment selectionsOnInterfacePageFragment on Page {
 
 query selectionsOnInterfaceQuery($id: ID!) {
   node(id: $id) {
-    ...selectionsOnInterfaceUserFragment
-    ...selectionsOnInterfacePageFragment
+  ...selectionsOnInterfaceUserFragment @alias
+  ...selectionsOnInterfacePageFragment @alias
   }
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/spread-of-assignable-fragment.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/spread-of-assignable-fragment.expected
@@ -7,7 +7,8 @@ query spreadOfAssignableFragmentQuery {
     ...spreadOfAssignableFragmentAssignable_node
   }
   node2: node(id: 5) {
-  ...spreadOfAssignableFragmentAssignable_node
+    # ...spreadOfAssignableFragmentAssignable_user
+    ...spreadOfAssignableFragmentAssignable_node
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/spread-of-assignable-fragment.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/spread-of-assignable-fragment.expected
@@ -7,8 +7,7 @@ query spreadOfAssignableFragmentQuery {
     ...spreadOfAssignableFragmentAssignable_node
   }
   node2: node(id: 5) {
-    ...spreadOfAssignableFragmentAssignable_user
-    ...spreadOfAssignableFragmentAssignable_node
+  ...spreadOfAssignableFragmentAssignable_node
   }
 }
 
@@ -110,10 +109,10 @@ fragment spreadOfAssignableFragmentAssignable_node on Node @assignable {
           {
             "args": null,
             "kind": "FragmentSpread",
-            "name": "spreadOfAssignableFragmentAssignable_user"
+            "name": "spreadOfAssignableFragmentAssignable_node"
           },
           {
-            "alias": null,
+            "alias": "__isspreadOfAssignableFragmentAssignable_node",
             "args": null,
             "kind": "ScalarField",
             "name": "__typename",
@@ -124,18 +123,6 @@ fragment spreadOfAssignableFragmentAssignable_node on Node @assignable {
             "args": null,
             "kind": "ScalarField",
             "name": "__id",
-            "storageKey": null
-          },
-          {
-            "args": null,
-            "kind": "FragmentSpread",
-            "name": "spreadOfAssignableFragmentAssignable_node"
-          },
-          {
-            "alias": "__isspreadOfAssignableFragmentAssignable_node",
-            "args": null,
-            "kind": "ScalarField",
-            "name": "__typename",
             "storageKey": null
           }
         ],
@@ -272,7 +259,6 @@ query spreadOfAssignableFragmentQuery {
   }
   node2: node(id: 5) {
     __typename
-    ...spreadOfAssignableFragmentAssignable_user
     ...spreadOfAssignableFragmentAssignable_node
     id
   }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/spread-of-assignable-fragment.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/spread-of-assignable-fragment.graphql
@@ -6,8 +6,7 @@ query spreadOfAssignableFragmentQuery {
     ...spreadOfAssignableFragmentAssignable_node
   }
   node2: node(id: 5) {
-    ...spreadOfAssignableFragmentAssignable_user
-    ...spreadOfAssignableFragmentAssignable_node
+  ...spreadOfAssignableFragmentAssignable_node
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/spread-of-assignable-fragment.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/spread-of-assignable-fragment.graphql
@@ -6,7 +6,8 @@ query spreadOfAssignableFragmentQuery {
     ...spreadOfAssignableFragmentAssignable_node
   }
   node2: node(id: 5) {
-  ...spreadOfAssignableFragmentAssignable_node
+    # ...spreadOfAssignableFragmentAssignable_user
+    ...spreadOfAssignableFragmentAssignable_node
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-and-handle.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-and-handle.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query streamAndHandleQuery {
   node(id: "<id>") {
-    ...streamAndHandleFragment
+  ...streamAndHandleFragment @alias
   }
 }
 
@@ -35,8 +35,19 @@ fragment streamAndHandleFragment on Feedback {
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "streamAndHandleFragment"
+                }
+              ],
+              "type": "Feedback",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "streamAndHandleFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-and-handle.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-and-handle.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query streamAndHandleQuery {
   node(id: "<id>") {
-  ...streamAndHandleFragment @alias
+    ...streamAndHandleFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-and-handle.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-and-handle.graphql
@@ -1,6 +1,6 @@
 query streamAndHandleQuery {
   node(id: "<id>") {
-    ...streamAndHandleFragment
+  ...streamAndHandleFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-and-handle.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-and-handle.graphql
@@ -1,6 +1,6 @@
 query streamAndHandleQuery {
   node(id: "<id>") {
-  ...streamAndHandleFragment @alias
+    ...streamAndHandleFragment @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/unknown-root-variable-in-fragment.invalid.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/unknown-root-variable-in-fragment.invalid.expected
@@ -22,10 +22,10 @@ fragment unknownRootVariableInFragmentProfile on User {
   }
 }
 ==================================== ERROR ====================================
-✖︎ Operation 'unknownRootVariableInFragmentQuery' references undefined variable: '$includeFriends'.
+✖︎ Expected `@alias` directive. `unknownRootVariableInFragmentProfile` is defined on `User` which might not match this selection type of `Node`. Add `@alias` to this spread to expose the fragment reference as a nullable property.
 
-  unknown-root-variable-in-fragment.invalid.graphql:13:20
-   12 │   # includeFriends is not defined on the referencing query, should error
-   13 │   ... @include(if: $includeFriends) {
-      │                    ^^^^^^^^^^^^^^^
-   14 │     friends(first: 10) {
+  unknown-root-variable-in-fragment.invalid.graphql:5:8
+    4 │     id
+    5 │     ...unknownRootVariableInFragmentProfile @relay(mask: false)
+      │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    6 │   }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/unused-variables-removed-from-print-not-codegen.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/unused-variables-removed-from-print-not-codegen.expected
@@ -2,7 +2,7 @@
 query unusedVariablesRemovedFromPrintNotCodegen_QueryWithUnusedVariablesQuery($id: ID!, $unusedFirst: Int, $unusedAfter: ID) {
   node(id: $id) {
     id
-    ...unusedVariablesRemovedFromPrintNotCodegen_ConnectionFragment @arguments(fetchConnection: false)
+  ...unusedVariablesRemovedFromPrintNotCodegen_ConnectionFragment @arguments(fetchConnection: false) @alias
   }
 }
 
@@ -66,14 +66,25 @@ fragment unusedVariablesRemovedFromPrintNotCodegen_ConnectionFragment on User
             "storageKey": null
           },
           {
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "fetchConnection",
-                "value": false
-              }
-            ],
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "fetchConnection",
+                      "value": false
+                    }
+                  ],
+                  "kind": "FragmentSpread",
+                  "name": "unusedVariablesRemovedFromPrintNotCodegen_ConnectionFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "unusedVariablesRemovedFromPrintNotCodegen_ConnectionFragment"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/unused-variables-removed-from-print-not-codegen.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/unused-variables-removed-from-print-not-codegen.expected
@@ -2,7 +2,7 @@
 query unusedVariablesRemovedFromPrintNotCodegen_QueryWithUnusedVariablesQuery($id: ID!, $unusedFirst: Int, $unusedAfter: ID) {
   node(id: $id) {
     id
-  ...unusedVariablesRemovedFromPrintNotCodegen_ConnectionFragment @arguments(fetchConnection: false) @alias
+    ...unusedVariablesRemovedFromPrintNotCodegen_ConnectionFragment @arguments(fetchConnection: false) @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/unused-variables-removed-from-print-not-codegen.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/unused-variables-removed-from-print-not-codegen.graphql
@@ -1,7 +1,7 @@
 query unusedVariablesRemovedFromPrintNotCodegen_QueryWithUnusedVariablesQuery($id: ID!, $unusedFirst: Int, $unusedAfter: ID) {
   node(id: $id) {
     id
-  ...unusedVariablesRemovedFromPrintNotCodegen_ConnectionFragment @arguments(fetchConnection: false) @alias
+    ...unusedVariablesRemovedFromPrintNotCodegen_ConnectionFragment @arguments(fetchConnection: false) @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/unused-variables-removed-from-print-not-codegen.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/unused-variables-removed-from-print-not-codegen.graphql
@@ -1,7 +1,7 @@
 query unusedVariablesRemovedFromPrintNotCodegen_QueryWithUnusedVariablesQuery($id: ID!, $unusedFirst: Int, $unusedAfter: ID) {
   node(id: $id) {
     id
-    ...unusedVariablesRemovedFromPrintNotCodegen_ConnectionFragment @arguments(fetchConnection: false)
+  ...unusedVariablesRemovedFromPrintNotCodegen_ConnectionFragment @arguments(fetchConnection: false) @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/unused_fragment_arg_unchecked.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/unused_fragment_arg_unchecked.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query unusedFragmentArgUnchecked_QueryWithUnusedFragmentArgumentQuery($id: ID!) {
   node(id: $id) {
-    ...unusedFragmentArgUnchecked_Profile
+  ...unusedFragmentArgUnchecked_Profile @alias
   }
 }
 
@@ -50,8 +50,19 @@ fragment unusedFragmentArgUnchecked_ProfilePhoto on User {
         "plural": false,
         "selections": [
           {
-            "args": null,
-            "kind": "FragmentSpread",
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "unusedFragmentArgUnchecked_Profile"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
             "name": "unusedFragmentArgUnchecked_Profile"
           }
         ],

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/unused_fragment_arg_unchecked.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/unused_fragment_arg_unchecked.expected
@@ -1,7 +1,7 @@
 ==================================== INPUT ====================================
 query unusedFragmentArgUnchecked_QueryWithUnusedFragmentArgumentQuery($id: ID!) {
   node(id: $id) {
-  ...unusedFragmentArgUnchecked_Profile @alias
+    ...unusedFragmentArgUnchecked_Profile @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/unused_fragment_arg_unchecked.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/unused_fragment_arg_unchecked.graphql
@@ -1,6 +1,6 @@
 query unusedFragmentArgUnchecked_QueryWithUnusedFragmentArgumentQuery($id: ID!) {
   node(id: $id) {
-  ...unusedFragmentArgUnchecked_Profile @alias
+    ...unusedFragmentArgUnchecked_Profile @alias
   }
 }
 

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/unused_fragment_arg_unchecked.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/unused_fragment_arg_unchecked.graphql
@@ -1,6 +1,6 @@
 query unusedFragmentArgUnchecked_QueryWithUnusedFragmentArgumentQuery($id: ID!) {
   node(id: $id) {
-    ...unusedFragmentArgUnchecked_Profile
+  ...unusedFragmentArgUnchecked_Profile @alias
   }
 }
 


### PR DESCRIPTION
Fixes #5063 

## Problem
`enforce_fragment_alias_where_ambiguous` was `Enabled` only when deserialized via Serde (using `#[serde(default = "enabled_feature_flag")]`), but `FeatureFlags::default()` produced `Disabled` because `#[derive(Default)]` ignores Serde attributes.

This was the reason that adding an empty object to the `featureFlags` enabled the `enforce_fragment_alias_where_ambiguous`, but omitting it didn't:
```
{
  //...
  "projects": {
    "test": {
      //...
      "featureFlags": {}
    }
  }
}
```

## Changes

- Implemented a manual `Default` for `FeatureFlags` that sets `enforce_fragment_alias_where_ambiguous` to `FeatureFlag::Enabled` and leaves all other fields at their existing defaults.
- Derived `PartialEq` for `FeatureFlags`, `FeatureFlag`, `Rollout` and `RolloutRange` to enable object equality in tests.

NOTE: This is probably a breaking change, since we're now (actually) enabling the flag by default.

## Tests

Updated/added unit tests in feature_flags.rs:
- `default_trait_sets_enforce_fragment_alias_enabled` ensures the Rust default enables the field (could be omitted?).
- `serde_default_from_empty_object_matches_intent` asserts deserializing `{}` equals `FeatureFlags::default()`.