### PR TITLE
fix(build): ship TypeScript definition files in gulp dist build

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -139,6 +139,22 @@ const flowDefs = gulp.parallel(
   ),
 );
 
+const typeDefs = gulp.parallel(
+  ...builds.map(
+    build =>
+      function typeDefsTask() {
+        return gulp
+          .src(
+            ['**/*.d.ts', '!**/__tests__/**/*.d.ts', '!**/__mocks__/**/*.d.ts'],
+            {
+              cwd: PACKAGES + '/' + build.package,
+            },
+          )
+          .pipe(gulp.dest(path.join(DIST, build.package)));
+      },
+  ),
+);
+
 const copyFilesTasks = [];
 builds.forEach(build => {
   copyFilesTasks.push(
@@ -174,7 +190,7 @@ const copyFiles = gulp.parallel(copyFilesTasks);
 
 const exportsFiles = gulp.series(
   copyFiles,
-  flowDefs,
+  gulp.parallel(flowDefs, typeDefs),
   modules,
   gulp.parallel(
     ...builds.map(


### PR DESCRIPTION
- Adds a `typeDefs` gulp task that copies all `**/*.d.ts` files from each package source directory into `dist/<package>/`, preserving subdirectory structure so relative imports within `.d.ts` files resolve correctly.
- Wires `typeDefs` into the `exportsFiles` pipeline, running in parallel with the existing `flowDefs` task.
- Affects all packages in the `builds` array (`relay-runtime`, `react-relay`, `relay-test-utils`, etc.), any package with `.d.ts` files now has them shipped.

## Root cause
`relay-runtime/package.json` declares `"types": "index.d.ts"`, but the gulpfile had no task to copy `.d.ts` files, so the type entry point was absent from every published dist.