### PR TITLE
Add workflow for updating yarn.lock

### DIFF
--- a/.github/workflows/update-yarn-lock.yml
+++ b/.github/workflows/update-yarn-lock.yml
@@ -1,0 +1,29 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+name: Update yarn.lock
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  update-yarn-lock:
+    name: Update yarn.lock file
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: yarn install
+        run: yarn install
+      - name: pull-request
+        uses: peter-evans/create-pull-request@v4
+        with:
+          title: "Update yarn.lock"
+          delete-branch: true
+          # Use a PAT with permissions to act as relay-bot and bypass branch protection
+          token: ${{ secrets.RELAY_BOT_GITHUB_PAT }}


### PR DESCRIPTION
## Summary
- Adds a new GitHub Actions workflow for automatically updating yarn.lock
- Follows the same pattern as the existing update-cargo-lock workflow
- Runs daily via cron schedule and can be manually triggered
- Creates automated PRs when yarn.lock needs updating

## Test plan
- Verify workflow syntax is valid
- Can be tested manually via workflow_dispatch