### PR TITLE
add support for .cjs .mjs and .js with package.json type="module"

### DIFF
--- a/compiler/crates/js-config-loader/src/lib.rs
+++ b/compiler/crates/js-config-loader/src/lib.rs
@@ -114,6 +114,7 @@ where
             LoaderSource::Js(format!(".{}.rc.cjs", name)),
             LoaderSource::Js(format!("{}.config.js", name)),
             LoaderSource::Js(format!("{}.config.cjs", name)),
+            LoaderSource::Js(format!("{}.config.mjs", name)),
         ],
     )
 }

--- a/compiler/crates/js-config-loader/src/loader.rs
+++ b/compiler/crates/js-config-loader/src/loader.rs
@@ -63,8 +63,9 @@ pub struct JsLoader;
 impl<T: for<'de> Deserialize<'de> + 'static> Loader<T> for JsLoader {
     fn load(&self, path: &Path) -> Result<Option<T>, ErrorCode> {
         let output = Command::new("node")
+            .arg("--input-type=module")
             .arg("-e")
-            .arg(r#"process.stdout.write(JSON.stringify(require(process.argv[1])))"#)
+            .arg(r#"process.stdout.write(JSON.stringify((await import(process.argv[1])).default))"#)
             .arg(path)
             .output()
             .expect("failed to execute process. Make sure you have Node installed.");

--- a/compiler/crates/js-config-loader/src/loader.rs
+++ b/compiler/crates/js-config-loader/src/loader.rs
@@ -62,6 +62,10 @@ impl<T: for<'de> Deserialize<'de> + 'static> Loader<T> for JsonLoader {
 pub struct JsLoader;
 impl<T: for<'de> Deserialize<'de> + 'static> Loader<T> for JsLoader {
     fn load(&self, path: &Path) -> Result<Option<T>, ErrorCode> {
+        // Windows requires absolute paths to be valid file:// URLs
+        #[cfg(target_os = "windows")]
+        let path = format!("file://{}", path.to_string_lossy());
+
         let output = Command::new("node")
             .arg("--input-type=module")
             .arg("-e")

--- a/compiler/crates/js-config-loader/src/loader.rs
+++ b/compiler/crates/js-config-loader/src/loader.rs
@@ -62,14 +62,19 @@ impl<T: for<'de> Deserialize<'de> + 'static> Loader<T> for JsonLoader {
 pub struct JsLoader;
 impl<T: for<'de> Deserialize<'de> + 'static> Loader<T> for JsLoader {
     fn load(&self, path: &Path) -> Result<Option<T>, ErrorCode> {
-        // Windows requires absolute paths to be valid file:// URLs
+        // Convert Windows paths to valid ECMAScript module specifiers
         #[cfg(target_os = "windows")]
-        let path = format!("file://{}", path.to_string_lossy());
+        let path = (if path.is_absolute() {
+            format!("file://{}", path.to_string_lossy())
+        } else {
+            path.to_string_lossy().into_owned()
+        })
+        .replace('\\', "/");
 
         let output = Command::new("node")
             .arg("--input-type=module")
             .arg("-e")
-            .arg(r#"import { sep } from "path";process.stdout.write(JSON.stringify((await import(process.argv[1].split(sep).join("/"))).default))"#)
+            .arg(r#"process.stdout.write(JSON.stringify((await import(process.argv[1])).default))"#)
             .arg(path)
             .output()
             .expect("failed to execute process. Make sure you have Node installed.");

--- a/compiler/crates/js-config-loader/src/loader.rs
+++ b/compiler/crates/js-config-loader/src/loader.rs
@@ -69,7 +69,7 @@ impl<T: for<'de> Deserialize<'de> + 'static> Loader<T> for JsLoader {
         let output = Command::new("node")
             .arg("--input-type=module")
             .arg("-e")
-            .arg(r#"process.stdout.write(JSON.stringify((await import(process.argv[1])).default))"#)
+            .arg(r#"import { sep } from "path";process.stdout.write(JSON.stringify((await import(process.argv[1].split(sep).join("/"))).default))"#)
             .arg(path)
             .output()
             .expect("failed to execute process. Make sure you have Node installed.");

--- a/compiler/crates/js-config-loader/tests/lib.rs
+++ b/compiler/crates/js-config-loader/tests/lib.rs
@@ -148,6 +148,25 @@ fn config_js() {
 }
 
 #[test]
+fn config_mjs() {
+    let dir = tempdir().unwrap();
+    let dir_d = dir.path().join("a/b/c/d");
+    let dir_f = dir.path().join("a/b/c/d/e/f");
+    create_dir_all(&dir_f).unwrap();
+
+    std::fs::write(
+        dir_d.join("foo.config.mjs"),
+        r#"
+        export default { name: "correct" };
+        "#,
+    )
+    .unwrap();
+
+    let config = search::<TestConfig>("foo", &dir_f).unwrap().unwrap();
+    assert_eq!(config.value.name, "correct");
+}
+
+#[test]
 fn config_js_invalid_js() {
     let dir = tempdir().unwrap();
     let dir_d = dir.path().join("a/b/c/d");

--- a/compiler/crates/relay-compiler/src/config.rs
+++ b/compiler/crates/relay-compiler/src/config.rs
@@ -297,14 +297,17 @@ impl Config {
     }
 
     pub fn load(config_path: PathBuf) -> Result<Self> {
-        let loader = if config_path.extension() == Some(OsStr::new("js")) {
+        let loader = if config_path.extension() == Some(OsStr::new("js"))
+            || config_path.extension() == Some(OsStr::new("cjs"))
+            || config_path.extension() == Some(OsStr::new("mjs"))
+        {
             LoaderSource::Js(config_path.display().to_string())
         } else if config_path.extension() == Some(OsStr::new("json")) {
             LoaderSource::Json(config_path.display().to_string())
         } else {
             return Err(Error::ConfigError {
                 details: format!(
-                    "Invalid file extension. Expected `.js` or `.json`. Provided file \"{}\".",
+                    "Invalid file extension. Expected `.js`, `.cjs`, `.mjs` or `.json`. Provided file \"{}\".",
                     config_path.display()
                 ),
             });

--- a/packages/babel-plugin-relay/README.md
+++ b/packages/babel-plugin-relay/README.md
@@ -24,6 +24,9 @@ const fragment = require('__generated__/User_fragment.graphql');
   project (i.e. in the same folder as the `package.json` file).
 - The `package.json` file contains a `"relay"` key.
 
+> [!IMPORTANT]
+> This Babel plugin does not support `relay.config.mjs` or `package.json` with `"type": "module"`.
+
 ### Supported configuration options for `babel-plugin-relay`
 
 - `artifactDirectory` A specific directory to output all artifacts to. When


### PR DESCRIPTION
When using Node.js projects with `"type": "module"` in package.json, the relay compiler currently fails to load configuration files due to incompatibilities between ESM and CommonJS

See https://github.com/facebook/relay/issues/4060#issuecomment-1828062646

This pr handle all three module format scenarios:

- Native ES modules (.mjs)
- CommonJS modules (.cjs)
- Regular .js files that respect the package.json "type" field 

It works by switching from Node `require()` to dynamic `import()` and using the `--input-type=module` flag

I also added a new test and verified that this approach works for Node 18.0.0

follow for #4873 (now with windows fix)
fixes #4060