### PR TITLE
Regenerate test-project artifacts after emit_nogrep_annotation flag

### DIFF
--- a/compiler/test-project/src/__generated__/AppQuery.graphql.js
+++ b/compiler/test-project/src/__generated__/AppQuery.graphql.js
@@ -4,9 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f1414a68f46c710d150c72ac5f9b46ac>>
+ * @generated SignedSource<<5213156639f5e33acfdd79872ea56f77>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* eslint-disable */

--- a/compiler/test-project/src/__generated__/Component_node.graphql.js
+++ b/compiler/test-project/src/__generated__/Component_node.graphql.js
@@ -4,9 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<fb386627518893887661f121bf909b09>>
+ * @generated SignedSource<<a250ee76bcf62cff1216b54dc6596ba3>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* eslint-disable */


### PR DESCRIPTION
it looks like commit 4e2fa215c by @captbaritone added the emit_nogrep_annotation feature flag which defaults to disabled, meaning @nogrep is no longer emitted in generated files

now the main branch pipeline fails on macOS as the relay compiler is generating files without @nogrep annotations, but the checked-in files have them