### PR TITLE
fix typescript type assertions with `use_import_type_syntax=true`

### DIFF
--- a/compiler/crates/relay-typegen/src/flow.rs
+++ b/compiler/crates/relay-typegen/src/flow.rs
@@ -106,6 +106,7 @@ impl Writer for FlowPrinter {
         name: &str,
         import_as: Option<&str>,
         from: &str,
+        _ignore_use_import_type_syntax: bool,
     ) -> FmtResult {
         let local_name = if let Some(import_as) = import_as {
             format!("{{{name} as {import_as}}}")
@@ -115,7 +116,12 @@ impl Writer for FlowPrinter {
         self.write_import_module_default(&local_name, from)
     }
 
-    fn write_import_type(&mut self, types: &[&str], from: &str) -> FmtResult {
+    fn write_import_type(
+        &mut self,
+        types: &[&str],
+        from: &str,
+        _ignore_use_import_type_syntax: bool,
+    ) -> FmtResult {
         writeln!(
             &mut self.result,
             "import type {{ {} }} from \"{}\";",
@@ -125,7 +131,7 @@ impl Writer for FlowPrinter {
     }
 
     fn write_import_fragment_type(&mut self, types: &[&str], from: &str) -> FmtResult {
-        self.write_import_type(types, from)
+        self.write_import_type(types, from, false)
     }
 
     fn write_export_fragment_type(&mut self, name: &str) -> FmtResult {

--- a/compiler/crates/relay-typegen/src/javascript.rs
+++ b/compiler/crates/relay-typegen/src/javascript.rs
@@ -52,11 +52,17 @@ impl Writer for JavaScriptPrinter {
         _name: &str,
         _alias: Option<&str>,
         _from: &str,
+        _ignore_use_import_type_syntax: bool,
     ) -> FmtResult {
         Ok(())
     }
 
-    fn write_import_type(&mut self, _types: &[&str], _from: &str) -> FmtResult {
+    fn write_import_type(
+        &mut self,
+        _types: &[&str],
+        _from: &str,
+        _ignore_use_import_type_syntax: bool,
+    ) -> FmtResult {
         Ok(())
     }
 

--- a/compiler/crates/relay-typegen/src/typegen_state.rs
+++ b/compiler/crates/relay-typegen/src/typegen_state.rs
@@ -59,7 +59,7 @@ impl RuntimeImports {
             runtime_import_types.push(RESULT_TYPE_NAME.lookup());
         }
         if !runtime_import_types.is_empty() {
-            writer.write_import_type(&runtime_import_types, RELAY_RUNTIME)
+            writer.write_import_type(&runtime_import_types, RELAY_RUNTIME, false)
         } else {
             Ok(())
         }

--- a/compiler/crates/relay-typegen/src/typescript.rs
+++ b/compiler/crates/relay-typegen/src/typescript.rs
@@ -118,21 +118,27 @@ impl Writer for TypeScriptPrinter {
         name: &str,
         import_as: Option<&str>,
         from: &str,
+        ignore_use_import_type_syntax: bool,
     ) -> FmtResult {
         let import_type = if let Some(import_as) = import_as {
             format!("{name} as {import_as}")
         } else {
             name.to_string()
         };
-        self.write_import_type(&[&import_type], from)
+        self.write_import_type(&[&import_type], from, ignore_use_import_type_syntax)
     }
 
-    fn write_import_type(&mut self, types: &[&str], from: &str) -> FmtResult {
+    fn write_import_type(
+        &mut self,
+        types: &[&str],
+        from: &str,
+        ignore_use_import_type_syntax: bool,
+    ) -> FmtResult {
         let from_without_extension = from.strip_suffix(".ts").unwrap_or(from);
         writeln!(
             &mut self.result,
             "import {}{{ {} }} from \"{}\";",
-            if self.use_import_type_syntax {
+            if !ignore_use_import_type_syntax && self.use_import_type_syntax {
                 "type "
             } else {
                 ""

--- a/compiler/crates/relay-typegen/src/write.rs
+++ b/compiler/crates/relay-typegen/src/write.rs
@@ -574,7 +574,7 @@ fn write_import_custom_type(
             let names = &[custom_type_import.name.lookup()];
             let path = &custom_type_import.path.to_str();
             match path {
-                Some(path) => writer.write_import_type(names, path),
+                Some(path) => writer.write_import_type(names, path, false),
                 _ => Ok(()),
             }
         }
@@ -672,6 +672,7 @@ fn write_relay_resolver_imports(
                     name.lookup(),
                     Some(import_as.lookup()),
                     resolver.import_path.lookup(),
+                    true,
                 )?;
             }
         }
@@ -682,6 +683,7 @@ fn write_relay_resolver_imports(
             writer.write_import_type(
                 &[live_resolver_context_import.name.lookup()],
                 live_resolver_context_import.import_path.lookup(),
+                true,
             )?;
             live_resolver_context_import_written = true;
         }
@@ -767,6 +769,7 @@ fn write_enum_definitions(
             writer.write_import_type(
                 &[enum_type.name.item.lookup()],
                 &format!("{}{}", enum_type.name.item, suffix),
+                false,
             )?;
         } else {
             let mut members: Vec<AST> = enum_type
@@ -1118,7 +1121,7 @@ fn write_custom_scalar_imports(
     writer: &mut Box<dyn Writer>,
 ) -> FmtResult {
     for (name, path) in custom_scalars.iter().sorted_by_key(|(key, _)| *key) {
-        writer.write_import_type(&[name.lookup()], path.to_str().unwrap())?
+        writer.write_import_type(&[name.lookup()], path.to_str().unwrap(), false)?
     }
 
     Ok(())

--- a/compiler/crates/relay-typegen/src/writer.rs
+++ b/compiler/crates/relay-typegen/src/writer.rs
@@ -370,9 +370,15 @@ pub trait Writer: Write {
         name: &str,
         import_as: Option<&str>,
         from: &str,
+        ignore_use_import_type_syntax: bool,
     ) -> FmtResult;
 
-    fn write_import_type(&mut self, types: &[&str], from: &str) -> FmtResult;
+    fn write_import_type(
+        &mut self,
+        types: &[&str],
+        from: &str,
+        ignore_use_import_type_syntax: bool,
+    ) -> FmtResult;
 
     fn write_import_fragment_type(&mut self, types: &[&str], from: &str) -> FmtResult;
 


### PR DESCRIPTION
# Overview
Fix for an issue where `useImportTypeSyntax: true` generates runtime errors in typescript when relay resolvers are used.

The changes are a bit ugly but as per [comment](https://github.com/facebook/relay/issues/4772#issuecomment-2289496903) the assertions are a short term solution



## Tests
I'm guessing it's not possible to toggle feature flags per fixture. I've manually tested this against my project:
- works for live resolvers
- works for normal resolvers

Closes #4818