### PR TITLE
Fix update-cargo-lock workflow by upgrading create-pull-request action

### DIFF
--- a/.github/workflows/update-cargo-lock.yml
+++ b/.github/workflows/update-cargo-lock.yml
@@ -31,7 +31,7 @@ jobs:
       - name: cargo check
         run: cargo check --features vendored --manifest-path=compiler/Cargo.toml
       - name: pull-request
-        uses: peter-evans/create-pull-request@v4
+        uses: peter-evans/create-pull-request@v8
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "Update Cargo.lock"


### PR DESCRIPTION
## Summary

The `update-cargo-lock.yml` workflow has been failing since January 6th due to a credential conflict between `actions/checkout@v6` and `peter-evans/create-pull-request@v4`.

**Error:**
```
remote: Duplicate header: "Authorization"
fatal: unable to access 'https://github.com/facebook/relay/': The requested URL returned error: 400
```

**Root cause:** The v4 version of `create-pull-request` (released 2022) has credential handling that conflicts with the newer `actions/checkout@v6` which uses `includeIf.gitdir` config entries for credential persistence.

**Fix:** Upgrade `peter-evans/create-pull-request` from v4 to v8 (latest version, released December 2025).

## Test plan

- [x] Validated by manually triggering the workflow on a feature branch: https://github.com/captbaritone/relay/actions/runs/21002627041
- [x] Workflow completed successfully without the "Duplicate header" error

PR created as part of testing: https://github.com/captbaritone/relay/pull/1/files