### PR TITLE
ci: declare workflow-scope permissions on three maintenance workflows

### DIFF
--- a/.github/workflows/update-cargo-lock.yml
+++ b/.github/workflows/update-cargo-lock.yml
@@ -12,6 +12,9 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+permissions:
+  contents: read
+
 jobs:
   update-cargo-lock:
     name: Update Cargo.lock file

--- a/.github/workflows/update-yarn-lock.yml
+++ b/.github/workflows/update-yarn-lock.yml
@@ -9,6 +9,9 @@ on:
   schedule:
     - cron: "0 0 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   update-yarn-lock:
     name: Update yarn.lock file

--- a/.github/workflows/vscode.yml
+++ b/.github/workflows/vscode.yml
@@ -2,6 +2,9 @@ name: Publish Relay VS Code Extension
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   vscode-release:
     name: VSCode Extension Release


### PR DESCRIPTION
This patch adds `permissions: contents: read` at workflow scope to three small workflows that currently rely on the repository default for their workflow `GITHUB_TOKEN`:

- `.github/workflows/update-cargo-lock.yml`
- `.github/workflows/update-yarn-lock.yml`
- `.github/workflows/vscode.yml`

In all three cases the actual write authority comes from a separately-injected secret, not the workflow token:

- the two lock-update jobs pass `RELAY_BOT_GITHUB_PAT` to `peter-evans/create-pull-request`, so the workflow token only needs to checkout
- `vscode.yml` passes `VSCE_PAT` to `vsce publish`, same story

So the workflow token only needs `contents: read` for `actions/checkout`. Spelling that out makes the contract explicit and means a future change to the repo's default workflow-token scope (or a compromised third-party action like `actions-rs/toolchain` or `peter-evans/create-pull-request`, cf. tj-actions/changed-files CVE-2025-30066) can't widen these particular workflows' authority.

Style matches `ci.yml` (per-job blocks) and `docusaurus.yml` (workflow-level `permissions: contents: write`). No behavioural change.