### PR TITLE
Fix CI: replace internal registry URLs in yarn.lock

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1871,7 +1871,7 @@ babel-plugin-polyfill-regenerator@^0.6.1:
 
 babel-plugin-syntax-hermes-parser@0.36.0:
   version "0.36.0"
-  resolved "https://registry.facebook.net/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.36.0.tgz#51e429f32f23b197c477a20525798a7a97709c80"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.36.0.tgz#51e429f32f23b197c477a20525798a7a97709c80"
   integrity sha512-LhD0xdoedDw7ansQgXbB2DADLZIK/LRXuWNBPuVzMc5S2WK5GyT89tCM+cQzxFGO0mGyLK6D5TrVOJJzAoDy8Q==
   dependencies:
     hermes-parser "0.36.0"
@@ -3576,7 +3576,7 @@ flatted@^3.1.0:
 
 flow-bin@^0.312.1:
   version "0.312.1"
-  resolved "https://registry.facebook.net/flow-bin/-/flow-bin-0.312.1.tgz#727f40d94b319ad418e97e45a729860b641cee79"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.312.1.tgz#727f40d94b319ad418e97e45a729860b641cee79"
   integrity sha512-jIo4SzaqMpnj1SjTPg8+QHPFOs6RY98mbzGw7uRJn6fHfaqly9hM30n5PwAhRPk8F5LFawNteeW3IOtr/7UJ3A==
 
 flush-write-stream@^1.0.2:
@@ -4076,7 +4076,7 @@ hasown@^2.0.2:
 
 hermes-eslint@0.36.0:
   version "0.36.0"
-  resolved "https://registry.facebook.net/hermes-eslint/-/hermes-eslint-0.36.0.tgz#d8148b7425e7c5ce02e6aa4e092fc1edb0419fa7"
+  resolved "https://registry.yarnpkg.com/hermes-eslint/-/hermes-eslint-0.36.0.tgz#d8148b7425e7c5ce02e6aa4e092fc1edb0419fa7"
   integrity sha512-oEmTrP/Onp8kA5N23/yF4kGgSKB+9KH0CsrY+zGsgq6nK4CqY0y7Atv51X+F4deBHxWngLOvYBLt32HtOps78Q==
   dependencies:
     esrecurse "^4.3.0"
@@ -4085,12 +4085,12 @@ hermes-eslint@0.36.0:
 
 hermes-estree@0.36.0:
   version "0.36.0"
-  resolved "https://registry.facebook.net/hermes-estree/-/hermes-estree-0.36.0.tgz#5b8c162e986159baf86bc4d01612cff9845ab0f7"
+  resolved "https://registry.yarnpkg.com/hermes-estree/-/hermes-estree-0.36.0.tgz#5b8c162e986159baf86bc4d01612cff9845ab0f7"
   integrity sha512-A1+8zn5oss2CFP7pKsOaxorQG6FNIz1WU1VDqruLPPZl3LVgeE2C5xfFg8Ow6/Ow4mSslLLtYP1J3n38eKyW9w==
 
 hermes-parser@0.36.0:
   version "0.36.0"
-  resolved "https://registry.facebook.net/hermes-parser/-/hermes-parser-0.36.0.tgz#756d6b07301789c5ff0ac3ac7ff6bffa8be7098c"
+  resolved "https://registry.yarnpkg.com/hermes-parser/-/hermes-parser-0.36.0.tgz#756d6b07301789c5ff0ac3ac7ff6bffa8be7098c"
   integrity sha512-GdpwMmH5x6IpC1cijvcvYnlPB60Mh6kTSF/NFdYV/j56gYdi+0RIakYs+eqOV+bbO0SW7mgVVGSsTJxyPQfo3w==
   dependencies:
     hermes-estree "0.36.0"
@@ -6134,7 +6134,7 @@ prelude-ls@^1.2.1:
 
 prettier-plugin-hermes-parser@0.36.0:
   version "0.36.0"
-  resolved "https://registry.facebook.net/prettier-plugin-hermes-parser/-/prettier-plugin-hermes-parser-0.36.0.tgz#8839207d3a4290b7afe1bd54fbc5154f963b8cf2"
+  resolved "https://registry.yarnpkg.com/prettier-plugin-hermes-parser/-/prettier-plugin-hermes-parser-0.36.0.tgz#8839207d3a4290b7afe1bd54fbc5154f963b8cf2"
   integrity sha512-CtlJ5l0DC48SN3OWSht5jAEIFU92xwHSe87/Bl005/9TlHyN2aAmPa6T/A2JLiIgRT/lGsCtc6srwEMM3/5k4w==
 
 prettier@3.6.2:


### PR DESCRIPTION
## Summary
- The ShipIt sync from fbsource (D103172778, commit 3dd4655ef2c8) updated hermes-parser and related packages to 0.36.0, but the yarn.lock was generated internally against `registry.facebook.net`
- GitHub Actions runners can't authenticate to `registry.facebook.net`, causing all JS CI jobs (lint, tests, flow typecheck, build) to fail with 401 Unauthorized
- This replaces 6 `registry.facebook.net` URLs with `registry.yarnpkg.com` in yarn.lock

## Affected packages
- `babel-plugin-syntax-hermes-parser@0.36.0`
- `flow-bin@0.312.1`
- `hermes-eslint@0.36.0`
- `hermes-estree@0.36.0`
- `hermes-parser@0.36.0`
- `prettier-plugin-hermes-parser@0.36.0`

## Test plan
- [ ] CI JS Lint passes
- [ ] CI JS Tests (Node 18.x, 20.x) pass
- [ ] CI Flow Typecheck passes
- [ ] CI Build Rust Compiler passes (uses `yarn install` on push to main)