### PR TITLE
quick-start.md: import AppQuery as type

### DIFF
--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -128,7 +128,7 @@ See [Relay Environment](../api-reference/relay-runtime/relay-environment.md) for
 Finally we can start defining the data we want to fetch and build our UI. Our app will fetch a list of films and render each one using a `<Film>` component.
 
 ```tsx title="src/App.tsx"
-import { AppQuery } from "./__generated__/AppQuery.graphql";
+import type { AppQuery } from "./__generated__/AppQuery.graphql";
 import { graphql, useLazyLoadQuery } from "react-relay";
 import Film from "./Film";
 


### PR DESCRIPTION
## Changes in this PR
The current guidance to use `import { AppQuery } from "./__generated__/AppQuery.graphql";` does not work as expected, since AppQuery is expected as a type.

## Testing
Tested by going through the entire "getting started" page