### PR TITLE
fix: always normalize @defer selections from initial payload

### DIFF
--- a/packages/relay-runtime/store/RelayResponseNormalizer.js
+++ b/packages/relay-runtime/store/RelayResponseNormalizer.js
@@ -402,13 +402,15 @@ class RelayResponseNormalizer {
         isDeferred,
       );
     }
-    if (isDeferred === false) {
-      // If defer is disabled there will be no additional response chunk:
-      // normalize the data already present.
-      this._traverseSelections(defer, record, data);
-    } else {
-      // Otherwise data *for this selection* should not be present: enqueue
-      // metadata to process the subsequent response chunk.
+    // Always normalize inline data. Per the GraphQL DeferStream RFC, @defer
+    // is a hint — servers MAY choose not to defer, returning data inline in
+    // the initial payload. When the server did defer (data absent), traversal
+    // encounters undefined fields and skips them (no writes). When the real
+    // incremental chunk arrives, _processDeferResponse overwrites normally.
+    // See: https://github.com/facebook/relay/issues/3904
+    this._traverseSelections(defer, record, data);
+    if (isDeferred !== false) {
+      // Enqueue metadata to process the subsequent response chunk (if any).
       this._incrementalPlaceholders.push({
         actorIdentifier: this._actorIdentifier,
         data,


### PR DESCRIPTION
## Summary

Fixes #3904, #5188

When a GraphQL server selectively honors `@defer` — deferring some fragments but returning others inline in the initial payload — Relay's `_normalizeDefer` skips traversing the inline selections entirely, silently dropping the data. The affected component renders with `undefined` despite the data being present in the network response.

Per the [DeferStream RFC](https://github.com/graphql/graphql-wg/blob/main/rfcs/DeferStream.md), `@defer` is a hint: servers MAY choose not to defer on a per-fragment basis, and clients must handle this gracefully.

## The Problem

`_normalizeDefer` currently uses an either/or pattern:

```js
if (isDeferred === false) {
  this._traverseSelections(defer, record, data);  // normalize inline
} else {
  this._incrementalPlaceholders.push({...});       // skip normalization
}
```

When `isDeferred` is truthy, the data is **not normalized into the store**. If no incremental chunk arrives for that label (because the server included the data inline), the data is permanently lost.

## The Fix

Always traverse selections, then create the placeholder:

```js
this._traverseSelections(defer, record, data);
if (isDeferred !== false) {
  this._incrementalPlaceholders.push({...});
}
```

**Safe because:**
- **Server didn't defer (data inline):** `_traverseSelections` normalizes the data. Placeholder exists but data is already in the store.
- **Server did defer (data absent):** `_traverseSelections` encounters undefined fields and skips them (no writes). The real incremental chunk normalizes the data normally via `_processDeferResponse`.
- **No behavior change** for `@defer(if: false)` or non-streaming responses.

## Selective Defer Scenario

This is particularly important for the **selective defer** case where a server defers some `@defer` fragments but not others in the same multipart response:

1. Initial payload (`hasNext: true`): contains data for Fragment A (not deferred by server) + placeholder for Fragment B (deferred)
2. Incremental chunk: delivers Fragment B data
3. **Before fix:** Fragment A data silently lost — normalizer skipped it
4. **After fix:** Fragment A data normalized from initial payload, Fragment B arrives via incremental delivery — both work

## Verification

Verified in production at Microsoft/Viva Engage via a pnpm patch against `relay-runtime@20.1.1`. The `PersonalActivityDashboard` page uses `@defer` on two fragments where the server defers one but not the other — both now render correctly with this fix.