### PR TITLE
Migrate from deprecated actions-rs/toolchain to dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,13 +93,12 @@ jobs:
     runs-on: ${{ matrix.target.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
         with:
           # Should stay in sync with fbcode/buck2/rust-toolchain
           # And other similar references in this file and
           # docusaurus.yml
           toolchain: nightly-2025-08-01
-          override: true
       - name: "Run tests"
         run: cargo test --manifest-path=compiler/Cargo.toml --locked ${{ matrix.target.features && '--features' }} ${{ matrix.target.features }}
 
@@ -119,13 +118,12 @@ jobs:
     runs-on: ${{ matrix.target.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
         with:
           # Should stay in sync with fbcode/buck2/rust-toolchain
           # And other similar references in this file and
           # docusaurus.yml
           toolchain: nightly-2025-08-01
-          override: true
       - name: "Update fixture tests"
         run: ./scripts/update-fixtures.sh
       - name: "Build test project"
@@ -140,11 +138,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
         with:
           # Should stay in sync with tools/third-party/rustfmt/.rustfmt-version
           toolchain: nightly-2025-08-01
-          override: true
           components: rustfmt
       - name: "rustfmt"
         run: grep -r --include "*.rs" --files-without-match $'\x40generated' crates | xargs rustfmt --check --config="skip_children=true"
@@ -182,14 +179,13 @@ jobs:
     runs-on: ${{ matrix.target.os }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
         with:
           # Should stay in sync with fbcode/buck2/rust-toolchain
           # And other similar references in this file and
           # docusaurus.yml
           toolchain: nightly-2025-08-01
-          override: true
-          target: ${{ matrix.target.target }}
+          targets: ${{ matrix.target.target }}
       - uses: actions/setup-node@v4
         if: github.event_name == 'push' && github.repository == 'facebook/relay' && github.ref == 'refs/heads/main'
         with:

--- a/.github/workflows/docusaurus.yml
+++ b/.github/workflows/docusaurus.yml
@@ -19,13 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
         with:
           # Should stay in sync with fbcode/buck2/rust-toolchain
           # And other similar references in this file and
           # ci.yml
           toolchain: nightly-2025-08-01
-          override: true
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       - name: "Build Compiler Playground Wasm NPM package"

--- a/.github/workflows/update-cargo-lock.yml
+++ b/.github/workflows/update-cargo-lock.yml
@@ -18,13 +18,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
+      - uses: dtolnay/rust-toolchain@f7ccc83f9ed1e5b9c81d8a67d7ad1a747e22a561
         with:
           # Should stay in sync with fbcode/buck2/rust-toolchain
           # And other similar references in this file and
           # ci.yml
           toolchain: nightly-2025-08-01
-          override: true
       - name: cargo check
         run: cargo check --features vendored --manifest-path=compiler/Cargo.toml
       - name: pull-request


### PR DESCRIPTION
## Summary

The `actions-rs/toolchain` action has been deprecated since 2020 and shows deprecation warnings in CI:

```
##[warning]The `set-output` command is deprecated and will be disabled soon.
```

This PR migrates all workflow files to use the actively maintained `dtolnay/rust-toolchain` action instead.

**Changes:**
- Replace `actions-rs/toolchain@v1` with `dtolnay/rust-toolchain` (pinned to commit SHA)
- Remove `override: true` (not needed with dtolnay/rust-toolchain)
- Change `target:` to `targets:` for cross-compilation targets (different API)

**Files updated:**
- `.github/workflows/ci.yml` (4 usages)
- `.github/workflows/update-cargo-lock.yml` (1 usage)
- `.github/workflows/docusaurus.yml` (1 usage)

## Test plan

- [ ] CI passes on this PR (validates the new action works correctly across all platforms)