### PR TITLE
Fix CI: Windows path separator normalization in integration tests

### DIFF
--- a/compiler/crates/relay-compiler/tests/relay_compiler_integration.rs
+++ b/compiler/crates/relay-compiler/tests/relay_compiler_integration.rs
@@ -105,5 +105,9 @@ pub async fn transform_fixture(fixture: &Fixture<'_>) -> Result<String, String> 
 fn format_compiler_error(root_dir: &Path, error: Error) -> String {
     let output = print_compiler_error(root_dir, error);
     // Replace the test directory path with a placeholder for deterministic test output
-    output.replace(root_dir.to_str().unwrap(), "<TEST_DIR>")
+    // On Windows, paths use backslashes, so we first replace the root directory,
+    // then normalize all remaining backslashes to forward slashes for consistent output
+    let output = output.replace(root_dir.to_str().unwrap(), "<TEST_DIR>");
+    // Normalize path separators for cross-platform consistency
+    output.replace('\\', "/")
 }


### PR DESCRIPTION
## Summary
- Fixed config_validation integration tests failing on Windows due to path separator differences
- The test output was using platform-native backslashes on Windows, but expected output uses forward slashes
- Normalized all path separators in test output to forward slashes for cross-platform consistency

## Test plan
- [x] Verified all 7 affected tests pass locally on macOS
- [ ] CI should pass on Windows after this change

### Affected tests:
- `config_validation_excluded_source_directory`
- `config_validation_invalid_exclude_glob`
- `config_validation_invalid_excludes_extensions_glob`
- `config_validation_missing_schema_extension_directory`
- `config_validation_missing_schema_file`
- `config_validation_missing_source_directory`
- `config_validation_project_missing`