### PR TITLE
Add regression test for RelayResponseNormalizer @skip + multi-fragment warning (#5119)

### DIFF
--- a/packages/relay-runtime/store/__tests__/RelayResponseNormalizer-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayResponseNormalizer-test.js
@@ -2681,6 +2681,74 @@ describe('RelayResponseNormalizer', () => {
     );
   });
 
+  it('warns without identifying source query when @skip omits a field selected by a sibling fragment (#5119)', () => {
+    // Regression test for facebook/relay#5119 — currently demonstrates
+    // buggy behavior; flip assertion when the underlying bug is fixed.
+    //
+    // Scenario from the issue: when two fragments in the same query
+    // select the same field but only one of them gates the selection
+    // with @skip(if: $skip), and the response payload omits that field
+    // (because it was generated against the @skip path), the normalizer
+    // emits a Warning that does not identify the originating query.
+    //
+    // The reporter notes this is "especially difficult to debug" when
+    // the skipped field is __typename. This test uses `firstName` instead
+    // because both fields traverse the same scalar-field warning path in
+    // _normalizeField (no abstract-type discrimination is involved when
+    // the parent is a concrete User), so the bug surface is identical.
+    const SkipFragment = graphql`
+      fragment RelayResponseNormalizerTest5119SkipFragment on User
+      @argumentDefinitions(skip: {type: "Boolean!"}) {
+        firstName @skip(if: $skip)
+      }
+    `;
+    const NoSkipFragment = graphql`
+      fragment RelayResponseNormalizerTest5119NoSkipFragment on User {
+        firstName
+      }
+    `;
+    const Query = graphql`
+      query RelayResponseNormalizerTest5119Query($id: ID, $skip: Boolean!) {
+        node(id: $id) {
+          id
+          __typename
+          ... on User {
+            ...RelayResponseNormalizerTest5119SkipFragment
+              @arguments(skip: $skip)
+              @dangerously_unaliased_fixme
+            ...RelayResponseNormalizerTest5119NoSkipFragment
+              @dangerously_unaliased_fixme
+          }
+        }
+      }
+    `;
+    const payload = {
+      node: {
+        id: '1',
+        __typename: 'User',
+        // firstName intentionally omitted to simulate the @skip-path response
+      },
+    };
+    const recordSource = new RelayRecordSource();
+    recordSource.set(ROOT_ID, RelayModernRecord.create(ROOT_ID, ROOT_TYPE));
+    expectToWarn(
+      'RelayResponseNormalizer: Payload did not contain a value for ' +
+        'field `firstName: firstName`. Check that you are parsing with the same query that ' +
+        'was used to fetch the payload.',
+      () => {
+        normalize(
+          recordSource,
+          createNormalizationSelector(Query.operation, ROOT_ID, {
+            id: '1',
+            skip: true,
+          }),
+          payload,
+          defaultOptions,
+        );
+      },
+    );
+  });
+
   it('does not warn in __DEV__ if payload data is missing for an abstract field', () => {
     const BarQuery = graphql`
       query RelayResponseNormalizerTest21Query {

--- a/packages/relay-runtime/store/__tests__/RelayResponseNormalizer-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayResponseNormalizer-test.js
@@ -2696,13 +2696,13 @@ describe('RelayResponseNormalizer', () => {
     // because both fields traverse the same scalar-field warning path in
     // _normalizeField (no abstract-type discrimination is involved when
     // the parent is a concrete User), so the bug surface is identical.
-    const SkipFragment = graphql`
+    graphql`
       fragment RelayResponseNormalizerTest5119SkipFragment on User
       @argumentDefinitions(skip: {type: "Boolean!"}) {
         firstName @skip(if: $skip)
       }
     `;
-    const NoSkipFragment = graphql`
+    graphql`
       fragment RelayResponseNormalizerTest5119NoSkipFragment on User {
         firstName
       }

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTest5119NoSkipFragment.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTest5119NoSkipFragment.graphql.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<7d226ab4066fd4707d5cc2861b68afec>>
+ * @flow
+ * @lightSyntaxTransform
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type RelayResponseNormalizerTest5119NoSkipFragment$fragmentType: FragmentType;
+export type RelayResponseNormalizerTest5119NoSkipFragment$data = {|
+  +firstName: ?string,
+  +$fragmentType: RelayResponseNormalizerTest5119NoSkipFragment$fragmentType,
+|};
+export type RelayResponseNormalizerTest5119NoSkipFragment$key = {
+  +$data?: RelayResponseNormalizerTest5119NoSkipFragment$data,
+  +$fragmentSpreads: RelayResponseNormalizerTest5119NoSkipFragment$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "RelayResponseNormalizerTest5119NoSkipFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "firstName",
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*:: as any*/).hash = "f0666b78b52cbf6d9c149dc4a9d22b53";
+}
+
+module.exports = ((node/*:: as any*/)/*:: as Fragment<
+  RelayResponseNormalizerTest5119NoSkipFragment$fragmentType,
+  RelayResponseNormalizerTest5119NoSkipFragment$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTest5119Query.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTest5119Query.graphql.js
@@ -1,0 +1,173 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<d6fd649e757863f10143a50deeb232a7>>
+ * @flow
+ * @lightSyntaxTransform
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { RelayResponseNormalizerTest5119NoSkipFragment$fragmentType } from "./RelayResponseNormalizerTest5119NoSkipFragment.graphql";
+import type { RelayResponseNormalizerTest5119SkipFragment$fragmentType } from "./RelayResponseNormalizerTest5119SkipFragment.graphql";
+export type RelayResponseNormalizerTest5119Query$variables = {|
+  id?: ?string,
+  skip: boolean,
+|};
+export type RelayResponseNormalizerTest5119Query$data = {|
+  +node: ?{|
+    +__typename: string,
+    +id: string,
+    +$fragmentSpreads: RelayResponseNormalizerTest5119NoSkipFragment$fragmentType & RelayResponseNormalizerTest5119SkipFragment$fragmentType,
+  |},
+|};
+export type RelayResponseNormalizerTest5119Query = {|
+  response: RelayResponseNormalizerTest5119Query$data,
+  variables: RelayResponseNormalizerTest5119Query$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "skip"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RelayResponseNormalizerTest5119Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*:: as any*/),
+          (v3/*:: as any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "args": [
+                  {
+                    "kind": "Variable",
+                    "name": "skip",
+                    "variableName": "skip"
+                  }
+                ],
+                "kind": "FragmentSpread",
+                "name": "RelayResponseNormalizerTest5119SkipFragment"
+              },
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "RelayResponseNormalizerTest5119NoSkipFragment"
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Operation",
+    "name": "RelayResponseNormalizerTest5119Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*:: as any*/),
+          (v3/*:: as any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "firstName",
+                "storageKey": null
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "5d9dfab578b1dcd5c40e83d84cd821ae",
+    "id": null,
+    "metadata": {},
+    "name": "RelayResponseNormalizerTest5119Query",
+    "operationKind": "query",
+    "text": "query RelayResponseNormalizerTest5119Query(\n  $id: ID\n  $skip: Boolean!\n) {\n  node(id: $id) {\n    id\n    __typename\n    ... on User {\n      ...RelayResponseNormalizerTest5119SkipFragment_qfE4l\n      ...RelayResponseNormalizerTest5119NoSkipFragment\n    }\n  }\n}\n\nfragment RelayResponseNormalizerTest5119NoSkipFragment on User {\n  firstName\n}\n\nfragment RelayResponseNormalizerTest5119SkipFragment_qfE4l on User {\n  firstName @skip(if: $skip)\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*:: as any*/).hash = "b5111ffaf61794ddb2b0e0e425f931da";
+}
+
+module.exports = ((node/*:: as any*/)/*:: as Query<
+  RelayResponseNormalizerTest5119Query$variables,
+  RelayResponseNormalizerTest5119Query$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTest5119SkipFragment.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayResponseNormalizerTest5119SkipFragment.graphql.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<d0519239d45eabf6dff5fa5d20e71d76>>
+ * @flow
+ * @lightSyntaxTransform
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type RelayResponseNormalizerTest5119SkipFragment$fragmentType: FragmentType;
+export type RelayResponseNormalizerTest5119SkipFragment$data = {|
+  +firstName?: ?string,
+  +$fragmentType: RelayResponseNormalizerTest5119SkipFragment$fragmentType,
+|};
+export type RelayResponseNormalizerTest5119SkipFragment$key = {
+  +$data?: RelayResponseNormalizerTest5119SkipFragment$data,
+  +$fragmentSpreads: RelayResponseNormalizerTest5119SkipFragment$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "skip"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "RelayResponseNormalizerTest5119SkipFragment",
+  "selections": [
+    {
+      "condition": "skip",
+      "kind": "Condition",
+      "passingValue": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "firstName",
+          "storageKey": null
+        }
+      ]
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*:: as any*/).hash = "88cf40a594035eba772bb2d820815fdb";
+}
+
+module.exports = ((node/*:: as any*/)/*:: as Fragment<
+  RelayResponseNormalizerTest5119SkipFragment$fragmentType,
+  RelayResponseNormalizerTest5119SkipFragment$data,
+>*/);


### PR DESCRIPTION
## Summary

Adds a regression test in `RelayResponseNormalizer-test.js` for the bug reported in #5119: when two fragments in the same query select the same field but only one of them gates the selection with `@skip(if: $skip)`, the normalizer emits the warning `Payload did not contain a value for field ...` without identifying the originating query.

This is **test-only** — no production code changes, no improvement to the warning message format. The test asserts current (buggy) behavior; whoever fixes the underlying bug or improves the warning to include source-query attribution should flip the assertion.

The reporter called out `__typename` as the painful case ("especially difficult to debug"). The test uses `firstName` instead — a `__typename` variant doesn't trigger the warning here because the parent selector `... on User` requires `node.__typename` to be present in the payload, which short-circuits the warning path before it reaches the User fragments. The in-test comment explains why `firstName` is path-equivalent: both traverse `_normalizeField`'s scalar warning path with no abstract-type discrimination involved when the parent (`User`) is a concrete type.

The test reuses the existing convention from the file (`expectToWarn`, `RelayRecordSource`, `createNormalizationSelector`, `disallowWarnings()` in scope at the top). Both fragment spreads carry `@dangerously_unaliased_fixme` because the compiler now requires aliases on duplicate selections; this matches the convention used elsewhere in the same file (e.g. the `_pvFragment` test).

Refs #5119.

## Notes for reviewer

- **Generated artifacts:** the test introduces a new query and two new fragments, requiring 3 new `__generated__/*.graphql.js` files. They were produced with `relay-compiler@0.0.0-main-38ad9e13` (the published `@20.1.1` rejects fields the current OSS test config uses). The structure follows the standard codegen format; if the maintainer's internal compiler regenerates with trivial differences (`SignedSource` hash, formatting), please regenerate as part of the import — happy to follow up if it causes any review friction.
- **Test name** is intentionally bug-leading ("warns without identifying source query…") rather than trigger-leading, so the regression intent is clear at a glance.
- **Assertion text is generic.** The `expectToWarn(...)` matcher is the same generic missing-field warning the existing L2640 test exercises with a trivial single-fragment query. The regression value of this test is in the **query/fragment shape** (sibling fragments, one `@skip`-gated), not in the assertion text. When the underlying bug is fixed (either better source attribution OR no-warn-on-this-pattern), the assertion needs to be updated — please cross-reference this comment if doing so.
- **Scope discipline:** single new `it()` in the existing `describe('RelayResponseNormalizer', ...)` block, immediately after the existing `'warns in __DEV__ if payload data is missing an expected field'` test (sibling concept).

## Commits

- **Commit 1**: regression test + 3 generated artifacts
- **Commit 2**: dropped unused `const SkipFragment`/`const NoSkipFragment` assignments to satisfy `eslint --max-warnings 0` (the fragments are picked up by the compiler from the tagged template literal regardless of whether the value is assigned)

## Test plan

- [x] `yarn jest packages/relay-runtime/store/__tests__/RelayResponseNormalizer-test.js -t '5119'` — 1 passed
- [x] full `RelayResponseNormalizer-test.js` suite still passes (61 total, was 60)
- [x] `yarn run lint packages/relay-runtime/store/__tests__/RelayResponseNormalizer-test.js` — clean (0 warnings)