### PR TITLE
Fix CI: rustfmt toolchain override and disk space for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,11 @@ jobs:
             os: windows-latest
     runs-on: ${{ matrix.target.os }}
     steps:
+      - name: Free disk space
+        if: matrix.target.os == 'ubuntu-latest'
+        run: |
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
       - uses: actions/checkout@v6
       - uses: actions-rs/toolchain@v1
         with:
@@ -143,12 +148,17 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           # Should stay in sync with tools/third-party/rustfmt/.rustfmt-version
+          # and the RUSTUP_TOOLCHAIN env var in the rustfmt step below
           toolchain: nightly-2025-08-01
           override: true
           components: rustfmt
       - name: "rustfmt"
         run: grep -r --include "*.rs" --files-without-match $'\x40generated' crates | xargs rustfmt --check --config="skip_children=true"
         working-directory: ./compiler/
+        env:
+          # Must match the toolchain installed above. This overrides
+          # compiler/rust-toolchain.toml which would otherwise take precedence.
+          RUSTUP_TOOLCHAIN: nightly-2025-08-01
 
   build-compiler:
     name: Build Rust Compiler (${{ matrix.target.os }})


### PR DESCRIPTION
## Summary
- **Rust Lint fix**: The lint job installs `nightly-2025-08-01` with rustfmt and uses `rustup override`, but `compiler/rust-toolchain.toml` (`nightly-2025-12-05`) takes higher precedence, causing rustfmt to run under a toolchain that doesn't have it installed. Fixed by setting `RUSTUP_TOOLCHAIN` env var which overrides `rust-toolchain.toml`. This has been failing since the toolchain was updated from `nightly-2025-08-01` in commit 7115055c3ff4.
- **Rust Tests (ubuntu) fix**: Debug-mode test compilation intermittently runs out of disk space on the GitHub Actions runner. Fixed by removing the Android SDK and .NET SDK (~20GB) before building, which only applies to ubuntu runners.

## Test plan
- [ ] Verify the Rust Lint job passes in CI
- [ ] Verify Rust Tests (ubuntu-latest) passes without disk space errors