### PR TITLE
Use relay-bot account for Cargo.lock update PRs

### DIFF
--- a/.github/workflows/update-cargo-lock.yml
+++ b/.github/workflows/update-cargo-lock.yml
@@ -16,9 +16,6 @@ jobs:
   update-cargo-lock:
     name: Update Cargo.lock file
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions-rs/toolchain@v1
@@ -33,6 +30,6 @@ jobs:
       - name: pull-request
         uses: peter-evans/create-pull-request@v8
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELAY_BOT_GITHUB_PAT }}
           title: "Update Cargo.lock"
           delete-branch: true


### PR DESCRIPTION
## Summary
- Switch from `GITHUB_TOKEN` to relay-bot's PAT (`secrets.RELAY_BOT_GITHUB_PAT`) for creating Cargo.lock update PRs
- Remove the `permissions` block since the PAT handles write operations and checkout doesn't need special permissions for public repos

## Test plan
- Verify the workflow runs successfully on the next scheduled run or manual trigger