### PR TITLE
Remove non-standard key from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,10 +84,6 @@
     "@babel/traverse": "^7.23.2"
   },
   "private": true,
-  "devEngines": {
-    "node": ">=20.x",
-    "npm": ">=8.x"
-  },
   "jest": {
     "testMatch": [
       "<rootDir>/packages/**/__tests__/**/*-test.js"


### PR DESCRIPTION
This is incompatible with the new version of Node we use for publishing in https://github.com/facebook/relay/commit/1a690bb7fe8a7442919aac6e3800b279f1d16335 and is causing publishing to [fail](https://github.com/facebook/relay/actions/runs/20314256249/job/58354189745) with:

```
npm error Invalid property "devEngines.node"
```