### PR TITLE
Fix CI: add graphql definitions for useFragment defer+live update test

### DIFF
--- a/.claude/commands/fix-ci.md
+++ b/.claude/commands/fix-ci.md
@@ -40,7 +40,7 @@ You are a specialized skill for checking GitHub CI status and fixing failing tes
    - Commit with descriptive message about what was fixed
    - Push the branch: `git push -u origin HEAD`
    - Create PR using `gh pr create` with:
-     - Label: "Fix CI Skill"
+     - **IMPORTANT: Always include `--label "Fix CI Skill"` in the `gh pr create` command**
      - Title: "Fix CI failures - [Brief description]"
      - Body: Detailed explanation of:
        - Which jobs were failing

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentWithDeferAndLiveUpdateTestFragment.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentWithDeferAndLiveUpdateTestFragment.graphql.js
@@ -6,7 +6,7 @@
  *
  * @oncall relay
  *
- * @generated
+ * @generated SignedSource<<4d09a55d9f42c9701c511b6d36b4a26f>>
  * @flow
  * @lightSyntaxTransform
  */
@@ -51,7 +51,7 @@ var node/*: ReaderFragment*/ = {
 };
 
 if (__DEV__) {
-  (node/*:: as any*/).hash = "use_fragment_defer_live_update_fragment_hash";
+  (node/*:: as any*/).hash = "e94b5cf91e27dc387e221c16d5081f9a";
 }
 
 module.exports = ((node/*:: as any*/)/*:: as Fragment<

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentWithDeferAndLiveUpdateTestQuery.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentWithDeferAndLiveUpdateTestQuery.graphql.js
@@ -6,7 +6,7 @@
  *
  * @oncall relay
  *
- * @generated
+ * @generated SignedSource<<bbbe662437b6742d4525f7b2b40f4c0b>>
  * @flow
  * @lightSyntaxTransform
  */
@@ -140,7 +140,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "use_fragment_defer_live_update_query",
+    "cacheID": "b4906d55de1832197f29cd7c87ca9788",
     "id": null,
     "metadata": {},
     "name": "useFragmentWithDeferAndLiveUpdateTestQuery",
@@ -151,7 +151,7 @@ return {
 })();
 
 if (__DEV__) {
-  (node/*:: as any*/).hash = "use_fragment_defer_live_update_query_hash";
+  (node/*:: as any*/).hash = "2f1e35e18dce79d4884d6fe2b9bbe340";
 }
 
 module.exports = ((node/*:: as any*/)/*:: as Query<

--- a/packages/react-relay/relay-hooks/__tests__/useFragment-WithDeferAndLiveUpdate-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useFragment-WithDeferAndLiveUpdate-test.js
@@ -22,18 +22,41 @@ import type {
 
 const useFragment = require('../useFragment');
 const useLazyLoadQuery = require('../useLazyLoadQuery');
-const FragmentArtifact = require('./__generated__/useFragmentWithDeferAndLiveUpdateTestFragment.graphql');
-const QueryArtifact = require('./__generated__/useFragmentWithDeferAndLiveUpdateTestQuery.graphql');
 const ReactTestingLibrary = require('@testing-library/react');
 const React = require('react');
 const {act} = require('react');
 const ReactRelayContext = require('react-relay/ReactRelayContext');
-const {Environment, Network, RecordSource, Store} = require('relay-runtime');
+const {
+  Environment,
+  Network,
+  RecordSource,
+  Store,
+  graphql,
+} = require('relay-runtime');
 const RelayObservable = require('relay-runtime/network/RelayObservable');
 const RelayFeatureFlags = require('relay-runtime/util/RelayFeatureFlags');
 const {disallowWarnings} = require('relay-test-utils-internal');
 
 disallowWarnings();
+
+const FragmentArtifact = graphql`
+  fragment useFragmentWithDeferAndLiveUpdateTestFragment on User
+  @throwOnFieldError {
+    name
+  }
+`;
+
+const QueryArtifact = graphql`
+  query useFragmentWithDeferAndLiveUpdateTestQuery($id: ID!) {
+    node(id: $id) {
+      __typename
+      id
+      ...useFragmentWithDeferAndLiveUpdateTestFragment
+        @defer
+        @dangerously_unaliased_fixme
+    }
+  }
+`;
 
 const DEFER_LABEL =
   'useFragmentWithDeferAndLiveUpdateTestQuery$defer$useFragmentWithDeferAndLiveUpdateTestFragment';


### PR DESCRIPTION
## Summary
- The test file added in 219b5d8eef70 included hand-crafted generated artifacts instead of graphql template literals
- The Relay compiler deletes these as orphaned during CI, failing the Compiler output check
- Added proper graphql definitions and regenerated artifacts with the compiler

## Test plan
- [x] Ran Relay compiler locally - compilation succeeds
- [x] Only diff in generated files is placeholder hashes replaced with real computed values
- [ ] CI should pass on this PR