### PR TITLE
Fix incorrect note block in client-schema-extensions.mdx

### DIFF
--- a/website/docs/guides/client-schema-extensions.mdx
+++ b/website/docs/guides/client-schema-extensions.mdx
@@ -14,7 +14,7 @@ import DocsRating from '@site/src/core/DocsRating';
 
 :::note
 See also [the local data updates](../../guided-tour/updating-data/local-data-updates/) and [client-only data](../../guided-tour/updating-data/client-only-data/) sections of the guided tour.
-:::note
+:::
 
 Relay can be used to read and write local data, and act as a single source of truth for _all_ data in your client application.
 


### PR DESCRIPTION
[afaict](https://docusaurus.io/docs/markdown-features/admonitions) note blocks need to end with `:::` not `:::note`