### PR TITLE
fix: add extensions field to PayloadError per GraphQL spec

### DIFF
--- a/packages/relay-runtime/network/RelayNetworkTypes.d.ts
+++ b/packages/relay-runtime/network/RelayNetworkTypes.d.ts
@@ -31,6 +31,7 @@ export interface PayloadError {
         }>
         | undefined;
     path?: Array<string | number>;
+    extensions?: PayloadExtensions | undefined;
     severity?: 'CRITICAL' | 'ERROR' | 'WARNING' | undefined; // Not officially part of the spec, but used at Facebook
 }
 

--- a/packages/relay-runtime/network/RelayNetworkTypes.js
+++ b/packages/relay-runtime/network/RelayNetworkTypes.js
@@ -36,6 +36,7 @@ export type PayloadError = interface {
     ...
   }>,
   path?: Array<string | number>,
+  extensions?: PayloadExtensions,
   // Not officially part of the spec, but used at Facebook
   severity?: 'CRITICAL' | 'ERROR' | 'WARNING',
 };

--- a/packages/relay-runtime/store/RelayErrorTrie.js
+++ b/packages/relay-runtime/store/RelayErrorTrie.js
@@ -11,7 +11,10 @@
 
 'use strict';
 
-import type {PayloadError, PayloadExtensions} from '../network/RelayNetworkTypes';
+import type {
+  PayloadError,
+  PayloadExtensions,
+} from '../network/RelayNetworkTypes';
 
 // $FlowFixMe[recursive-definition]
 const SELF: Self = Symbol('$SELF');

--- a/packages/relay-runtime/store/RelayErrorTrie.js
+++ b/packages/relay-runtime/store/RelayErrorTrie.js
@@ -11,7 +11,7 @@
 
 'use strict';
 
-import type {PayloadError} from '../network/RelayNetworkTypes';
+import type {PayloadError, PayloadExtensions} from '../network/RelayNetworkTypes';
 
 // $FlowFixMe[recursive-definition]
 const SELF: Self = Symbol('$SELF');
@@ -27,6 +27,7 @@ export type TRelayFieldErrorForDisplay = Readonly<{
 export type TRelayFieldError = Readonly<{
   ...TRelayFieldErrorForDisplay,
   message: string,
+  extensions?: PayloadExtensions,
 }>;
 
 /**
@@ -108,26 +109,14 @@ function getErrorsByKey(
   if (Array.isArray(value)) {
     return value;
   }
-  const errors: Array<
-    Readonly<{
-      message: string,
-      path?: Array<string | number>,
-      severity?: 'CRITICAL' | 'ERROR' | 'WARNING',
-    }>,
-  > = [];
+  const errors: Array<TRelayFieldError> = [];
   recursivelyCopyErrorsIntoArray(value, errors);
   return errors;
 }
 
 function recursivelyCopyErrorsIntoArray(
   trieOrSet: RelayErrorTrie,
-  errors: Array<
-    Readonly<{
-      message: string,
-      path?: Array<string | number>,
-      severity?: 'CRITICAL' | 'ERROR' | 'WARNING',
-    }>,
-  >,
+  errors: Array<TRelayFieldError>,
 ): void {
   for (const [childKey, value] of trieOrSet) {
     const oldLength = errors.length;
@@ -142,14 +131,10 @@ function recursivelyCopyErrorsIntoArray(
     const newLength = errors.length;
     for (let index = oldLength; index < newLength; index++) {
       const error = errors[index];
-      if (error.path == null) {
-        errors[index] = {
-          ...error,
-          path: [childKey],
-        };
-      } else {
-        error.path.unshift(childKey);
-      }
+      errors[index] = {
+        ...error,
+        path: error.path == null ? [childKey] : [childKey, ...error.path],
+      };
     }
   }
 }

--- a/packages/relay-runtime/store/RelayStoreTypes.d.ts
+++ b/packages/relay-runtime/store/RelayStoreTypes.d.ts
@@ -11,6 +11,7 @@ import {
   Network,
   PayloadData,
   PayloadError,
+  PayloadExtensions,
   ReactFlightServerTree,
   UploadableMap,
 } from '../network/RelayNetworkTypes';
@@ -1004,6 +1005,7 @@ export type TRelayFieldError =
     & TRelayFieldErrorForDisplay
     & Readonly<{
         message: string;
+        extensions?: PayloadExtensions | undefined;
     }>;
 
 /**


### PR DESCRIPTION
The GraphQL spec (https://spec.graphql.org/September2025/#sec-Errors) states that errors may include an extensions entry whose value must be a map with no additional restrictions on its contents. PayloadError was missing this field.

This also propagates extensions through to `TRelayFieldError` so the field is preserved during normalization and available to consumers. As a side effect, stale inline type annotations in `RelayErrorTrie.js` that manually duplicated the error shape have been replaced with `TRelayFieldError` directly, and a mutation of a ReadonlyArray path via unshift has been replaced with an immutable spread.