### PR TITLE
Support named exports with nodejs ESM

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -89,6 +89,9 @@ module.exports = {
     // Custom rules for our own codebase
     'relay-internal/no-mixed-import-and-require': 'error',
     'relay-internal/sort-imports': 'error',
+
+    // Enabled only in relay package entry files
+    'relay-internal/esm-compatible-cjs': 'off',
   },
   overrides: [
     {

--- a/packages/eslint-plugin-relay-internal/lib/index.js
+++ b/packages/eslint-plugin-relay-internal/lib/index.js
@@ -17,4 +17,5 @@ module.exports.rules = {
   'no-mixed-import-and-require': require('./rules/no-mixed-import-and-require'),
   'sort-imports': require('./rules/sort-imports'), // Synced from WWW
   'no-for-of-loops': require('./rules/no-for-of-loops'),
+  'esm-compatible-cjs': require('./rules/esm-compatible-cjs'),
 };

--- a/packages/eslint-plugin-relay-internal/lib/rules/esm-compatible-cjs.js
+++ b/packages/eslint-plugin-relay-internal/lib/rules/esm-compatible-cjs.js
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @oncall eslint
+ */
+
+'use strict';
+
+/**
+ * When an ESM file imports a common js file (like relay-runtime), Node.js will
+ * use cjs-module-lexer (https://github.com/nodejs/cjs-module-lexer/) to try
+ * to determine compatible named exports.
+ *
+ * From the node.js docs (https://nodejs.org/api/esm.html):
+ * > Named exports detection covers many common export patterns, reexport
+ * > patterns and build tool and transpiler outputs. See cjs-module-lexer
+ * > for the exact semantics implemented.
+ *
+ * In the entry points of react-relay and relay-runtime, the pattern of
+ * exporting a property on another object causes cjs-module-lexer to not
+ * detect any subsequent named exports.
+ *
+ * Example:
+ *
+ * This doesn't work
+ * module.exports = {
+ *   fetchQuery: RelayRuntime.fetchQuery
+ * };
+ *
+ * This does work
+ * const { fetchQuery } = RelayRuntime;
+ * module.exports = {
+ *   fetchQuery
+ * };
+ *
+ * This rule enforces that relay's entry files can be used with ESM named exports.
+ *
+ */
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    messages: {
+      esmCompatibleCjs:
+        "Relay's entry files must be compatible with ESM named exports, use a simple identifier assignment.",
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const invalidExports = [];
+    return {
+      ExpressionStatement(node) {
+        if (
+          node.expression.type === 'AssignmentExpression' &&
+          node.expression.left.object.type === 'Identifier' &&
+          node.expression.left.object.name === 'module' &&
+          node.expression.left.property.type === 'Identifier' &&
+          node.expression.left.property.name === 'exports' &&
+          node.expression.right.type === 'ObjectExpression'
+        ) {
+          for (const property of node.expression.right.properties) {
+            if (property.value.type !== 'Identifier') {
+              invalidExports.push(property.value);
+            }
+          }
+        }
+      },
+      'Program:exit'() {
+        if (invalidExports.length > 0) {
+          for (const invalidExport of invalidExports) {
+            context.report({
+              messageId: 'esmCompatibleCjs',
+              node: invalidExport,
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/react-relay/hooks.js
+++ b/packages/react-relay/hooks.js
@@ -11,6 +11,8 @@
 
 'use strict';
 
+/* eslint relay-internal/esm-compatible-cjs: error */
+
 const EntryPointContainer = require('./relay-hooks/EntryPointContainer.react');
 const loadEntryPoint = require('./relay-hooks/loadEntryPoint');
 const {loadQuery} = require('./relay-hooks/loadQuery');
@@ -62,26 +64,37 @@ export type {
   FetchPolicy,
 } from 'relay-runtime';
 
+const {
+  ConnectionHandler,
+  applyOptimisticMutation,
+  commitLocalUpdate,
+  commitMutation,
+  graphql,
+  readInlineData,
+  requestSubscription,
+  fetchQuery,
+} = RelayRuntime;
+
 /**
  * The public interface for Relay Hooks.
  * This will eventually become the main public interface for react-relay.
  */
 module.exports = {
-  ConnectionHandler: RelayRuntime.ConnectionHandler,
+  ConnectionHandler,
 
-  applyOptimisticMutation: RelayRuntime.applyOptimisticMutation,
-  commitLocalUpdate: RelayRuntime.commitLocalUpdate,
-  commitMutation: RelayRuntime.commitMutation,
-  graphql: RelayRuntime.graphql,
-  readInlineData: RelayRuntime.readInlineData,
-  requestSubscription: RelayRuntime.requestSubscription,
+  applyOptimisticMutation,
+  commitLocalUpdate,
+  commitMutation,
+  graphql,
+  readInlineData,
+  requestSubscription,
 
   EntryPointContainer: EntryPointContainer,
   RelayEnvironmentProvider: RelayEnvironmentProvider,
 
   ProfilerContext: ProfilerContext,
 
-  fetchQuery: RelayRuntime.fetchQuery,
+  fetchQuery,
 
   loadQuery: loadQuery,
   loadEntryPoint: loadEntryPoint,

--- a/packages/react-relay/index.js
+++ b/packages/react-relay/index.js
@@ -11,6 +11,8 @@
 
 'use strict';
 
+/* eslint relay-internal/esm-compatible-cjs: error */
+
 const ReactRelayContext = require('./ReactRelayContext');
 const ReactRelayFragmentContainer = require('./ReactRelayFragmentContainer');
 const ReactRelayLocalQueryRenderer = require('./ReactRelayLocalQueryRenderer');
@@ -80,31 +82,49 @@ export type {
   FetchPolicy,
 } from 'relay-runtime';
 
+const {
+  ConnectionHandler,
+  MutationTypes,
+  RangeOperations,
+  applyOptimisticMutation,
+  commitLocalUpdate,
+  commitMutation,
+  fetchQuery_DEPRECATED,
+  graphql,
+  readInlineData,
+  requestSubscription,
+  fetchQuery,
+} = RelayRuntime;
+
+const createFragmentContainer = ReactRelayFragmentContainer.createContainer;
+const createPaginationContainer = ReactRelayPaginationContainer.createContainer;
+const createRefetchContainer = ReactRelayRefetchContainer.createContainer;
+
 /**
  * The public interface to react-relay.
  * Currently contains both Relay Hooks and legacy Container APIs.
  * Will eventually only export the interface from ./hooks.js.
  */
 module.exports = {
-  ConnectionHandler: RelayRuntime.ConnectionHandler,
+  ConnectionHandler,
   QueryRenderer: ReactRelayQueryRenderer,
   LocalQueryRenderer: ReactRelayLocalQueryRenderer,
 
-  MutationTypes: RelayRuntime.MutationTypes,
-  RangeOperations: RelayRuntime.RangeOperations,
+  MutationTypes,
+  RangeOperations,
 
   ReactRelayContext,
 
-  applyOptimisticMutation: RelayRuntime.applyOptimisticMutation,
-  commitLocalUpdate: RelayRuntime.commitLocalUpdate,
-  commitMutation: RelayRuntime.commitMutation,
-  createFragmentContainer: ReactRelayFragmentContainer.createContainer,
-  createPaginationContainer: ReactRelayPaginationContainer.createContainer,
-  createRefetchContainer: ReactRelayRefetchContainer.createContainer,
-  fetchQuery_DEPRECATED: RelayRuntime.fetchQuery_DEPRECATED,
-  graphql: RelayRuntime.graphql,
-  readInlineData: RelayRuntime.readInlineData,
-  requestSubscription: RelayRuntime.requestSubscription,
+  applyOptimisticMutation,
+  commitLocalUpdate,
+  commitMutation,
+  createFragmentContainer,
+  createPaginationContainer,
+  createRefetchContainer,
+  fetchQuery_DEPRECATED,
+  graphql,
+  readInlineData,
+  requestSubscription,
 
   // Relay Hooks
   EntryPointContainer: EntryPointContainer,
@@ -112,7 +132,7 @@ module.exports = {
 
   ProfilerContext: ProfilerContext,
 
-  fetchQuery: RelayRuntime.fetchQuery,
+  fetchQuery,
 
   loadQuery: loadQuery,
   loadEntryPoint: loadEntryPoint,

--- a/packages/react-relay/legacy.js
+++ b/packages/react-relay/legacy.js
@@ -11,6 +11,8 @@
 
 'use strict';
 
+/* eslint relay-internal/esm-compatible-cjs: error */
+
 const ReactRelayContext = require('./ReactRelayContext');
 const ReactRelayFragmentContainer = require('./ReactRelayFragmentContainer');
 const ReactRelayLocalQueryRenderer = require('./ReactRelayLocalQueryRenderer');
@@ -47,28 +49,45 @@ export type {
   FetchPolicy,
 } from 'relay-runtime';
 
+const {
+  ConnectionHandler,
+  MutationTypes,
+  RangeOperations,
+  applyOptimisticMutation,
+  commitLocalUpdate,
+  commitMutation,
+  fetchQuery_DEPRECATED,
+  graphql,
+  readInlineData,
+  requestSubscription,
+} = RelayRuntime;
+
+const createFragmentContainer = ReactRelayFragmentContainer.createContainer;
+const createPaginationContainer = ReactRelayPaginationContainer.createContainer;
+const createRefetchContainer = ReactRelayRefetchContainer.createContainer;
+
 /**
  * Legacy react-relay exports.
  * Should prefer using interface defined in ./hooks.js
  */
 module.exports = {
-  ConnectionHandler: RelayRuntime.ConnectionHandler,
+  ConnectionHandler,
   QueryRenderer: ReactRelayQueryRenderer,
   LocalQueryRenderer: ReactRelayLocalQueryRenderer,
 
-  MutationTypes: RelayRuntime.MutationTypes,
-  RangeOperations: RelayRuntime.RangeOperations,
+  MutationTypes,
+  RangeOperations,
 
   ReactRelayContext,
 
-  applyOptimisticMutation: RelayRuntime.applyOptimisticMutation,
-  commitLocalUpdate: RelayRuntime.commitLocalUpdate,
-  commitMutation: RelayRuntime.commitMutation,
-  createFragmentContainer: ReactRelayFragmentContainer.createContainer,
-  createPaginationContainer: ReactRelayPaginationContainer.createContainer,
-  createRefetchContainer: ReactRelayRefetchContainer.createContainer,
-  fetchQuery_DEPRECATED: RelayRuntime.fetchQuery_DEPRECATED,
-  graphql: RelayRuntime.graphql,
-  readInlineData: RelayRuntime.readInlineData,
-  requestSubscription: RelayRuntime.requestSubscription,
+  applyOptimisticMutation,
+  commitLocalUpdate,
+  commitMutation,
+  createFragmentContainer,
+  createPaginationContainer,
+  createRefetchContainer,
+  fetchQuery_DEPRECATED,
+  graphql,
+  readInlineData,
+  requestSubscription,
 };

--- a/packages/relay-runtime/index.js
+++ b/packages/relay-runtime/index.js
@@ -11,6 +11,8 @@
 
 'use strict';
 
+/* eslint relay-internal/esm-compatible-cjs: error */
+
 const {isErrorResult, isValueResult} = require('./experimental');
 const ConnectionHandler = require('./handlers/connection/ConnectionHandler');
 const ConnectionInterface = require('./handlers/connection/ConnectionInterface');
@@ -262,6 +264,77 @@ if (__DEV__) {
   }
 }
 
+const {
+  areEqualSelectors,
+  createNormalizationSelector,
+  createReaderSelector,
+  getDataIDsFromFragment,
+  getDataIDsFromObject,
+  getPluralSelector,
+  getSelector,
+  getSelectorsFromObject,
+  getSingularSelector,
+  getVariablesFromFragment,
+  getVariablesFromObject,
+  getVariablesFromPluralFragment,
+  getVariablesFromSingularFragment,
+} = RelayModernSelector;
+
+const {createOperationDescriptor, createRequestDescriptor} =
+  RelayModernOperationDescriptor;
+
+const {
+  getArgumentValues,
+  getModuleComponentKey,
+  getModuleOperationKey,
+  getStorageKey,
+  FRAGMENTS_KEY,
+  FRAGMENT_OWNER_KEY,
+  ID_KEY,
+  REF_KEY,
+  REFS_KEY,
+  ROOT_ID,
+  ROOT_TYPE,
+  TYPENAME_KEY,
+} = RelayStoreUtils;
+
+const {
+  getNode,
+  getFragment,
+  getInlineDataFragment,
+  getPaginationFragment,
+  getRefetchableFragment,
+  getRequest,
+  graphql,
+  isFragment,
+  isInlineDataFragment,
+  isRequest,
+} = GraphQLTag;
+
+const {readFragment} = ResolverFragments;
+
+const {DEFAULT_HANDLE_KEY} = RelayDefaultHandleKey;
+
+const {MutationTypes, RangeOperations} = RelayDeclarativeMutationConfig;
+
+const {VIEWER_ID, VIEWER_TYPE} = ViewerPattern;
+
+const __internal = {
+  ResolverFragments,
+  OperationTracker: RelayOperationTracker,
+  createRelayContext: createRelayContext,
+  createRelayLoggingContext: createRelayLoggingContext,
+  getOperationVariables: RelayConcreteVariables.getOperationVariables,
+  getLocalVariables: RelayConcreteVariables.getLocalVariables,
+  fetchQuery: fetchQueryInternal.fetchQuery,
+  fetchQueryDeduped: fetchQueryInternal.fetchQueryDeduped,
+  getPromiseForActiveRequest: fetchQueryInternal.getPromiseForActiveRequest,
+  getObservableForActiveRequest:
+    fetchQueryInternal.getObservableForActiveRequest,
+  normalizeResponse: normalizeResponse,
+  withProvidedVariables: withProvidedVariables,
+};
+
 /**
  * The public interface to Relay Runtime.
  */
@@ -276,59 +349,55 @@ module.exports = {
   ReplaySubject: RelayReplaySubject,
   Store: RelayModernStore,
 
-  areEqualSelectors: RelayModernSelector.areEqualSelectors,
+  areEqualSelectors,
   createFragmentSpecResolver: createFragmentSpecResolver,
-  createNormalizationSelector: RelayModernSelector.createNormalizationSelector,
-  createOperationDescriptor:
-    RelayModernOperationDescriptor.createOperationDescriptor,
-  createReaderSelector: RelayModernSelector.createReaderSelector,
-  createRequestDescriptor:
-    RelayModernOperationDescriptor.createRequestDescriptor,
-  getArgumentValues: RelayStoreUtils.getArgumentValues,
-  getDataIDsFromFragment: RelayModernSelector.getDataIDsFromFragment,
-  getDataIDsFromObject: RelayModernSelector.getDataIDsFromObject,
-  getNode: GraphQLTag.getNode,
-  getFragment: GraphQLTag.getFragment,
-  getInlineDataFragment: GraphQLTag.getInlineDataFragment,
-  getModuleComponentKey: RelayStoreUtils.getModuleComponentKey,
-  getModuleOperationKey: RelayStoreUtils.getModuleOperationKey,
-  getPaginationFragment: GraphQLTag.getPaginationFragment,
-  getPluralSelector: RelayModernSelector.getPluralSelector,
-  getRefetchableFragment: GraphQLTag.getRefetchableFragment,
-  getRequest: GraphQLTag.getRequest,
+  createNormalizationSelector,
+  createOperationDescriptor,
+  createReaderSelector,
+  createRequestDescriptor,
+  getArgumentValues,
+  getDataIDsFromFragment,
+  getDataIDsFromObject,
+  getNode,
+  getFragment,
+  getInlineDataFragment,
+  getModuleComponentKey,
+  getModuleOperationKey,
+  getPaginationFragment,
+  getPluralSelector,
+  getRefetchableFragment,
+  getRequest,
   getRequestIdentifier: getRequestIdentifier,
-  getSelector: RelayModernSelector.getSelector,
-  getSelectorsFromObject: RelayModernSelector.getSelectorsFromObject,
-  getSingularSelector: RelayModernSelector.getSingularSelector,
-  getStorageKey: RelayStoreUtils.getStorageKey,
-  getVariablesFromFragment: RelayModernSelector.getVariablesFromFragment,
-  getVariablesFromObject: RelayModernSelector.getVariablesFromObject,
-  getVariablesFromPluralFragment:
-    RelayModernSelector.getVariablesFromPluralFragment,
-  getVariablesFromSingularFragment:
-    RelayModernSelector.getVariablesFromSingularFragment,
+  getSelector,
+  getSelectorsFromObject,
+  getSingularSelector,
+  getStorageKey,
+  getVariablesFromFragment,
+  getVariablesFromObject,
+  getVariablesFromPluralFragment,
+  getVariablesFromSingularFragment,
   handlePotentialSnapshotErrors,
-  graphql: GraphQLTag.graphql,
+  graphql,
   isErrorResult: isErrorResult,
   isValueResult: isValueResult,
-  isFragment: GraphQLTag.isFragment,
-  isInlineDataFragment: GraphQLTag.isInlineDataFragment,
+  isFragment,
+  isInlineDataFragment,
   isSuspenseSentinel,
   suspenseSentinel,
-  isRequest: GraphQLTag.isRequest,
+  isRequest,
   readInlineData,
-  readFragment: ResolverFragments.readFragment,
+  readFragment,
 
   // Declarative mutation API
-  MutationTypes: RelayDeclarativeMutationConfig.MutationTypes,
-  RangeOperations: RelayDeclarativeMutationConfig.RangeOperations,
+  MutationTypes,
+  RangeOperations,
 
   // Extensions
   DefaultHandlerProvider: RelayDefaultHandlerProvider,
   ConnectionHandler,
   MutationHandlers,
-  VIEWER_ID: ViewerPattern.VIEWER_ID,
-  VIEWER_TYPE: ViewerPattern.VIEWER_TYPE,
+  VIEWER_ID,
+  VIEWER_TYPE,
 
   // Helpers (can be implemented via the above API)
   applyOptimisticMutation,
@@ -351,15 +420,15 @@ module.exports = {
   RelayConcreteNode: RelayConcreteNode,
   RelayError: RelayError,
   RelayFeatureFlags: RelayFeatureFlags,
-  DEFAULT_HANDLE_KEY: RelayDefaultHandleKey.DEFAULT_HANDLE_KEY,
-  FRAGMENTS_KEY: RelayStoreUtils.FRAGMENTS_KEY,
-  FRAGMENT_OWNER_KEY: RelayStoreUtils.FRAGMENT_OWNER_KEY,
-  ID_KEY: RelayStoreUtils.ID_KEY,
-  REF_KEY: RelayStoreUtils.REF_KEY,
-  REFS_KEY: RelayStoreUtils.REFS_KEY,
-  ROOT_ID: RelayStoreUtils.ROOT_ID,
-  ROOT_TYPE: RelayStoreUtils.ROOT_TYPE,
-  TYPENAME_KEY: RelayStoreUtils.TYPENAME_KEY,
+  DEFAULT_HANDLE_KEY,
+  FRAGMENTS_KEY,
+  FRAGMENT_OWNER_KEY,
+  ID_KEY,
+  REF_KEY,
+  REFS_KEY,
+  ROOT_ID,
+  ROOT_TYPE,
+  TYPENAME_KEY,
 
   deepFreeze: deepFreeze,
   generateClientID: generateClientID,
@@ -377,19 +446,5 @@ module.exports = {
   getPaginationVariables: getPaginationVariables,
   getPendingOperationsForFragment: getPendingOperationsForFragment,
   getValueAtPath: getValueAtPath,
-  __internal: {
-    ResolverFragments,
-    OperationTracker: RelayOperationTracker,
-    createRelayContext: createRelayContext,
-    createRelayLoggingContext: createRelayLoggingContext,
-    getOperationVariables: RelayConcreteVariables.getOperationVariables,
-    getLocalVariables: RelayConcreteVariables.getLocalVariables,
-    fetchQuery: fetchQueryInternal.fetchQuery,
-    fetchQueryDeduped: fetchQueryInternal.fetchQueryDeduped,
-    getPromiseForActiveRequest: fetchQueryInternal.getPromiseForActiveRequest,
-    getObservableForActiveRequest:
-      fetchQueryInternal.getObservableForActiveRequest,
-    normalizeResponse: normalizeResponse,
-    withProvidedVariables: withProvidedVariables,
-  },
+  __internal,
 };


### PR DESCRIPTION
It is currently not possible to use named exports with Relay in a Node.js ESM file. For example, in a brand new project with the latest version of relay-runtime as a dependency, the following code will error:

index.mjs:
```js filename="index.mjs"
import { fetchQuery } from 'relay-runtime'
```

```
file:///index.mjs:1
import { fetchQuery } from 'relay-runtime';
         ^^^^^^^^^^
SyntaxError: Named export 'fetchQuery' not found. The requested module 'relay-runtime' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'relay-runtime';
const { fetchQuery } = pkg;

    at #asyncInstantiate (node:internal/modules/esm/module_job:302:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:405:5)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:660:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
```

When an ESM file `import`s a common js file (like relay-runtime) Node.js will use [cjs-module-lexer](https://github.com/nodejs/cjs-module-lexer/tree/2.0.0) to try to determine compatible named exports.

[From the node.js docs](https://nodejs.org/api/esm.html):
> Named exports detection covers many common export patterns, reexport patterns and build tool and transpiler outputs. See [cjs-module-lexer](https://github.com/nodejs/cjs-module-lexer/tree/2.0.0) for the exact semantics implemented.

In the entry points of react-relay and relay-runtime, the pattern of exporting a property on another object causes `cjs-module-lexer` to not detect any of named exports.

Example:

```js
// This doesn't work
module.exports = {
  fetchQuery: RelayRuntime.fetchQuery
};

// This does work
const { fetchQuery } = RelayRuntime;
module.exports = {
  fetchQuery
};
```

In this PR, I updated the entrypoints of react-relay and relay-runtime to allow Node.js's cjs named export detection to work properly.  I added a test case to the Gulp build process since to test this we need the final transpiled code, but I am open to other approaches.