### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/update-cargo-lock.yml
+++ b/.github/workflows/update-cargo-lock.yml
@@ -28,7 +28,7 @@ jobs:
       - name: cargo check
         run: cargo check --features vendored --manifest-path=compiler/Cargo.toml
       - name: pull-request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v8
         with:
           title: "Update Cargo.lock"
           delete-branch: true


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `peter-evans/create-pull-request` | [`v4`](https://github.com/peter-evans/create-pull-request/releases/tag/v4) | [`v8`](https://github.com/peter-evans/create-pull-request/releases/tag/v8) | [Release](https://github.com/peter-evans/create-pull-request/releases/tag/v8) | update-cargo-lock.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
