### PR TITLE
Update config schema snapshot for shard_extra_artifacts

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -2933,9 +2933,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/compiler/crates/relay-compiler/relay-compiler-config-schema.json
+++ b/compiler/crates/relay-compiler/relay-compiler-config-schema.json
@@ -739,6 +739,13 @@
             "kind": "disabled"
           }
         },
+        "shard_extra_artifacts": {
+          "description": "Shard generated extra artifacts into subdirectories under\n`extraArtifactsOutput` that mirror the source file's relative path,\nhonoring `shardOutput` / `shardStripRegex`.",
+          "$ref": "#/$defs/FeatureFlag",
+          "default": {
+            "kind": "disabled"
+          }
+        },
         "skip_printing_nulls": {
           "$ref": "#/$defs/FeatureFlag",
           "default": {
@@ -979,6 +986,9 @@
             },
             "prefer_fetchable_in_refetch_queries": false,
             "relay_resolver_enable_interface_output_type": {
+              "kind": "disabled"
+            },
+            "shard_extra_artifacts": {
               "kind": "disabled"
             },
             "skip_printing_nulls": {


### PR DESCRIPTION
## Summary
- The `shard_extra_artifacts` feature flag was added in D105719732 but the JSON schema snapshot was not regenerated
- This updates the checked-in `relay-compiler-config-schema.json` snapshot to include the new feature flag
- Stacked on top of #5297 (Update Cargo.lock) which also needs to land to fix the `--locked` CI failure

## Test plan
- Ran `UPDATE_SNAPSHOTS=1 cargo test -p relay-compiler --test relay_compiler_relay_config_schema_json_test` locally — passes