### PR TITLE
Fix CI: Remove @nogrep from test-project generated files

### DIFF
--- a/compiler/test-project/src/__generated__/AppQuery.graphql.js
+++ b/compiler/test-project/src/__generated__/AppQuery.graphql.js
@@ -4,9 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<f1414a68f46c710d150c72ac5f9b46ac>>
+ * @generated SignedSource<<5213156639f5e33acfdd79872ea56f77>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* eslint-disable */

--- a/compiler/test-project/src/__generated__/Component_node.graphql.js
+++ b/compiler/test-project/src/__generated__/Component_node.graphql.js
@@ -4,9 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<fb386627518893887661f121bf909b09>>
+ * @generated SignedSource<<a250ee76bcf62cff1216b54dc6596ba3>>
  * @lightSyntaxTransform
- * @nogrep
  */
 
 /* eslint-disable */


### PR DESCRIPTION
## Summary
- The `emit_nogrep_annotation` feature flag (added in 4e2fa215cbce) defaults to disabled, so the compiler no longer emits `@nogrep` in generated artifacts
- The test-project generated files still had `@nogrep`, causing the "Compiler output check" CI job to fail since `check-git-status.sh` detects the mismatch
- Regenerated test-project files to match the compiler's current output

## Test plan
- CI should pass — the "Compiler output check" job will no longer detect changes after running the compiler on the test-project