### PR TITLE
Fix: `@catch` on fragment root breaks `usePaginationFragment` and `usePrefetchableForwardPaginationFragment`

### DIFF
--- a/packages/react-relay/relay-hooks/__tests__/__generated__/usePaginationFragmentCatchTestRootCatchFragment.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/usePaginationFragmentCatchTestRootCatchFragment.graphql.js
@@ -1,0 +1,181 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<32f1e5483f7f2865ffecba7b9b260c7f>>
+ * @flow
+ * @lightSyntaxTransform
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ReaderFragment, RefetchableFragment } from 'relay-runtime';
+import type { FragmentType, Result } from "relay-runtime";
+declare export opaque type usePaginationFragmentCatchTestRootCatchFragment$fragmentType: FragmentType;
+type usePaginationFragmentCatchTestRootCatchRefetchableFragmentQuery$variables = any;
+export type usePaginationFragmentCatchTestRootCatchFragment$data = Result<{|
+  +friends: ?{|
+    +edges: ?ReadonlyArray<?{|
+      +node: ?{|
+        +__typename: "User",
+      |},
+    |}>,
+  |},
+  +id: string,
+  +$fragmentType: usePaginationFragmentCatchTestRootCatchFragment$fragmentType,
+|}, unknown>;
+export type usePaginationFragmentCatchTestRootCatchFragment$key = {
+  +$data?: usePaginationFragmentCatchTestRootCatchFragment$data,
+  +$fragmentSpreads: usePaginationFragmentCatchTestRootCatchFragment$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = (function(){
+var v0 = [
+  "friends"
+];
+return {
+  "argumentDefinitions": [
+    {
+      "kind": "RootArgument",
+      "name": "after"
+    },
+    {
+      "kind": "RootArgument",
+      "name": "first"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": {
+    "catchTo": "RESULT",
+    "connection": [
+      {
+        "count": "first",
+        "cursor": "after",
+        "direction": "forward",
+        "path": (v0/*:: as any*/)
+      }
+    ],
+    "refetch": {
+      "connection": {
+        "forward": {
+          "count": "first",
+          "cursor": "after"
+        },
+        "backward": null,
+        "path": (v0/*:: as any*/)
+      },
+      "fragmentPathInResult": [
+        "node"
+      ],
+      "operation": require('./usePaginationFragmentCatchTestRootCatchRefetchableFragmentQuery.graphql'),
+      "identifierInfo": {
+        "identifierField": "id",
+        "identifierQueryVariableName": "id"
+      }
+    }
+  },
+  "name": "usePaginationFragmentCatchTestRootCatchFragment",
+  "selections": [
+    {
+      "alias": "friends",
+      "args": null,
+      "concreteType": "FriendsConnection",
+      "kind": "LinkedField",
+      "name": "__usePaginationFragmentCatchTestRootCatchFragment__friends_connection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "FriendsEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "User",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "cursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "endCursor",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+})();
+
+if (__DEV__) {
+  (node/*:: as any*/).hash = "fbb2b3fa3b6a1eb0829f97e6cfc55708";
+}
+
+module.exports = ((node/*:: as any*/)/*:: as RefetchableFragment<
+  usePaginationFragmentCatchTestRootCatchFragment$fragmentType,
+  usePaginationFragmentCatchTestRootCatchFragment$data,
+  usePaginationFragmentCatchTestRootCatchRefetchableFragmentQuery$variables,
+>*/);

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/usePaginationFragmentCatchTestRootCatchQuery.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/usePaginationFragmentCatchTestRootCatchQuery.graphql.js
@@ -1,0 +1,219 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<a56a5026fa3257ec3400e9702b37b823>>
+ * @flow
+ * @lightSyntaxTransform
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { usePaginationFragmentCatchTestRootCatchFragment$fragmentType } from "./usePaginationFragmentCatchTestRootCatchFragment.graphql";
+export type usePaginationFragmentCatchTestRootCatchQuery$variables = {|
+  after?: ?string,
+  first?: ?number,
+|};
+export type usePaginationFragmentCatchTestRootCatchQuery$data = {|
+  +me: ?{|
+    +$fragmentSpreads: usePaginationFragmentCatchTestRootCatchFragment$fragmentType,
+  |},
+|};
+export type usePaginationFragmentCatchTestRootCatchQuery = {|
+  response: usePaginationFragmentCatchTestRootCatchQuery$data,
+  variables: usePaginationFragmentCatchTestRootCatchQuery$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "after"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "first"
+},
+v2 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "after"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "first"
+  }
+],
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [
+      (v0/*:: as any*/),
+      (v1/*:: as any*/)
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "usePaginationFragmentCatchTestRootCatchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "usePaginationFragmentCatchTestRootCatchFragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      (v1/*:: as any*/),
+      (v0/*:: as any*/)
+    ],
+    "kind": "Operation",
+    "name": "usePaginationFragmentCatchTestRootCatchQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v2/*:: as any*/),
+            "concreteType": "FriendsConnection",
+            "kind": "LinkedField",
+            "name": "friends",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FriendsEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "User",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__typename",
+                        "storageKey": null
+                      },
+                      (v3/*:: as any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "cursor",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "kind": "LinkedField",
+                "name": "pageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "endCursor",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "hasNextPage",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": (v2/*:: as any*/),
+            "filters": null,
+            "handle": "connection",
+            "key": "usePaginationFragmentCatchTestRootCatchFragment__friends",
+            "kind": "LinkedHandle",
+            "name": "friends"
+          },
+          (v3/*:: as any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "d53c12bd36c54efda0155d644e3f59c9",
+    "id": null,
+    "metadata": {},
+    "name": "usePaginationFragmentCatchTestRootCatchQuery",
+    "operationKind": "query",
+    "text": "query usePaginationFragmentCatchTestRootCatchQuery(\n  $first: Int\n  $after: ID\n) {\n  me {\n    ...usePaginationFragmentCatchTestRootCatchFragment\n    id\n  }\n}\n\nfragment usePaginationFragmentCatchTestRootCatchFragment on User {\n  friends(after: $after, first: $first) {\n    edges {\n      node {\n        __typename\n        id\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*:: as any*/).hash = "f1acf4cfb88f6703a6d7d8fcf0c39c70";
+}
+
+module.exports = ((node/*:: as any*/)/*:: as Query<
+  usePaginationFragmentCatchTestRootCatchQuery$variables,
+  usePaginationFragmentCatchTestRootCatchQuery$data,
+>*/);

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/usePaginationFragmentCatchTestRootCatchRefetchableFragmentQuery.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/usePaginationFragmentCatchTestRootCatchRefetchableFragmentQuery.graphql.js
@@ -1,0 +1,238 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<7a81df39a17686cf5c0d2bba6442e81e>>
+ * @flow
+ * @lightSyntaxTransform
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+import type { usePaginationFragmentCatchTestRootCatchFragment$fragmentType } from "./usePaginationFragmentCatchTestRootCatchFragment.graphql";
+export type usePaginationFragmentCatchTestRootCatchRefetchableFragmentQuery$variables = {|
+  after?: ?string,
+  first?: ?number,
+  id: string,
+|};
+export type usePaginationFragmentCatchTestRootCatchRefetchableFragmentQuery$data = {|
+  +node: ?{|
+    +$fragmentSpreads: usePaginationFragmentCatchTestRootCatchFragment$fragmentType,
+  |},
+|};
+export type usePaginationFragmentCatchTestRootCatchRefetchableFragmentQuery = {|
+  response: usePaginationFragmentCatchTestRootCatchRefetchableFragmentQuery$data,
+  variables: usePaginationFragmentCatchTestRootCatchRefetchableFragmentQuery$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "after"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "first"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = [
+  {
+    "kind": "Variable",
+    "name": "after",
+    "variableName": "after"
+  },
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "first"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "usePaginationFragmentCatchTestRootCatchRefetchableFragmentQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "usePaginationFragmentCatchTestRootCatchFragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Operation",
+    "name": "usePaginationFragmentCatchTestRootCatchRefetchableFragmentQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*:: as any*/),
+          (v3/*:: as any*/),
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": (v4/*:: as any*/),
+                "concreteType": "FriendsConnection",
+                "kind": "LinkedField",
+                "name": "friends",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "FriendsEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "User",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*:: as any*/),
+                          (v3/*:: as any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "cursor",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "PageInfo",
+                    "kind": "LinkedField",
+                    "name": "pageInfo",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endCursor",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "hasNextPage",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": (v4/*:: as any*/),
+                "filters": null,
+                "handle": "connection",
+                "key": "usePaginationFragmentCatchTestRootCatchFragment__friends",
+                "kind": "LinkedHandle",
+                "name": "friends"
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "8610d24acee5d5cd19ceb3c363acbaf5",
+    "id": null,
+    "metadata": {},
+    "name": "usePaginationFragmentCatchTestRootCatchRefetchableFragmentQuery",
+    "operationKind": "query",
+    "text": "query usePaginationFragmentCatchTestRootCatchRefetchableFragmentQuery(\n  $after: ID\n  $first: Int\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...usePaginationFragmentCatchTestRootCatchFragment\n    id\n  }\n}\n\nfragment usePaginationFragmentCatchTestRootCatchFragment on User {\n  friends(after: $after, first: $first) {\n    edges {\n      node {\n        __typename\n        id\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*:: as any*/).hash = "fbb2b3fa3b6a1eb0829f97e6cfc55708";
+}
+
+module.exports = ((node/*:: as any*/)/*:: as Query<
+  usePaginationFragmentCatchTestRootCatchRefetchableFragmentQuery$variables,
+  usePaginationFragmentCatchTestRootCatchRefetchableFragmentQuery$data,
+>*/);

--- a/packages/react-relay/relay-hooks/__tests__/usePaginationFragmentCatch-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/usePaginationFragmentCatch-test.js
@@ -108,3 +108,94 @@ test('@catch does not interfere with the hasNext value returned by usePagination
 
   expect(container?.container.textContent).toBe('Connection has more items');
 });
+
+test('@catch on the root of the fragment does not interfere with the hasNext value returned by usePaginationFragment', async () => {
+  const QUERY = graphql`
+    query usePaginationFragmentCatchTestRootCatchQuery(
+      $first: Int
+      $after: ID
+    ) {
+      me {
+        ...usePaginationFragmentCatchTestRootCatchFragment
+      }
+    }
+  `;
+
+  function MyComponent() {
+    const query = useLazyLoadQuery(QUERY, {});
+
+    const {hasNext} = usePaginationFragment(
+      graphql`
+        fragment usePaginationFragmentCatchTestRootCatchFragment on User
+        @catch
+        @refetchable(
+          queryName: "usePaginationFragmentCatchTestRootCatchRefetchableFragmentQuery"
+        ) {
+          friends(after: $after, first: $first)
+            @connection(
+              key: "usePaginationFragmentCatchTestRootCatchFragment__friends"
+            ) {
+            edges {
+              node {
+                __typename
+              }
+            }
+          }
+        }
+      `,
+      query.me,
+    );
+
+    return hasNext
+      ? 'Connection has more items'
+      : 'Connection has NO more items';
+  }
+
+  const environment = createMockEnvironment({});
+  function App() {
+    return (
+      <RelayEnvironmentProvider environment={environment}>
+        <Suspense fallback="Loading...">
+          <MyComponent />
+        </Suspense>
+      </RelayEnvironmentProvider>
+    );
+  }
+
+  let container = null;
+  await act(async () => {
+    container = ReactTestingLibrary.render(<App />);
+  });
+
+  expect(container?.container.textContent).toEqual('Loading...');
+
+  await act(async () => {
+    environment.mock.resolveMostRecentOperation({
+      data: {
+        me: {
+          id: '4',
+          __typename: 'User',
+          name: 'Christian',
+          friends: {
+            edges: [
+              {
+                __typename: 'FiendEdge',
+                cursor: 'cursor:0',
+                node: {
+                  id: '8',
+                  __typename: 'User',
+                },
+              },
+            ],
+            pageInfo: {
+              endCursor: 'cursor:1',
+              hasNextPage: true,
+            },
+          },
+        },
+      },
+    });
+  });
+
+  expect(container?.container.textContent).toBe('Connection has more items');
+});

--- a/packages/react-relay/relay-hooks/getFragmentInternalData.js
+++ b/packages/react-relay/relay-hooks/getFragmentInternalData.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+import type {ReaderFragment} from 'relay-runtime';
+
+/**
+ * When `@catch` is applied to a fragment's root, the reader wraps the fragment
+ * data in a `Result` envelope (`{ok: true, value} | {ok: false, errors}`).
+ * Internal hook code (pagination, refetch) needs to read the underlying value
+ * to find the connection / identifier fields. The user-facing fragment data
+ * remains wrapped.
+ */
+function getFragmentInternalData(
+  fragmentNode: ReaderFragment,
+  fragmentData: mixed,
+): mixed {
+  if (fragmentNode.metadata?.catchTo !== 'RESULT') {
+    return fragmentData;
+  }
+  if (fragmentData == null || typeof fragmentData !== 'object') {
+    return fragmentData;
+  }
+  // $FlowFixMe[prop-missing] Result<T, _> shape
+  return fragmentData.ok === true ? fragmentData.value : null;
+}
+
+module.exports = getFragmentInternalData;

--- a/packages/react-relay/relay-hooks/useLoadMoreFunction.js
+++ b/packages/react-relay/relay-hooks/useLoadMoreFunction.js
@@ -148,8 +148,7 @@ hook useLoadMoreFunction_CURRENT<TVariables extends Variables>(
     };
   }, [disposeFetch]);
 
-  const isRequestInvalid =
-    internalFragmentData == null || isParentQueryActive;
+  const isRequestInvalid = internalFragmentData == null || isParentQueryActive;
 
   const loadMore = useCallback(
     (

--- a/packages/react-relay/relay-hooks/useLoadMoreFunction.js
+++ b/packages/react-relay/relay-hooks/useLoadMoreFunction.js
@@ -23,6 +23,7 @@ import type {
 } from 'relay-runtime';
 
 const getConnectionState = require('./getConnectionState');
+const getFragmentInternalData = require('./getFragmentInternalData');
 const useFetchTrackingRef = require('./useFetchTrackingRef');
 const useIsMountedRef = require('./useIsMountedRef');
 const useIsOperationNodeActive = require('./useIsOperationNodeActive');
@@ -100,11 +101,17 @@ hook useLoadMoreFunction_CURRENT<TVariables extends Variables>(
     fragmentNode,
     componentDisplayName,
   );
+  // When @catch wraps the fragment root in a Result envelope, look inside
+  // .value for the connection / identifier fields.
+  const internalFragmentData = getFragmentInternalData(
+    fragmentNode,
+    fragmentData,
+  );
   const identifierValue =
     identifierInfo?.identifierField != null &&
-    fragmentData != null &&
-    typeof fragmentData === 'object'
-      ? fragmentData[identifierInfo.identifierField]
+    internalFragmentData != null &&
+    typeof internalFragmentData === 'object'
+      ? internalFragmentData[identifierInfo.identifierField]
       : null;
 
   const isMountedRef = useIsMountedRef();
@@ -130,7 +137,7 @@ hook useLoadMoreFunction_CURRENT<TVariables extends Variables>(
   const {cursor, hasMore} = getConnectionState(
     direction,
     fragmentNode,
-    fragmentData,
+    internalFragmentData,
     connectionPathInFragmentData,
   );
 
@@ -141,7 +148,8 @@ hook useLoadMoreFunction_CURRENT<TVariables extends Variables>(
     };
   }, [disposeFetch]);
 
-  const isRequestInvalid = fragmentData == null || isParentQueryActive;
+  const isRequestInvalid =
+    internalFragmentData == null || isParentQueryActive;
 
   const loadMore = useCallback(
     (

--- a/packages/react-relay/relay-hooks/useLoadMoreFunction_EXPERIMENTAL.js
+++ b/packages/react-relay/relay-hooks/useLoadMoreFunction_EXPERIMENTAL.js
@@ -142,8 +142,7 @@ hook useLoadMoreFunction_EXPERIMENTAL<TVariables extends Variables>(
     connectionPathInFragmentData,
   );
 
-  const isRequestInvalid =
-    internalFragmentData == null || isParentQueryActive;
+  const isRequestInvalid = internalFragmentData == null || isParentQueryActive;
 
   const isMountedRef = useIsMountedRef();
   const loadMore = useCallback(

--- a/packages/react-relay/relay-hooks/useLoadMoreFunction_EXPERIMENTAL.js
+++ b/packages/react-relay/relay-hooks/useLoadMoreFunction_EXPERIMENTAL.js
@@ -24,6 +24,7 @@ import type {
 } from 'relay-runtime';
 
 const getConnectionState = require('./getConnectionState');
+const getFragmentInternalData = require('./getFragmentInternalData');
 const useIsMountedRef = require('./useIsMountedRef');
 const useIsOperationNodeActive = require('./useIsOperationNodeActive');
 const useRelayEnvironment = require('./useRelayEnvironment');
@@ -89,11 +90,17 @@ hook useLoadMoreFunction_EXPERIMENTAL<TVariables extends Variables>(
     fragmentNode,
     componentDisplayName,
   );
+  // When @catch wraps the fragment root in a Result envelope, look inside
+  // .value for the connection / identifier fields.
+  const internalFragmentData = getFragmentInternalData(
+    fragmentNode,
+    fragmentData,
+  );
   const identifierValue =
     identifierInfo?.identifierField != null &&
-    fragmentData != null &&
-    typeof fragmentData === 'object'
-      ? fragmentData[identifierInfo.identifierField]
+    internalFragmentData != null &&
+    typeof internalFragmentData === 'object'
+      ? internalFragmentData[identifierInfo.identifierField]
       : null;
 
   const fetchStatusRef = useRef<
@@ -131,11 +138,12 @@ hook useLoadMoreFunction_EXPERIMENTAL<TVariables extends Variables>(
   const {cursor, hasMore} = getConnectionState(
     direction,
     fragmentNode,
-    fragmentData,
+    internalFragmentData,
     connectionPathInFragmentData,
   );
 
-  const isRequestInvalid = fragmentData == null || isParentQueryActive;
+  const isRequestInvalid =
+    internalFragmentData == null || isParentQueryActive;
 
   const isMountedRef = useIsMountedRef();
   const loadMore = useCallback(

--- a/packages/react-relay/relay-hooks/usePrefetchableForwardPaginationFragment.js
+++ b/packages/react-relay/relay-hooks/usePrefetchableForwardPaginationFragment.js
@@ -16,6 +16,7 @@ import type {Options} from './useRefetchableFragmentInternal';
 import type {FragmentType, Variables} from 'relay-runtime';
 import type {PrefetchableRefetchableFragment} from 'relay-runtime';
 
+const getFragmentInternalData = require('./getFragmentInternalData');
 const useFragment = require('./useFragment');
 const useLoadMoreFunction = require('./useLoadMoreFunction');
 const useRefetchableFragmentInternal = require('./useRefetchableFragmentInternal');
@@ -122,7 +123,7 @@ hook usePrefetchableForwardPaginationFragment<
 
   const edgeKeys = useMemo(() => {
     const connection = getValueAtPath(
-      fragmentData,
+      getFragmentInternalData(fragmentNode, fragmentData),
       connectionPathInFragmentData,
     );
     if (connection == null) {
@@ -131,7 +132,7 @@ hook usePrefetchableForwardPaginationFragment<
     const {EDGES} = ConnectionInterface.get();
     // $FlowFixMe[incompatible-use]
     return connection[EDGES];
-  }, [connectionPathInFragmentData, fragmentData]);
+  }, [connectionPathInFragmentData, fragmentData, fragmentNode]);
 
   const sourceSize = edgeKeys == null ? -1 : edgeKeys.length;
 

--- a/packages/react-relay/relay-hooks/usePrefetchableForwardPaginationFragment_EXPERIMENTAL.js
+++ b/packages/react-relay/relay-hooks/usePrefetchableForwardPaginationFragment_EXPERIMENTAL.js
@@ -16,6 +16,7 @@ import type {Options} from './useRefetchableFragmentInternal';
 import type {FragmentType, Variables} from 'relay-runtime';
 import type {PrefetchableRefetchableFragment} from 'relay-runtime';
 
+const getFragmentInternalData = require('./getFragmentInternalData');
 const useFragment = require('./useFragment');
 const useLoadMoreFunction = require('./useLoadMoreFunction');
 const useRefetchableFragmentInternal = require('./useRefetchableFragmentInternal');
@@ -122,7 +123,7 @@ hook usePrefetchableForwardPaginationFragment_EXPERIMENTAL<
 
   const edgeKeys = useMemo(() => {
     const connection = getValueAtPath(
-      fragmentData,
+      getFragmentInternalData(fragmentNode, fragmentData),
       connectionPathInFragmentData,
     );
     if (connection == null) {
@@ -131,7 +132,7 @@ hook usePrefetchableForwardPaginationFragment_EXPERIMENTAL<
     const {EDGES} = ConnectionInterface.get();
     // $FlowFixMe[incompatible-use]
     return connection[EDGES];
-  }, [connectionPathInFragmentData, fragmentData]);
+  }, [connectionPathInFragmentData, fragmentData, fragmentNode]);
 
   const sourceSize = edgeKeys == null ? -1 : edgeKeys.length;
 

--- a/packages/react-relay/relay-hooks/useRefetchableFragmentInternal.js
+++ b/packages/react-relay/relay-hooks/useRefetchableFragmentInternal.js
@@ -26,6 +26,7 @@ import type {
   VariablesOf,
 } from 'relay-runtime';
 
+const getFragmentInternalData = require('./getFragmentInternalData');
 const ProfilerContext = require('./ProfilerContext');
 const {getQueryResourceForEnvironment} = require('./QueryResource');
 const readFragmentInternal = require('./readFragmentInternal');
@@ -383,11 +384,17 @@ hook useRefetchFunction<TQuery extends OperationType>(
   refetchableRequest: ConcreteRequest,
 ): RefetchFn<TQuery, InternalOptions> {
   const isMountedRef = useIsMountedRef();
+  // When @catch wraps the fragment root in a Result envelope, look inside
+  // .value for the identifier field.
+  const internalFragmentData = getFragmentInternalData(
+    fragmentNode,
+    fragmentData,
+  );
   const identifierValue =
     identifierInfo?.identifierField != null &&
-    fragmentData != null &&
-    typeof fragmentData === 'object'
-      ? fragmentData[identifierInfo.identifierField]
+    internalFragmentData != null &&
+    typeof internalFragmentData === 'object'
+      ? internalFragmentData[identifierInfo.identifierField]
       : null;
   return useCallback(
     (


### PR DESCRIPTION
Fixes: #5070

## Problem

When `@catch` is applied to the **root** of a fragment used with `usePaginationFragment`, `hasNext` always returned `false` even when the response included `pageInfo.hasNextPage: true`. `@catch` on a child field worked correctly — only the root-level case was broken.

## Root cause

When `@catch` is on the fragment root, the compiler sets `metadata.catchTo: "RESULT"` on the ReaderFragment. At read time, `RelayReader._catchErrors` wraps the entire fragment data in a `Result` envelope:

```js
{ok: true, value: {friends: ..., id: ...}}
// or
{ok: false, errors: [...]}
```

The pagination/refetch hook internals were reading fields directly off `fragmentData` and never unwrapping this envelope:

- `getConnectionState` did `getValueAtPath(fragmentData, ["friends"])` → `undefined` → returned `{cursor: null, hasMore: false}` → `hasNext === false`.
- `useLoadMoreFunction` and `useRefetchableFragmentInternal` did `fragmentData[identifierField]` → `undefined` → broken refetch identifier.

## Fix

Added a tiny helper `getFragmentInternalData(fragmentNode, fragmentData)` that unwraps the `Result` envelope when `catchTo === 'RESULT'` (no-op otherwise). Applied it at every internal call site that reads from `fragmentData`. The user-facing `data` returned from `usePaginationFragment` remains wrapped, matching the generated `Result<T, unknown>` type.