### PR TITLE
Fix Windows file URI construction in relay-lsp

### DIFF
--- a/compiler/crates/relay-lsp/src/diagnostic_reporter.rs
+++ b/compiler/crates/relay-lsp/src/diagnostic_reporter.rs
@@ -45,9 +45,7 @@ use crate::lsp_process_error::LSPProcessResult;
 fn url_from_location(location: Location, root_dir: &Path) -> Option<Uri> {
     let file_path = location.source_location().path();
     let canonical_path = canonicalize(root_dir.join(file_path)).ok()?;
-    format!("file://{}", canonical_path.to_str()?)
-        .parse::<Uri>()
-        .ok()
+    crate::utils::path_to_file_uri(&canonical_path)
 }
 
 #[derive(Default, Clone)]
@@ -247,9 +245,7 @@ impl DiagnosticReporter {
     pub fn url_from_location(&self, location: Location) -> Option<Uri> {
         url_from_location(location, &self.root_dir).or_else(|| {
             // TODO(brandondail) we should always be able to parse as a Uri, so log here when we don't
-            format!("file://{}/", self.root_dir.to_str()?)
-                .parse::<Uri>()
-                .ok()
+            crate::utils::dir_to_file_uri(&self.root_dir)
         })
     }
 
@@ -290,8 +286,7 @@ impl DiagnosticReporter {
             tags: None,
             ..Default::default()
         };
-        let uri = format!("file://{}/", self.root_dir.to_str().unwrap())
-            .parse::<Uri>()
+        let uri = crate::utils::dir_to_file_uri(&self.root_dir)
             .expect("print_generic_error: Could not convert self.root_dir to Uri");
         self.add_diagnostic(uri, diagnostic);
     }

--- a/compiler/crates/relay-lsp/src/goto_definition.rs
+++ b/compiler/crates/relay-lsp/src/goto_definition.rs
@@ -351,10 +351,9 @@ fn get_location(
     };
     let range = lsp_types::Range { start, end: start };
 
-    let uri =
-        crate::utils::path_to_file_uri(std::path::Path::new(path)).ok_or_else(|| {
-            LSPRuntimeError::UnexpectedError(format!("Could not convert path to URI: {path}"))
-        })?;
+    let uri = crate::utils::path_to_file_uri(std::path::Path::new(path)).ok_or_else(|| {
+        LSPRuntimeError::UnexpectedError(format!("Could not convert path to URI: {path}"))
+    })?;
 
     Ok(lsp_types::Location { uri, range })
 }

--- a/compiler/crates/relay-lsp/src/goto_definition.rs
+++ b/compiler/crates/relay-lsp/src/goto_definition.rs
@@ -20,7 +20,6 @@ use intern::string_key::StringKey;
 use log::error;
 use log::info;
 use lsp_types::GotoDefinitionResponse;
-use lsp_types::Uri;
 use lsp_types::request::GotoDefinition;
 use lsp_types::request::Request;
 use schema::SDLSchema;
@@ -352,9 +351,10 @@ fn get_location(
     };
     let range = lsp_types::Range { start, end: start };
 
-    let uri = format!("file://{path}").parse::<Uri>().map_err(|e| {
-        LSPRuntimeError::UnexpectedError(format!("Could not parse path as URL: {e}"))
-    })?;
+    let uri =
+        crate::utils::path_to_file_uri(std::path::Path::new(path)).ok_or_else(|| {
+            LSPRuntimeError::UnexpectedError(format!("Could not convert path to URI: {path}"))
+        })?;
 
     Ok(lsp_types::Location { uri, range })
 }

--- a/compiler/crates/relay-lsp/src/graphql_tools.rs
+++ b/compiler/crates/relay-lsp/src/graphql_tools.rs
@@ -56,7 +56,7 @@ pub(crate) struct GraphQLExecuteQueryParams {
 impl GraphQLExecuteQueryParams {
     fn get_uri(&self) -> Option<Uri> {
         if let Some(path) = &self.document_path {
-            format!("file://{path}").parse::<Uri>().ok()
+            crate::utils::path_to_file_uri(std::path::Path::new(path))
         } else {
             None
         }

--- a/compiler/crates/relay-lsp/src/location.rs
+++ b/compiler/crates/relay-lsp/src/location.rs
@@ -106,13 +106,7 @@ fn get_file_contents(path: &Path) -> LSPRuntimeResult<String> {
 }
 
 fn get_uri(path: &PathBuf) -> LSPRuntimeResult<Uri> {
-    format!(
-        "file://{}",
-        path.to_str()
-            .ok_or_else(|| LSPRuntimeError::UnexpectedError(format!(
-                "Could not cast path {path:?} as string"
-            )))?
-    )
-    .parse::<Uri>()
-    .map_err(|e| LSPRuntimeError::UnexpectedError(e.to_string()))
+    crate::utils::path_to_file_uri(path).ok_or_else(|| {
+        LSPRuntimeError::UnexpectedError(format!("Could not convert path {path:?} to URI"))
+    })
 }

--- a/compiler/crates/relay-lsp/src/utils.rs
+++ b/compiler/crates/relay-lsp/src/utils.rs
@@ -295,3 +295,26 @@ pub fn position_to_offset(
     }
     None
 }
+
+/// Converts a filesystem path to a `file://` URI, handling both Unix and Windows paths.
+pub fn path_to_file_uri(path: &Path) -> Option<Uri> {
+    let path_str = path.to_str()?;
+    str_path_to_file_uri(path_str)
+}
+
+/// Converts a directory path to a `file://` URI with a trailing slash.
+pub fn dir_to_file_uri(path: &Path) -> Option<Uri> {
+    let path_str = path.to_str()?;
+    let with_slash = format!("{path_str}/");
+    str_path_to_file_uri(&with_slash)
+}
+
+fn str_path_to_file_uri(path: &str) -> Option<Uri> {
+    let normalized = path.replace('\\', "/");
+    let uri_str = if normalized.starts_with('/') {
+        format!("file://{normalized}")
+    } else {
+        format!("file:///{normalized}")
+    };
+    uri_str.parse::<Uri>().ok()
+}


### PR DESCRIPTION
## Summary

- The `lsp-types` 0.94→0.97 update (6098dee) replaced `Url::from_file_path`/`from_directory_path` with manual `format!("file://{}", path)`, which produces invalid URIs on Windows (e.g., `file://D:\a\relay\...` instead of `file:///D:/a/relay/...`)
- Added `path_to_file_uri` and `dir_to_file_uri` helpers to `utils.rs` that normalize backslashes to forward slashes and ensure the correct `file:///` prefix
- Applied the fix across all 6 call sites in `diagnostic_reporter.rs`, `location.rs`, `goto_definition.rs`, and `graphql_tools.rs`

## Test plan

- [x] `cargo check -p relay-lsp` passes
- [x] `cargo test -p relay-lsp -- diagnostic_reporter` — all 7 tests pass locally including the previously failing `report_diagnostic_test`
- [ ] Verify Windows CI (`Rust Tests (windows-latest)`) passes in this PR's CI run