### PR TITLE
Document fetchPolicy option for fetchQuery

### DIFF
--- a/website/docs/api-reference/relay-runtime/fetch-query.mdx
+++ b/website/docs/api-reference/relay-runtime/fetch-query.mdx
@@ -48,6 +48,11 @@ fetchQuery(
 * `options`: *_[Optional]_* options object
     * `networkCacheConfig`: *_[Optional]_ *Object containing cache config options
         * `force`: Boolean value. If true, will bypass the network response cache. Defaults to true.
+    * `fetchPolicy`: *_[Optional]_* Determines whether `fetchQuery` should reuse data that is already available in the local Relay store. Must be one of the following values:
+        * `"network-only"`: *(default)* Always issue a network request, regardless of what is in the store.
+        * `"store-or-network"`: Reuse data from the store if the full query is available locally; otherwise, issue a network request.
+
+        The `"store-and-network"` and `"store-only"` fetch policies are **not supported** by `fetchQuery`, because it is designed around issuing a single network request and returning the response. If you need those policies, use [`useLazyLoadQuery`](../use-lazy-load-query/) instead.
 
 ### Flow Type Parameters
 


### PR DESCRIPTION
Follow-up to #4880.

The `fetchPolicy` option isn't mentioned in the fetchQuery docs, which is what caused the confusion in that issue. This adds it to the Arguments section with the two supported values (`network-only`, `store-or-network`) and an explicit note that `store-and-network` and `store-only` aren't supported, pointing people at `useLazyLoadQuery` instead.

The TypeScript types on DefinitelyTyped already match the Flow type (`FetchQueryFetchPolicy = "store-or-network" | "network-only"`), so nothing was needed on that side.