### PR TITLE
Fix Cargo.lock update PRs being immediately auto-closed

### DIFF
--- a/.github/workflows/update-cargo-lock.yml
+++ b/.github/workflows/update-cargo-lock.yml
@@ -32,4 +32,5 @@ jobs:
         with:
           token: ${{ secrets.RELAY_BOT_GITHUB_PAT }}
           title: "Update Cargo.lock"
+          branch: update-cargo-lock
           delete-branch: true

--- a/.github/workflows/update-yarn-lock.yml
+++ b/.github/workflows/update-yarn-lock.yml
@@ -24,6 +24,7 @@ jobs:
         uses: peter-evans/create-pull-request@v4
         with:
           title: "Update yarn.lock"
+          branch: update-yarn-lock
           delete-branch: true
           # Use a PAT with permissions to act as relay-bot and bypass branch protection
           token: ${{ secrets.RELAY_BOT_GITHUB_PAT }}


### PR DESCRIPTION
## Summary

Both `update-cargo-lock.yml` and `update-yarn-lock.yml` workflows use `peter-evans/create-pull-request` without specifying a `branch` parameter, so both default to the branch name `create-pull-request/patch`. Both run on the same daily cron schedule (`0 0 * * *`). When the yarn.lock workflow runs a few minutes after the Cargo.lock workflow and finds no yarn.lock changes, it force-pushes the shared branch back to `main` and deletes it — which closes the Cargo.lock PR.

This gives each workflow its own unique branch name to prevent the collision.

## Evidence

Every single "Update Cargo.lock" PR has been auto-closed within ~6 minutes of creation. Example: [#5183](https://github.com/facebook/relay/pull/5183) (created `00:24:24Z`, closed `00:30:06Z`).

The timing of the two workflows lines up exactly:

| Workflow | Run started | Key event |
|----------|------------|-----------|
| Update Cargo.lock ([run 22376164131](https://github.com/facebook/relay/actions/runs/22376164131)) | `00:22:18Z` | PR #5183 created at `00:24:24Z` |
| Update yarn.lock ([run 22376351601](https://github.com/facebook/relay/actions/runs/22376351601)) | `00:29:16Z` | PR #5183 closed at `00:30:06Z` |

**From the Cargo.lock workflow logs** — the action creates the branch and PR successfully:
```
Pull request branch to create or update set to 'create-pull-request/patch'
Created branch 'create-pull-request/patch'
Created pull request #5183 (facebook:create-pull-request/patch => main)
```

**From the yarn.lock workflow logs** — the action finds the same branch, sees no yarn.lock changes, force-pushes it back to main, then deletes it:
```
Pull request branch 'create-pull-request/patch' already exists as remote branch 'origin/create-pull-request/patch'
Resetting 'create-pull-request/patch'
git push --force-with-lease origin HEAD:refs/heads/create-pull-request/patch
 + 75c742cb9...f2ecd6bee HEAD -> create-pull-request/patch (forced update)
git push --delete --force origin refs/heads/create-pull-request/patch
```

The force-push replaces the Cargo.lock commit (`75c742cb9`) with the bare `main` HEAD (`f2ecd6bee`), and then the branch is deleted, which closes the PR.

## Test plan

- [ ] Wait for the next scheduled run (midnight UTC) and verify the Cargo.lock PR stays open
- [ ] Alternatively, trigger both workflows manually via `workflow_dispatch` and verify they create separate branches (`update-cargo-lock` and `update-yarn-lock`)