### PR TITLE
 Fix typo in Vite plugin link in babel-plugin docs

### DIFF
--- a/website/versioned_docs/version-v19.0.0/getting-started/babel-plugin.md
+++ b/website/versioned_docs/version-v19.0.0/getting-started/babel-plugin.md
@@ -10,7 +10,7 @@ keywords:
 
 Relay requires a [Babel plugin](https://www.npmjs.com/package/babel-plugin-relay) to convert GraphQL to compiler-generated runtime artifacts. Depending upon what framework/bundler you are using, there may be a framwork-specific plugin you can use:
 
-- Vite: [vite-pugin-relay](https://github.com/oscartbeaumont/vite-plugin-relay)
+- Vite: [vite-plugin-relay](https://github.com/oscartbeaumont/vite-plugin-relay)
 - Next.js: [Relay config opton](https://nextjs.org/docs/architecture/nextjs-compiler#relay)
 - SWC: [@swc/plugin-relay](https://www.npmjs.com/package/@swc/plugin-relay)
 

--- a/website/versioned_docs/version-v20.0.0/getting-started/babel-plugin.md
+++ b/website/versioned_docs/version-v20.0.0/getting-started/babel-plugin.md
@@ -10,7 +10,7 @@ keywords:
 
 Relay requires a [Babel plugin](https://www.npmjs.com/package/babel-plugin-relay) to convert GraphQL to compiler-generated runtime artifacts. Depending upon what framework/bundler you are using, there may be a framwork-specific plugin you can use:
 
-- Vite: [vite-pugin-relay](https://github.com/oscartbeaumont/vite-plugin-relay)
+- Vite: [vite-plugin-relay](https://github.com/oscartbeaumont/vite-plugin-relay)
 - Next.js: [Relay config opton](https://nextjs.org/docs/architecture/nextjs-compiler#relay)
 - SWC: [@swc/plugin-relay](https://www.npmjs.com/package/@swc/plugin-relay)
 


### PR DESCRIPTION
Hi @captbaritone :)
I fixed a typo in the Vite integration link within the babel-plugin documentation.