### PR TITLE
Update babel-plugin.md documentation to use npm

### DIFF
--- a/website/versioned_docs/version-v20.1.0/getting-started/babel-plugin.md
+++ b/website/versioned_docs/version-v20.1.0/getting-started/babel-plugin.md
@@ -17,7 +17,7 @@ Relay requires a [Babel plugin](https://www.npmjs.com/package/babel-plugin-relay
 If not, you can install the Babel plugin manually:
 
 ```sh
-yarn add --dev babel-plugin-relay graphql
+npm install --save-dev babel-plugin-relay graphql
 ```
 
 Add `"relay"` to the list of plugins in your `.babelrc` file:


### PR DESCRIPTION
Documentation switches between npm in Quick Start to yarn in babel plugin. Changed to npm.