### PR TITLE
Fix trusted publishing Node.js compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18.x
+          node-version: 20.x
           registry-url: https://registry.npmjs.org/
           cache: "yarn"
       - name: Install dependencies

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   },
   "private": true,
   "devEngines": {
-    "node": ">=18.x",
+    "node": ">=20.x",
     "npm": ">=8.x"
   },
   "jest": {


### PR DESCRIPTION
## Summary
- Update main-release job to use Node.js 20.x to support npm@11.7.0 for trusted publishing
- Update package.json devEngines to require Node.js >=20.x 
- Keep CI matrix testing on both 18.x and 20.x for backward compatibility

## Problem
The trusted publishing workflow was failing because npm@11.7.0 requires Node.js "^20.17.0 || >=22.9.0" but the main-release job was using Node.js 18.x.

## Solution
Upgrade the publishing job to use Node.js 20.x while maintaining compatibility testing on both versions.

🤖 Generated with [Claude Code](https://claude.ai/code)

Currently trying to update `npm` to a version that supports Trusted Publishing triggers the following error in CI:

```
Run npm install -g npm@11.7.0
npm error code EBADENGINE
npm error engine Unsupported engine
npm error engine Not compatible with your version of node/npm: npm@11.7.0
npm error notsup Not compatible with your version of node/npm: npm@11.7.0
npm error notsup Required: {"node":"^20.17.0 || >=22.9.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v18.20.8"}
npm error A complete log of this run can be found in: /home/runner/.npm/_logs/2025-12-17T01_06_05_575Z-debug-0.log
Error: Process completed with exit code 1.
```

I suspect this is due to one of these node version constraints because npm 11.7 does not support Node 18. Version 20 should be fine here since we already cover Node 20 in the matrix of node versions we test.

