### PR TITLE
Filter raw_response output types for concrete fields

### DIFF
--- a/compiler/crates/relay-typegen/src/visit.rs
+++ b/compiler/crates/relay-typegen/src/visit.rs
@@ -2384,6 +2384,24 @@ pub(crate) fn raw_response_visit_selections(
             ),
         }
     }
+
+    if let Some(concrete_type) = enclosing_linked_field_concrete_type {
+        // If we are generating for a concrete field type, we should 1. remove
+        // any selections that are for a different concrete type, since they are
+        // not applicable to our field, and 2. mark any selections without a
+        // concrete type as being for our field's concrete type, so that
+        // `raw_response_selections_to_babel` doesn't generate redundant types.
+        type_selections.retain_mut(|type_selection| {
+            match type_selection.get_enclosing_concrete_type() {
+                Some(selection_concrete_type) => selection_concrete_type == concrete_type,
+                None => {
+                    type_selection.set_concrete_type(concrete_type);
+                    true
+                }
+            }
+        });
+    }
+
     type_selections
 }
 

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/relay-resolver-raw-response.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/relay-resolver-raw-response.expected
@@ -31,12 +31,10 @@ export type relayResolver_Query$data = {
   },
 };
 export type relayResolver_Query$rawResponse = {
-  readonly me: ?({
-    readonly id: string,
-  } | {
+  readonly me: ?{
     readonly id: string,
     readonly name: ?string,
-  }),
+  },
 };
 export type relayResolver_Query = {
   rawResponse: relayResolver_Query$rawResponse,

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/spread-interface-fragment-on-concrete-raw-type.expected
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/spread-interface-fragment-on-concrete-raw-type.expected
@@ -1,0 +1,84 @@
+==================================== INPUT ====================================
+fragment MyFragment on Actor {
+  name
+  ... on User {
+    canViewerLike
+  }
+  ... on Page {
+    subscribeStatus
+  }
+}
+
+query MyQuery @raw_response_type {
+  me {
+    canViewerComment
+    ...MyFragment
+  }
+}
+
+mutation MyMutation @raw_response_type {
+  setName(name: "test") {
+    canViewerComment
+    ...MyFragment
+  }
+}
+==================================== OUTPUT ===================================
+import type { MyFragment$fragmentType } from "MyFragment.graphql";
+export type MyMutation$variables = {};
+export type MyMutation$data = {
+  readonly setName: ?{
+    readonly canViewerComment: ?CustomBoolean,
+    readonly $fragmentSpreads: MyFragment$fragmentType,
+  },
+};
+export type MyMutation$rawResponse = {
+  readonly setName: ?{
+    readonly __isActor: "User",
+    readonly canViewerComment: ?CustomBoolean,
+    readonly canViewerLike: ?CustomBoolean,
+    readonly id: string,
+    readonly name: ?string,
+  },
+};
+export type MyMutation = {
+  rawResponse: MyMutation$rawResponse,
+  response: MyMutation$data,
+  variables: MyMutation$variables,
+};
+-------------------------------------------------------------------------------
+import type { MyFragment$fragmentType } from "MyFragment.graphql";
+export type MyQuery$variables = {};
+export type MyQuery$data = {
+  readonly me: ?{
+    readonly canViewerComment: ?CustomBoolean,
+    readonly $fragmentSpreads: MyFragment$fragmentType,
+  },
+};
+export type MyQuery$rawResponse = {
+  readonly me: ?{
+    readonly __isActor: "User",
+    readonly canViewerComment: ?CustomBoolean,
+    readonly canViewerLike: ?CustomBoolean,
+    readonly id: string,
+    readonly name: ?string,
+  },
+};
+export type MyQuery = {
+  rawResponse: MyQuery$rawResponse,
+  response: MyQuery$data,
+  variables: MyQuery$variables,
+};
+-------------------------------------------------------------------------------
+import type { FragmentType } from "relay-runtime";
+declare export opaque type MyFragment$fragmentType: FragmentType;
+export type MyFragment$data = {
+  readonly canViewerLike?: ?CustomBoolean,
+  readonly name: ?string,
+  readonly subscribeStatus?: ?string,
+  readonly $fragmentType: MyFragment$fragmentType,
+};
+export type MyFragment$key = {
+  readonly $data?: MyFragment$data,
+  readonly $fragmentSpreads: MyFragment$fragmentType,
+  ...
+};

--- a/compiler/crates/relay-typegen/tests/generate_flow/fixtures/spread-interface-fragment-on-concrete-raw-type.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_flow/fixtures/spread-interface-fragment-on-concrete-raw-type.graphql
@@ -1,0 +1,23 @@
+fragment MyFragment on Actor {
+  name
+  ... on User {
+    canViewerLike
+  }
+  ... on Page {
+    subscribeStatus
+  }
+}
+
+query MyQuery @raw_response_type {
+  me {
+    canViewerComment
+    ...MyFragment
+  }
+}
+
+mutation MyMutation @raw_response_type {
+  setName(name: "test") {
+    canViewerComment
+    ...MyFragment
+  }
+}

--- a/compiler/crates/relay-typegen/tests/generate_flow_test.rs
+++ b/compiler/crates/relay-typegen/tests/generate_flow_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<902ba7d30b889ac8e52b036c2f2bef08>>
+ * @generated SignedSource<<dce7d30eb9f3f87e2cad498bbb3334a1>>
  */
 
 mod generate_flow;
@@ -1067,6 +1067,13 @@ async fn simple() {
     let input = include_str!("generate_flow/fixtures/simple.graphql");
     let expected = include_str!("generate_flow/fixtures/simple.expected");
     test_fixture(transform_fixture, file!(), "simple.graphql", "generate_flow/fixtures/simple.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn spread_interface_fragment_on_concrete_raw_type() {
+    let input = include_str!("generate_flow/fixtures/spread-interface-fragment-on-concrete-raw-type.graphql");
+    let expected = include_str!("generate_flow/fixtures/spread-interface-fragment-on-concrete-raw-type.expected");
+    test_fixture(transform_fixture, file!(), "spread-interface-fragment-on-concrete-raw-type.graphql", "generate_flow/fixtures/spread-interface-fragment-on-concrete-raw-type.expected", input, expected).await;
 }
 
 #[tokio::test]

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/relay-resolver-on-query-with-output-type.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/relay-resolver-on-query-with-output-type.expected
@@ -46,8 +46,6 @@ export type Foo_user$rawResponse = {
       readonly id: string;
       readonly lastName: string | null | undefined;
     }>;
-  } | {
-    readonly id: string;
   } | null | undefined;
 };
 export type Foo_user = {

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/spread-interface-fragment-on-concrete-raw-type.expected
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/spread-interface-fragment-on-concrete-raw-type.expected
@@ -1,0 +1,82 @@
+==================================== INPUT ====================================
+fragment MyFragment on Actor {
+  name
+  ... on User {
+    canViewerLike
+  }
+  ... on Page {
+    subscribeStatus
+  }
+}
+
+query MyQuery @raw_response_type {
+  me {
+    canViewerComment
+    ...MyFragment
+  }
+}
+
+mutation MyMutation @raw_response_type {
+  setName(name: "test") {
+    canViewerComment
+    ...MyFragment
+  }
+}
+==================================== OUTPUT ===================================
+import { FragmentRefs } from "relay-runtime";
+export type MyMutation$variables = Record<PropertyKey, never>;
+export type MyMutation$data = {
+  readonly setName: {
+    readonly canViewerComment: boolean | null | undefined;
+    readonly " $fragmentSpreads": FragmentRefs<"MyFragment">;
+  } | null | undefined;
+};
+export type MyMutation$rawResponse = {
+  readonly setName: {
+    readonly __isActor: "User";
+    readonly canViewerComment: boolean | null | undefined;
+    readonly canViewerLike: boolean | null | undefined;
+    readonly id: string;
+    readonly name: string | null | undefined;
+  } | null | undefined;
+};
+export type MyMutation = {
+  rawResponse: MyMutation$rawResponse;
+  response: MyMutation$data;
+  variables: MyMutation$variables;
+};
+-------------------------------------------------------------------------------
+import { FragmentRefs } from "relay-runtime";
+export type MyQuery$variables = Record<PropertyKey, never>;
+export type MyQuery$data = {
+  readonly me: {
+    readonly canViewerComment: boolean | null | undefined;
+    readonly " $fragmentSpreads": FragmentRefs<"MyFragment">;
+  } | null | undefined;
+};
+export type MyQuery$rawResponse = {
+  readonly me: {
+    readonly __isActor: "User";
+    readonly canViewerComment: boolean | null | undefined;
+    readonly canViewerLike: boolean | null | undefined;
+    readonly id: string;
+    readonly name: string | null | undefined;
+  } | null | undefined;
+};
+export type MyQuery = {
+  rawResponse: MyQuery$rawResponse;
+  response: MyQuery$data;
+  variables: MyQuery$variables;
+};
+-------------------------------------------------------------------------------
+import { FragmentRefs } from "relay-runtime";
+export type MyFragment$data = {
+  readonly canViewerLike?: boolean | null | undefined;
+  readonly name: string | null | undefined;
+  readonly subscribeStatus?: string | null | undefined;
+  readonly " $fragmentType": "MyFragment";
+};
+export type MyFragment$key = {
+  readonly " $data"?: MyFragment$data;
+  readonly " $fragmentSpreads": FragmentRefs<"MyFragment">;
+};

--- a/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/spread-interface-fragment-on-concrete-raw-type.graphql
+++ b/compiler/crates/relay-typegen/tests/generate_typescript/fixtures/spread-interface-fragment-on-concrete-raw-type.graphql
@@ -1,0 +1,23 @@
+fragment MyFragment on Actor {
+  name
+  ... on User {
+    canViewerLike
+  }
+  ... on Page {
+    subscribeStatus
+  }
+}
+
+query MyQuery @raw_response_type {
+  me {
+    canViewerComment
+    ...MyFragment
+  }
+}
+
+mutation MyMutation @raw_response_type {
+  setName(name: "test") {
+    canViewerComment
+    ...MyFragment
+  }
+}

--- a/compiler/crates/relay-typegen/tests/generate_typescript_test.rs
+++ b/compiler/crates/relay-typegen/tests/generate_typescript_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<0cae3d9ae2292e1fcd67286661d1d350>>
+ * @generated SignedSource<<df1be6dc17d550445e4385cad31c5ae8>>
  */
 
 mod generate_typescript;
@@ -661,6 +661,13 @@ async fn simple_use_import_type_syntax() {
     let input = include_str!("generate_typescript/fixtures/simple-use-import-type-syntax.graphql");
     let expected = include_str!("generate_typescript/fixtures/simple-use-import-type-syntax.expected");
     test_fixture(transform_fixture, file!(), "simple-use-import-type-syntax.graphql", "generate_typescript/fixtures/simple-use-import-type-syntax.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn spread_interface_fragment_on_concrete_raw_type() {
+    let input = include_str!("generate_typescript/fixtures/spread-interface-fragment-on-concrete-raw-type.graphql");
+    let expected = include_str!("generate_typescript/fixtures/spread-interface-fragment-on-concrete-raw-type.expected");
+    test_fixture(transform_fixture, file!(), "spread-interface-fragment-on-concrete-raw-type.graphql", "generate_typescript/fixtures/spread-interface-fragment-on-concrete-raw-type.expected", input, expected).await;
 }
 
 #[tokio::test]


### PR DESCRIPTION
When generating a raw_response type for a concrete fields, we may (e.g.,) still be spreading a fragment which is for an abstract type. We should cut down our type selections based on the actual concrete type of the field, to generate more specific raw_response types. We should also mark the selections has having the same concrete type as our field, preventing redundant arms of the final TypeScript/Flow union types from being output.

This makes the output raw response types a lot more pleasant to work with.

Fixes #5090