### PR TITLE
Restrict npm publish job to main branch and version tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -227,7 +227,7 @@ jobs:
   main-release:
     name: Publish to NPM
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.repository == 'facebook/relay'
+    if: github.event_name == 'push' && github.repository == 'facebook/relay' && (github.ref == 'refs/heads/main' || (github.ref_type == 'tag' && startsWith(github.ref_name, 'v')))
     needs: [js-tests, js-lint, typecheck, build-tests, build-compiler]
     environment: npm-publish
     permissions:


### PR DESCRIPTION
## Summary
- Add branch/tag condition to the `main-release` job to only run on pushes to `main` or version tags (e.g., `v1.0.0`)
- Prevents permission errors when the job runs on non-main branches where the `npm-publish` environment is not accessible

## Test plan
- Verify CI passes on this PR (the `main-release` job should be skipped)
- Confirm npm publish still works when merging to main