### PR TITLE
fix(DataChecker): respect @defer if condition in availability check

### DIFF
--- a/packages/relay-runtime/store/DataChecker.js
+++ b/packages/relay-runtime/store/DataChecker.js
@@ -1,82 +1,57 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
  * @flow strict-local
  * @format
- * @emails oncall+relay
+ * @oncall relay
  */
-
-// flowlint ambiguous-object-type:error
 
 'use strict';
 
-const RelayConcreteNode = require('../util/RelayConcreteNode');
-const RelayFeatureFlags = require('../util/RelayFeatureFlags');
-const RelayModernRecord = require('./RelayModernRecord');
-const RelayRecordSourceMutator = require('../mutations/RelayRecordSourceMutator');
-const RelayRecordSourceProxy = require('../mutations/RelayRecordSourceProxy');
-const RelayStoreReactFlightUtils = require('./RelayStoreReactFlightUtils');
-const RelayStoreUtils = require('./RelayStoreUtils');
-
-const cloneRelayHandleSourceField = require('./cloneRelayHandleSourceField');
-const cloneRelayScalarHandleSourceField = require('./cloneRelayScalarHandleSourceField');
-const getOperation = require('../util/getOperation');
-const invariant = require('invariant');
-
-const {isClientID} = require('./ClientID');
-const {EXISTENT, UNKNOWN} = require('./RelayRecordState');
-const {generateTypeID} = require('./TypeID');
-
+import type {ActorIdentifier} from '../multi-actor-environment/ActorIdentifier';
 import type {
-  NormalizationField,
-  NormalizationFlightField,
   NormalizationLinkedField,
+  NormalizationLiveResolverField,
   NormalizationModuleImport,
   NormalizationNode,
+  NormalizationResolverField,
   NormalizationScalarField,
   NormalizationSelection,
 } from '../util/NormalizationNode';
 import type {DataID, Variables} from '../util/RelayRuntimeTypes';
 import type {GetDataID} from './RelayResponseNormalizer';
 import type {
+  LogFunction,
   MissingFieldHandler,
   MutableRecordSource,
   NormalizationSelector,
   OperationLoader,
-  ReactFlightReachableQuery,
-  Record,
   RecordSource,
 } from './RelayStoreTypes';
 
-export type Availability = {|
+const RelayRecordSourceMutator = require('../mutations/RelayRecordSourceMutator');
+const RelayRecordSourceProxy = require('../mutations/RelayRecordSourceProxy');
+const getOperation = require('../util/getOperation');
+const {isClientID} = require('./ClientID');
+const cloneRelayHandleSourceField = require('./cloneRelayHandleSourceField');
+const cloneRelayScalarHandleSourceField = require('./cloneRelayScalarHandleSourceField');
+const {getLocalVariables} = require('./RelayConcreteVariables');
+const RelayModernRecord = require('./RelayModernRecord');
+const {EXISTENT, UNKNOWN} = require('./RelayRecordState');
+const RelayStoreUtils = require('./RelayStoreUtils');
+const {TYPE_SCHEMA_TYPE, generateTypeID} = require('./TypeID');
+const invariant = require('invariant');
+
+export type Availability = {
   +status: 'available' | 'missing',
   +mostRecentlyInvalidatedAt: ?number,
-|};
+};
 
-const {
-  CONDITION,
-  CLIENT_EXTENSION,
-  DEFER,
-  FLIGHT_FIELD,
-  FRAGMENT_SPREAD,
-  INLINE_FRAGMENT,
-  LINKED_FIELD,
-  LINKED_HANDLE,
-  MODULE_IMPORT,
-  SCALAR_FIELD,
-  SCALAR_HANDLE,
-  STREAM,
-  TYPE_DISCRIMINATOR,
-} = RelayConcreteNode;
-const {
-  ROOT_ID,
-  getModuleOperationKey,
-  getStorageKey,
-  getArgumentValues,
-} = RelayStoreUtils;
+const {getModuleOperationKey, getStorageKey, getArgumentValues} =
+  RelayStoreUtils;
 
 /**
  * Synchronously check whether the records required to fulfill the given
@@ -89,73 +64,145 @@ const {
  * If all records are present, returns `true`, otherwise `false`.
  */
 function check(
-  source: RecordSource,
-  target: MutableRecordSource,
+  getSourceForActor: (actorIdentifier: ActorIdentifier) => RecordSource,
+  getTargetForActor: (actorIdentifier: ActorIdentifier) => MutableRecordSource,
+  defaultActorIdentifier: ActorIdentifier,
   selector: NormalizationSelector,
-  handlers: $ReadOnlyArray<MissingFieldHandler>,
+  handlers: ReadonlyArray<MissingFieldHandler>,
   operationLoader: ?OperationLoader,
   getDataID: GetDataID,
+  shouldProcessClientComponents: ?boolean,
+  log: ?LogFunction,
+  useExecTimeResolvers: ?boolean,
 ): Availability {
+  if (log != null) {
+    log({
+      name: 'store.datachecker.start',
+      selector,
+    });
+  }
   const {dataID, node, variables} = selector;
   const checker = new DataChecker(
-    source,
-    target,
+    getSourceForActor,
+    getTargetForActor,
+    defaultActorIdentifier,
     variables,
     handlers,
     operationLoader,
     getDataID,
+    shouldProcessClientComponents,
+    log,
+    useExecTimeResolvers,
   );
-  return checker.check(node, dataID);
+  const result = checker.check(node, dataID);
+  if (log != null) {
+    log({
+      name: 'store.datachecker.end',
+      selector,
+    });
+  }
+  return result;
 }
 
 /**
  * @private
  */
 class DataChecker {
-  _handlers: $ReadOnlyArray<MissingFieldHandler>;
+  _handlers: ReadonlyArray<MissingFieldHandler>;
   _mostRecentlyInvalidatedAt: number | null;
   _mutator: RelayRecordSourceMutator;
   _operationLoader: OperationLoader | null;
-  _operationLastWrittenAt: ?number;
   _recordSourceProxy: RelayRecordSourceProxy;
   _recordWasMissing: boolean;
   _source: RecordSource;
+  _useExecTimeResolvers: boolean;
   _variables: Variables;
+  _shouldProcessClientComponents: ?boolean;
+  +_getSourceForActor: (actorIdentifier: ActorIdentifier) => RecordSource;
+  +_getTargetForActor: (
+    actorIdentifier: ActorIdentifier,
+  ) => MutableRecordSource;
+  +_getDataID: GetDataID;
+  +_mutatorRecordSourceProxyCache: Map<
+    ActorIdentifier,
+    [RelayRecordSourceMutator, RelayRecordSourceProxy],
+  >;
+  _log: ?LogFunction;
 
   constructor(
-    source: RecordSource,
-    target: MutableRecordSource,
+    getSourceForActor: (actorIdentifier: ActorIdentifier) => RecordSource,
+    getTargetForActor: (
+      actorIdentifier: ActorIdentifier,
+    ) => MutableRecordSource,
+    defaultActorIdentifier: ActorIdentifier,
     variables: Variables,
-    handlers: $ReadOnlyArray<MissingFieldHandler>,
+    handlers: ReadonlyArray<MissingFieldHandler>,
     operationLoader: ?OperationLoader,
     getDataID: GetDataID,
+    shouldProcessClientComponents: ?boolean,
+    log: ?LogFunction,
+    useExecTimeResolvers: ?boolean,
   ) {
-    const mutator = new RelayRecordSourceMutator(source, target);
+    this._getSourceForActor = getSourceForActor;
+    this._getTargetForActor = getTargetForActor;
+    this._getDataID = getDataID;
+    this._source = getSourceForActor(defaultActorIdentifier);
+    this._mutatorRecordSourceProxyCache = new Map();
+    const [mutator, recordSourceProxy] = this._getMutatorAndRecordProxyForActor(
+      defaultActorIdentifier,
+    );
+    this._useExecTimeResolvers = useExecTimeResolvers ?? false;
     this._mostRecentlyInvalidatedAt = null;
     this._handlers = handlers;
     this._mutator = mutator;
     this._operationLoader = operationLoader ?? null;
-    this._recordSourceProxy = new RelayRecordSourceProxy(mutator, getDataID);
+    this._recordSourceProxy = recordSourceProxy;
     this._recordWasMissing = false;
-    this._source = source;
     this._variables = variables;
+    this._shouldProcessClientComponents = shouldProcessClientComponents;
+    this._log = log;
+  }
+
+  _getMutatorAndRecordProxyForActor(
+    actorIdentifier: ActorIdentifier,
+  ): [RelayRecordSourceMutator, RelayRecordSourceProxy] {
+    let tuple = this._mutatorRecordSourceProxyCache.get(actorIdentifier);
+    if (tuple == null) {
+      const target = this._getTargetForActor(actorIdentifier);
+
+      const mutator = new RelayRecordSourceMutator(
+        this._getSourceForActor(actorIdentifier),
+        target,
+      );
+      const recordSourceProxy = new RelayRecordSourceProxy(
+        mutator,
+        this._getDataID,
+        undefined,
+        this._handlers,
+        this._log,
+      );
+      tuple = [mutator, recordSourceProxy];
+      this._mutatorRecordSourceProxyCache.set(actorIdentifier, tuple);
+    }
+    return tuple;
   }
 
   check(node: NormalizationNode, dataID: DataID): Availability {
+    this._assignClientAbstractTypes(node);
     this._traverse(node, dataID);
 
     return this._recordWasMissing === true
       ? {
-          status: 'missing',
           mostRecentlyInvalidatedAt: this._mostRecentlyInvalidatedAt,
+          status: 'missing',
         }
       : {
-          status: 'available',
           mostRecentlyInvalidatedAt: this._mostRecentlyInvalidatedAt,
+          status: 'available',
         };
   }
 
-  _getVariableValue(name: string): mixed {
+  _getVariableValue(name: string): unknown {
     invariant(
       this._variables.hasOwnProperty(name),
       'RelayAsyncLoader(): Undefined variable `%s`.',
@@ -168,39 +215,22 @@ class DataChecker {
     this._recordWasMissing = true;
   }
 
-  _getDataForHandlers(
-    field: NormalizationField,
-    dataID: DataID,
-  ): {
-    args: Variables,
-    record: ?Record,
-    ...
-  } {
-    return {
-      args: field.args ? getArgumentValues(field.args, this._variables) : {},
-      // Getting a snapshot of the record state is potentially expensive since
-      // we will need to merge the sink and source records. Since we do not create
-      // any new records in this process, it is probably reasonable to provide
-      // handlers with a copy of the source record.
-      // The only thing that the provided record will not contain is fields
-      // added by previous handlers.
-      record: this._source.get(dataID),
-    };
-  }
-
   _handleMissingScalarField(
     field: NormalizationScalarField,
     dataID: DataID,
-  ): mixed {
+  ): unknown {
     if (field.name === 'id' && field.alias == null && isClientID(dataID)) {
       return undefined;
     }
-    const {args, record} = this._getDataForHandlers(field, dataID);
+    const args =
+      field.args != undefined
+        ? getArgumentValues(field.args, this._variables)
+        : {};
     for (const handler of this._handlers) {
       if (handler.kind === 'scalar') {
         const newValue = handler.handle(
           field,
-          record,
+          this._recordSourceProxy.get(dataID),
           args,
           this._recordSourceProxy,
         );
@@ -209,6 +239,15 @@ class DataChecker {
         }
       }
     }
+    if (this._log != null) {
+      this._log({
+        name: 'store.datachecker.missing',
+        kind: 'scalar',
+        dataID,
+        fieldName: field.name,
+        storageKey: getStorageKey(field, this._variables),
+      });
+    }
     this._handleMissing();
   }
 
@@ -216,12 +255,15 @@ class DataChecker {
     field: NormalizationLinkedField,
     dataID: DataID,
   ): ?DataID {
-    const {args, record} = this._getDataForHandlers(field, dataID);
+    const args =
+      field.args != undefined
+        ? getArgumentValues(field.args, this._variables)
+        : {};
     for (const handler of this._handlers) {
       if (handler.kind === 'linked') {
         const newValue = handler.handle(
           field,
-          record,
+          this._recordSourceProxy.get(dataID),
           args,
           this._recordSourceProxy,
         );
@@ -233,6 +275,15 @@ class DataChecker {
         }
       }
     }
+    if (this._log != null) {
+      this._log({
+        name: 'store.datachecker.missing',
+        kind: 'linked',
+        dataID,
+        fieldName: field.name,
+        storageKey: getStorageKey(field, this._variables),
+      });
+    }
     this._handleMissing();
   }
 
@@ -240,12 +291,15 @@ class DataChecker {
     field: NormalizationLinkedField,
     dataID: DataID,
   ): ?Array<?DataID> {
-    const {args, record} = this._getDataForHandlers(field, dataID);
+    const args =
+      field.args != undefined
+        ? getArgumentValues(field.args, this._variables)
+        : {};
     for (const handler of this._handlers) {
       if (handler.kind === 'pluralLinked') {
         const newValue = handler.handle(
           field,
-          record,
+          this._recordSourceProxy.get(dataID),
           args,
           this._recordSourceProxy,
         );
@@ -263,12 +317,28 @@ class DataChecker {
         }
       }
     }
+    if (this._log != null) {
+      this._log({
+        name: 'store.datachecker.missing',
+        kind: 'pluralLinked',
+        dataID,
+        fieldName: field.name,
+        storageKey: getStorageKey(field, this._variables),
+      });
+    }
     this._handleMissing();
   }
 
   _traverse(node: NormalizationNode, dataID: DataID): void {
     const status = this._mutator.getStatus(dataID);
     if (status === UNKNOWN) {
+      if (this._log != null) {
+        this._log({
+          name: 'store.datachecker.missing',
+          kind: 'unknown_record',
+          dataID,
+        });
+      }
       this._handleMissing();
     }
 
@@ -287,28 +357,33 @@ class DataChecker {
   }
 
   _traverseSelections(
-    selections: $ReadOnlyArray<NormalizationSelection>,
+    selections: ReadonlyArray<NormalizationSelection>,
     dataID: DataID,
   ): void {
     selections.forEach(selection => {
       switch (selection.kind) {
-        case SCALAR_FIELD:
+        case 'ScalarField':
           this._checkScalar(selection, dataID);
           break;
-        case LINKED_FIELD:
+        case 'LinkedField':
           if (selection.plural) {
             this._checkPluralLink(selection, dataID);
           } else {
             this._checkLink(selection, dataID);
           }
           break;
-        case CONDITION:
-          const conditionValue = this._getVariableValue(selection.condition);
+        case 'ActorChange':
+          this._checkActorChange(selection.linkedField, dataID);
+          break;
+        case 'Condition':
+          const conditionValue = Boolean(
+            this._getVariableValue(selection.condition),
+          );
           if (conditionValue === selection.passingValue) {
             this._traverseSelections(selection.selections, dataID);
           }
           break;
-        case INLINE_FRAGMENT: {
+        case 'InlineFragment': {
           const {abstractKey} = selection;
           if (abstractKey == null) {
             // concrete type refinement: only check data if the type exactly matches
@@ -316,7 +391,7 @@ class DataChecker {
             if (typeName === selection.type) {
               this._traverseSelections(selection.selections, dataID);
             }
-          } else if (RelayFeatureFlags.ENABLE_PRECISE_TYPE_REFINEMENT) {
+          } else {
             // Abstract refinement: check data depending on whether the type
             // conforms to the interface/union or not:
             // - Type known to _not_ implement the interface: don't check the selections.
@@ -342,14 +417,10 @@ class DataChecker {
               // missing so don't bother reading the fragment
               this._handleMissing();
             } // else false: known to not implement the interface
-          } else {
-            // legacy behavior for abstract refinements: always check even
-            // if the type doesn't conform
-            this._traverseSelections(selection.selections, dataID);
           }
           break;
         }
-        case LINKED_HANDLE: {
+        case 'LinkedHandle': {
           // Handles have no selections themselves; traverse the original field
           // where the handle was set-up instead.
           const handleField = cloneRelayHandleSourceField(
@@ -364,7 +435,7 @@ class DataChecker {
           }
           break;
         }
-        case SCALAR_HANDLE: {
+        case 'ScalarHandle': {
           const handleField = cloneRelayScalarHandleSourceField(
             selection,
             selections,
@@ -374,52 +445,81 @@ class DataChecker {
           this._checkScalar(handleField, dataID);
           break;
         }
-        case MODULE_IMPORT:
+        case 'ModuleImport':
           this._checkModuleImport(selection, dataID);
           break;
-        case DEFER:
-        case STREAM:
-          this._traverseSelections(selection.selections, dataID);
+        case 'Defer':
+        case 'Stream': {
+          const isDeferred =
+            selection.if == null ||
+            Boolean(this._getVariableValue(selection.if));
+          if (isDeferred) {
+            // Defer/stream is active: fields are expected to arrive via
+            // incremental delivery. Their absence should not cause the
+            // overall check to return "missing".
+            const prevRecordWasMissing = this._recordWasMissing;
+            this._traverseSelections(selection.selections, dataID);
+            this._recordWasMissing = prevRecordWasMissing;
+          } else {
+            // Defer/stream is inactive (if: false): fields are expected
+            // inline and must be present.
+            this._traverseSelections(selection.selections, dataID);
+          }
           break;
-        // $FlowFixMe[incompatible-type]
-        case FRAGMENT_SPREAD:
+        }
+        case 'FragmentSpread':
+          const prevVariables = this._variables;
+          this._variables = getLocalVariables(
+            this._variables,
+            selection.fragment.argumentDefinitions,
+            selection.args,
+          );
           this._traverseSelections(selection.fragment.selections, dataID);
+          this._variables = prevVariables;
           break;
-        case CLIENT_EXTENSION:
+        case 'ClientExtension':
           const recordWasMissing = this._recordWasMissing;
           this._traverseSelections(selection.selections, dataID);
           this._recordWasMissing = recordWasMissing;
           break;
-        case TYPE_DISCRIMINATOR:
-          if (RelayFeatureFlags.ENABLE_PRECISE_TYPE_REFINEMENT) {
-            const {abstractKey} = selection;
-            const recordType = this._mutator.getType(dataID);
-            invariant(
-              recordType != null,
-              'DataChecker: Expected record `%s` to have a known type',
-              dataID,
-            );
-            const typeID = generateTypeID(recordType);
-            const implementsInterface = this._mutator.getValue(
-              typeID,
-              abstractKey,
-            );
-            if (implementsInterface == null) {
-              // unsure if the type implements the interface: data is
-              // missing
-              this._handleMissing();
-            } // else: if it does or doesn't implement, we don't need to check or skip anything else
+        case 'TypeDiscriminator':
+          const {abstractKey} = selection;
+          const recordType = this._mutator.getType(dataID);
+          invariant(
+            recordType != null,
+            'DataChecker: Expected record `%s` to have a known type',
+            dataID,
+          );
+          const typeID = generateTypeID(recordType);
+          const implementsInterface = this._mutator.getValue(
+            typeID,
+            abstractKey,
+          );
+          if (implementsInterface == null) {
+            // unsure if the type implements the interface: data is
+            // missing
+            this._handleMissing();
+          } // else: if it does or doesn't implement, we don't need to check or skip anything else
+          break;
+        case 'ClientComponent':
+          if (this._shouldProcessClientComponents === false) {
+            break;
+          }
+          this._traverseSelections(selection.fragment.selections, dataID);
+          break;
+        case 'RelayResolver':
+        case 'RelayLiveResolver':
+          if (!this._useExecTimeResolvers) {
+            this._checkResolver(selection, dataID);
           }
           break;
-        case FLIGHT_FIELD:
-          if (RelayFeatureFlags.ENABLE_REACT_FLIGHT_COMPONENT_FIELD) {
-            this._checkFlightField(selection, dataID);
-          } else {
-            throw new Error('Flight fields are not yet supported.');
+        case 'ClientEdgeToClientObject':
+          if (!this._useExecTimeResolvers) {
+            this._checkResolver(selection.backingField, dataID);
           }
           break;
         default:
-          (selection: empty);
+          selection as empty;
           invariant(
             false,
             'RelayAsyncLoader(): Unexpected ast kind `%s`.',
@@ -427,6 +527,14 @@ class DataChecker {
           );
       }
     });
+  }
+  _checkResolver(
+    resolver: NormalizationResolverField | NormalizationLiveResolverField,
+    dataID: DataID,
+  ) {
+    if (resolver.fragment) {
+      this._traverseSelections([resolver.fragment], dataID);
+    }
   }
 
   _checkModuleImport(
@@ -449,7 +557,14 @@ class DataChecker {
     const normalizationRootNode = operationLoader.get(operationReference);
     if (normalizationRootNode != null) {
       const operation = getOperation(normalizationRootNode);
+      const prevVariables = this._variables;
+      this._variables = getLocalVariables(
+        this._variables,
+        operation.argumentDefinitions,
+        moduleImport.args,
+      );
       this._traverse(operation, dataID);
+      this._variables = prevVariables;
     } else {
       // If the fragment is not available, we assume that the data cannot have been
       // processed yet and must therefore be missing.
@@ -506,55 +621,57 @@ class DataChecker {
     }
   }
 
-  _checkFlightField(field: NormalizationFlightField, dataID: DataID): void {
+  _checkActorChange(field: NormalizationLinkedField, dataID: DataID): void {
     const storageKey = getStorageKey(field, this._variables);
-    const linkedID = this._mutator.getLinkedRecordID(dataID, storageKey);
+    const record = this._source.get(dataID);
+    const tuple =
+      record != null
+        ? RelayModernRecord.getActorLinkedRecordID(record, storageKey)
+        : record;
 
-    if (linkedID == null) {
-      if (linkedID === undefined) {
-        this._handleMissing();
-        return;
-      }
-      return;
-    }
-
-    const tree = this._mutator.getValue(
-      linkedID,
-      RelayStoreReactFlightUtils.REACT_FLIGHT_TREE_STORAGE_KEY,
-    );
-    const reachableQueries = this._mutator.getValue(
-      linkedID,
-      RelayStoreReactFlightUtils.REACT_FLIGHT_QUERIES_STORAGE_KEY,
-    );
-
-    if (tree == null || !Array.isArray(reachableQueries)) {
-      this._handleMissing();
-      return;
-    }
-
-    const operationLoader = this._operationLoader;
-    invariant(
-      operationLoader !== null,
-      'DataChecker: Expected an operationLoader to be configured when using ' +
-        'React Flight.',
-    );
-    // In Flight, the variables that are in scope for reachable queries aren't
-    // the same as what's in scope for the outer query.
-    const prevVariables = this._variables;
-    // $FlowFixMe[incompatible-cast]
-    for (const query of (reachableQueries: Array<ReactFlightReachableQuery>)) {
-      this._variables = query.variables;
-      const normalizationRootNode = operationLoader.get(query.module);
-      if (normalizationRootNode != null) {
-        const operation = getOperation(normalizationRootNode);
-        this._traverseSelections(operation.selections, ROOT_ID);
-      } else {
-        // If the fragment is not available, we assume that the data cannot have
-        // been processed yet and must therefore be missing.
+    if (tuple == null) {
+      if (tuple === undefined) {
         this._handleMissing();
       }
+    } else {
+      const [actorIdentifier, linkedID] = tuple;
+      const prevSource = this._source;
+      const prevMutator = this._mutator;
+      const prevRecordSourceProxy = this._recordSourceProxy;
+
+      const [mutator, recordSourceProxy] =
+        this._getMutatorAndRecordProxyForActor(actorIdentifier);
+
+      this._source = this._getSourceForActor(actorIdentifier);
+      this._mutator = mutator;
+      this._recordSourceProxy = recordSourceProxy;
+      this._assignClientAbstractTypes(field);
+      this._traverse(field, linkedID);
+      this._source = prevSource;
+      this._mutator = prevMutator;
+      this._recordSourceProxy = prevRecordSourceProxy;
     }
-    this._variables = prevVariables;
+  }
+
+  // For abstract types defined in the client schema extension, we won't be
+  // getting `__is<AbstractType>` hints from the server. To handle this, the
+  // compiler attaches additional metadata on the normalization artifact,
+  // which we need to record into the store.
+  _assignClientAbstractTypes(node: NormalizationNode) {
+    const {clientAbstractTypes} = node;
+    if (clientAbstractTypes != null) {
+      for (const abstractType of Object.keys(clientAbstractTypes)) {
+        for (const concreteType of clientAbstractTypes[abstractType]) {
+          const typeID = generateTypeID(concreteType);
+          if (this._source.get(typeID) == null) {
+            this._mutator.create(typeID, TYPE_SCHEMA_TYPE);
+          }
+          if (this._mutator.getValue(typeID, abstractType) == null) {
+            this._mutator.setValue(typeID, abstractType, true);
+          }
+        }
+      }
+    }
   }
 }
 

--- a/packages/relay-runtime/store/__tests__/DataChecker-test.js
+++ b/packages/relay-runtime/store/__tests__/DataChecker-test.js
@@ -1,62 +1,88 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
  * @flow strict-local
- * @emails oncall+relay
+ * @format
+ * @oncall relay
  */
 
-// flowlint ambiguous-object-type:error
-
 'use strict';
+import type {NormalizationLinkedField} from '../../util/NormalizationNode';
+import type {ReaderLinkedField} from '../../util/ReaderNode';
+import type {Variables} from '../../util/RelayRuntimeTypes';
+import type {ReadOnlyRecordProxy, RecordSourceJSON} from '../RelayStoreTypes';
+import type {
+  DataCheckerTest6Query$data,
+  DataCheckerTest6Query$variables,
+} from './__generated__/DataCheckerTest6Query.graphql';
+import type {
+  DataCheckerTest9Query$data,
+  DataCheckerTest9Query$variables,
+} from './__generated__/DataCheckerTest9Query.graphql';
+import type {
+  DataCheckerTestQuery$data,
+  DataCheckerTestQuery$variables,
+} from './__generated__/DataCheckerTestQuery.graphql';
+import type {Query as $IMPORTED_TYPE$_Query} from 'relay-runtime/util/RelayRuntimeTypes';
 
-const RelayFeatureFlags = require('../../util/RelayFeatureFlags');
-const RelayModernRecord = require('../RelayModernRecord');
+const {
+  INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+} = require('../../multi-actor-environment/ActorIdentifier');
+const {getRequest, graphql} = require('../../query/GraphQLTag');
+const getRelayHandleKey = require('../../util/getRelayHandleKey');
+const {check} = require('../DataChecker');
+const defaultGetDataID = require('../defaultGetDataID');
+const {createNormalizationSelector} = require('../RelayModernSelector');
 const RelayModernStore = require('../RelayModernStore');
 const RelayRecordSource = require('../RelayRecordSource');
-
-const defaultGetDataID = require('../defaultGetDataID');
-const getRelayHandleKey = require('../../util/getRelayHandleKey');
-
-const {graphql, getRequest} = require('../../query/GraphQLTag');
-const {check} = require('../DataChecker');
-const {createNormalizationSelector} = require('../RelayModernSelector');
 const {ROOT_ID} = require('../RelayStoreUtils');
-const {generateTypeID, TYPE_SCHEMA_TYPE} = require('../TypeID');
+const {TYPE_SCHEMA_TYPE, generateTypeID} = require('../TypeID');
 const {createMockEnvironment} = require('relay-test-utils-internal');
 
 // TODO:
 // You may see some of the "__FlowFixMe__" in the calls to `createNormalizationSelector`.
 // This is because in this test we're relying on similarities between Reader and Normalization nodes during runtime.
-// This is not correct, and Flow is reporting these errors correctly. We need to prioritze fixing this.
+// This is not correct, and Flow is reporting these errors correctly. We need to prioritize fixing this.
 
 describe('check()', () => {
-  let Query;
-  let sampleData;
+  let Query:
+    | $IMPORTED_TYPE$_Query<
+        DataCheckerTest6Query$variables,
+        DataCheckerTest6Query$data,
+      >
+    | $IMPORTED_TYPE$_Query<
+        DataCheckerTest9Query$variables,
+        DataCheckerTest9Query$data,
+      >
+    | $IMPORTED_TYPE$_Query<
+        DataCheckerTestQuery$variables,
+        DataCheckerTestQuery$data,
+      >;
+  let sampleData: RecordSourceJSON;
   beforeEach(() => {
     sampleData = {
       '1': {
         __id: '1',
-        id: '1',
         __typename: 'User',
         firstName: 'Alice',
         'friends(first:3)': {__ref: 'client:1'},
+        id: '1',
         'profilePicture(size:32)': {__ref: 'client:4'},
       },
       '2': {
         __id: '2',
         __typename: 'User',
-        id: '2',
         firstName: 'Bob',
+        id: '2',
       },
       '3': {
         __id: '3',
         __typename: 'User',
-        id: '3',
         firstName: 'Claire',
+        id: '3',
       },
       'client:1': {
         __id: 'client:1',
@@ -122,8 +148,9 @@ describe('check()', () => {
     const source = RelayRecordSource.create(sampleData);
     const target = RelayRecordSource.create();
     const status = check(
-      source,
-      target,
+      () => source,
+      () => target,
+      INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
       createNormalizationSelector(getRequest(Query).operation, ROOT_ID, {
         id: '1',
         size: 32,
@@ -133,27 +160,27 @@ describe('check()', () => {
       defaultGetDataID,
     );
     expect(status).toEqual({
-      status: 'available',
       mostRecentlyInvalidatedAt: null,
+      status: 'available',
     });
     expect(target.size()).toBe(0);
   });
 
   it('reads fragment data', () => {
-    const data = {
+    const data: RecordSourceJSON = {
       '1': {
         __id: '1',
-        id: '1',
         __typename: 'User',
         firstName: 'Alice',
         'friends(first:1)': {__ref: 'client:1'},
+        id: '1',
         'profilePicture(size:32)': {__ref: 'client:3'},
       },
       '2': {
         __id: '2',
         __typename: 'User',
-        id: '2',
         firstName: 'Bob',
+        id: '2',
       },
       'client:1': {
         __id: 'client:1',
@@ -178,7 +205,7 @@ describe('check()', () => {
     const target = RelayRecordSource.create();
     const BarFragment = graphql`
       fragment DataCheckerTestFragment on User
-        @argumentDefinitions(size: {type: "[Int]"}) {
+      @argumentDefinitions(size: {type: "[Int]"}) {
         id
         firstName
         friends(first: 1) {
@@ -196,9 +223,10 @@ describe('check()', () => {
       }
     `;
     const status = check(
-      source,
-      target,
-      createNormalizationSelector((BarFragment: $FlowFixMe), '1', {
+      () => source,
+      () => target,
+      INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+      createNormalizationSelector(BarFragment as $FlowFixMe, '1', {
         size: 32,
       }),
       [],
@@ -206,21 +234,22 @@ describe('check()', () => {
       defaultGetDataID,
     );
     expect(status).toEqual({
-      status: 'available',
       mostRecentlyInvalidatedAt: null,
+      status: 'available',
     });
     expect(target.size()).toBe(0);
   });
 
   it('reads handle fields in fragment', () => {
     const handleKey = getRelayHandleKey('test', null, 'profilePicture');
-    const data = {
+    const data: RecordSourceJSON = {
       '1': {
         __id: '1',
-        id: '1',
         __typename: 'User',
-        'profilePicture(size:32)': {__ref: 'client:1'},
+        // $FlowFixMe[invalid-computed-prop]
         [handleKey]: {__ref: 'client:3'},
+        id: '1',
+        'profilePicture(size:32)': {__ref: 'client:1'},
       },
       'client:1': {
         __id: 'client:2',
@@ -243,26 +272,27 @@ describe('check()', () => {
       }
     `;
     const status = check(
-      source,
-      target,
-      createNormalizationSelector((Fragment: $FlowFixMe), '1', {}),
+      () => source,
+      () => target,
+      INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+      createNormalizationSelector(Fragment as $FlowFixMe, '1', {}),
       [],
       null,
       defaultGetDataID,
     );
     expect(status).toEqual({
-      status: 'available',
       mostRecentlyInvalidatedAt: null,
+      status: 'available',
     });
     expect(target.size()).toBe(0);
   });
 
   it('reads handle fields in fragment and checks missing', () => {
-    const data = {
+    const data: RecordSourceJSON = {
       '1': {
         __id: '1',
-        id: '1',
         __typename: 'User',
+        id: '1',
         'profilePicture(size:32)': {__ref: 'client:1'},
         // missing [handleKey] field
       },
@@ -287,29 +317,31 @@ describe('check()', () => {
       }
     `;
     const status = check(
-      source,
-      target,
-      createNormalizationSelector((Fragment: $FlowFixMe), '1', {}),
+      () => source,
+      () => target,
+      INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+      createNormalizationSelector(Fragment as $FlowFixMe, '1', {}),
       [],
       null,
       defaultGetDataID,
     );
     expect(status).toEqual({
-      status: 'missing',
       mostRecentlyInvalidatedAt: null,
+      status: 'missing',
     });
     expect(target.size()).toBe(0);
   });
 
   it('reads handle fields in fragment and checks missing sub field', () => {
     const handleKey = getRelayHandleKey('test', null, 'profilePicture');
-    const data = {
+    const data: RecordSourceJSON = {
       '1': {
         __id: '1',
-        id: '1',
         __typename: 'User',
-        'profilePicture(size:32)': {__ref: 'client:1'},
+        // $FlowFixMe[invalid-computed-prop]
         [handleKey]: {__ref: 'client:3'},
+        id: '1',
+        'profilePicture(size:32)': {__ref: 'client:1'},
       },
       'client:1': {
         __id: 'client:2',
@@ -332,34 +364,31 @@ describe('check()', () => {
       }
     `;
     const status = check(
-      source,
-      target,
-      createNormalizationSelector((Fragment: $FlowFixMe), '1', {}),
+      () => source,
+      () => target,
+      INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+      createNormalizationSelector(Fragment as $FlowFixMe, '1', {}),
       [],
       null,
       defaultGetDataID,
     );
     expect(status).toEqual({
-      status: 'missing',
       mostRecentlyInvalidatedAt: null,
+      status: 'missing',
     });
     expect(target.size()).toBe(0);
   });
 
   it('reads handle fields in operation', () => {
     const handleKey = getRelayHandleKey('test', null, 'profilePicture');
-    const data = {
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
+    const data: RecordSourceJSON = {
       '1': {
         __id: '1',
-        id: '1',
         __typename: 'User',
-        'profilePicture(size:32)': {__ref: 'client:1'},
+        // $FlowFixMe[invalid-computed-prop]
         [handleKey]: {__ref: 'client:3'},
+        id: '1',
+        'profilePicture(size:32)': {__ref: 'client:1'},
       },
       'client:1': {
         __id: 'client:2',
@@ -370,6 +399,11 @@ describe('check()', () => {
         __id: 'client:2',
         __typename: 'Photo',
         uri: 'https://...',
+      },
+      'client:root': {
+        __id: 'client:root',
+        __typename: '__Root',
+        me: {__ref: '1'},
       },
     };
     const source = RelayRecordSource.create(data);
@@ -387,8 +421,9 @@ describe('check()', () => {
     `;
 
     const status = check(
-      source,
-      target,
+      () => source,
+      () => target,
+      INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
       createNormalizationSelector(
         getRequest(ProfilePictureQuery).operation,
         'client:root',
@@ -399,23 +434,18 @@ describe('check()', () => {
       defaultGetDataID,
     );
     expect(status).toEqual({
-      status: 'available',
       mostRecentlyInvalidatedAt: null,
+      status: 'available',
     });
     expect(target.size()).toBe(0);
   });
 
   it('reads handle fields in operation and checks missing', () => {
-    const data = {
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
+    const data: RecordSourceJSON = {
       '1': {
         __id: '1',
-        id: '1',
         __typename: 'User',
+        id: '1',
         'profilePicture(size:32)': {__ref: 'client:1'},
         // missing [handleKey] field
       },
@@ -428,6 +458,11 @@ describe('check()', () => {
         __id: 'client:2',
         __typename: 'Photo',
         uri: 'https://...',
+      },
+      'client:root': {
+        __id: 'client:root',
+        __typename: '__Root',
+        me: {__ref: '1'},
       },
     };
     const source = RelayRecordSource.create(data);
@@ -444,8 +479,9 @@ describe('check()', () => {
       }
     `;
     const status = check(
-      source,
-      target,
+      () => source,
+      () => target,
+      INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
       createNormalizationSelector(
         getRequest(ProfilePictureQuery).operation,
         'client:root',
@@ -456,26 +492,22 @@ describe('check()', () => {
       defaultGetDataID,
     );
     expect(status).toEqual({
-      status: 'missing',
       mostRecentlyInvalidatedAt: null,
+      status: 'missing',
     });
     expect(target.size()).toBe(0);
   });
 
   it('reads handle fields in operation and checks missing sub field', () => {
     const handleKey = getRelayHandleKey('test', null, 'profilePicture');
-    const data = {
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
+    const data: RecordSourceJSON = {
       '1': {
         __id: '1',
-        id: '1',
         __typename: 'User',
-        'profilePicture(size:32)': {__ref: 'client:1'},
+        // $FlowFixMe[invalid-computed-prop]
         [handleKey]: {__ref: 'client:3'},
+        id: '1',
+        'profilePicture(size:32)': {__ref: 'client:1'},
       },
       'client:1': {
         __id: 'client:2',
@@ -486,6 +518,11 @@ describe('check()', () => {
         __id: 'client:2',
         __typename: 'Photo',
         // uri field is missing
+      },
+      'client:root': {
+        __id: 'client:root',
+        __typename: '__Root',
+        me: {__ref: '1'},
       },
     };
     const source = RelayRecordSource.create(data);
@@ -502,8 +539,9 @@ describe('check()', () => {
       }
     `;
     const status = check(
-      source,
-      target,
+      () => source,
+      () => target,
+      INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
       createNormalizationSelector(
         getRequest(ProfilePictureQuery).operation,
         'client:root',
@@ -514,31 +552,32 @@ describe('check()', () => {
       defaultGetDataID,
     );
     expect(status).toEqual({
-      status: 'missing',
       mostRecentlyInvalidatedAt: null,
+      status: 'missing',
     });
     expect(target.size()).toBe(0);
   });
 
   it('reads scalar handle fields in operation and checks presence', () => {
     const handleKey = getRelayHandleKey('test', null, 'uri');
-    const data = {
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
+    const data: RecordSourceJSON = {
       '1': {
         __id: '1',
-        id: '1',
         __typename: 'User',
+        id: '1',
         'profilePicture(size:32)': {__ref: 'client:1'},
       },
       'client:1': {
         __id: 'client:2',
         __typename: 'Photo',
-        uri: 'https://...',
+        // $FlowFixMe[invalid-computed-prop]
         [handleKey]: 'https://...',
+        uri: 'https://...',
+      },
+      'client:root': {
+        __id: 'client:root',
+        __typename: '__Root',
+        me: {__ref: '1'},
       },
     };
     const source = RelayRecordSource.create(data);
@@ -555,8 +594,9 @@ describe('check()', () => {
       }
     `;
     const status = check(
-      source,
-      target,
+      () => source,
+      () => target,
+      INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
       createNormalizationSelector(
         getRequest(ProfilePictureQuery).operation,
         'client:root',
@@ -567,23 +607,18 @@ describe('check()', () => {
       defaultGetDataID,
     );
     expect(status).toEqual({
-      status: 'available',
       mostRecentlyInvalidatedAt: null,
+      status: 'available',
     });
     expect(target.size()).toBe(0);
   });
 
   it('reads scalar handle fields in operation and checks missing', () => {
-    const data = {
-      'client:root': {
-        __id: 'client:root',
-        __typename: '__Root',
-        me: {__ref: '1'},
-      },
+    const data: RecordSourceJSON = {
       '1': {
         __id: '1',
-        id: '1',
         __typename: 'User',
+        id: '1',
         'profilePicture(size:32)': {__ref: 'client:1'},
       },
       'client:1': {
@@ -591,6 +626,11 @@ describe('check()', () => {
         __typename: 'Photo',
         uri: 'https://...',
         // [handleKey] field is missing
+      },
+      'client:root': {
+        __id: 'client:root',
+        __typename: '__Root',
+        me: {__ref: '1'},
       },
     };
     const source = RelayRecordSource.create(data);
@@ -608,8 +648,9 @@ describe('check()', () => {
     `;
 
     const status = check(
-      source,
-      target,
+      () => source,
+      () => target,
+      INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
       createNormalizationSelector(
         getRequest(ProfilePictureQuery).operation,
         'client:root',
@@ -620,8 +661,8 @@ describe('check()', () => {
       defaultGetDataID,
     );
     expect(status).toEqual({
-      status: 'missing',
       mostRecentlyInvalidatedAt: null,
+      status: 'missing',
     });
     expect(target.size()).toBe(0);
   });
@@ -663,20 +704,23 @@ describe('check()', () => {
       BarQuery = graphql`
         query DataCheckerTest4Query($id: ID!) {
           node(id: $id) {
-            ...DataCheckerTest4Fragment
+            ...DataCheckerTest4Fragment @dangerously_unaliased_fixme
           }
         }
       `;
       const nodes = {
-        DataCheckerTestPlainUserNameRenderer_nameFragment,
         DataCheckerTestMarkdownUserNameRenderer_nameFragment,
+        DataCheckerTestPlainUserNameRenderer_nameFragment,
       };
 
       loader = {
         get: jest.fn(
-          moduleName => nodes[String(moduleName).replace(/\$.*/, '')],
+          (moduleName: unknown) =>
+            // $FlowFixMe[invalid-computed-prop]
+            nodes[String(moduleName).replace(/\$.*/, '')],
         ),
-        load: jest.fn(moduleName =>
+        load: jest.fn((moduleName: unknown) =>
+          // $FlowFixMe[invalid-computed-prop]
           Promise.resolve(nodes[String(moduleName).replace(/\$.*/, '')]),
         ),
       };
@@ -684,26 +728,24 @@ describe('check()', () => {
 
     it('returns true when the match field/record exist and match a supported type (plaintext)', () => {
       // When the type matches PlainUserNameRenderer
-      const storeData = {
+      const storeData: RecordSourceJSON = {
         '1': {
           __id: '1',
-          id: '1',
           __typename: 'User',
-          'nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])': {
-            __ref:
-              'client:1:nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])',
+          id: '1',
+          'nameRenderer(supported:"34hjiS")': {
+            __ref: 'client:1:nameRenderer(supported:"34hjiS")',
           },
         },
-        'client:1:nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])': {
-          __id:
-            'client:1:nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])',
-          __typename: 'PlainUserNameRenderer',
+        'client:1:nameRenderer(supported:"34hjiS")': {
+          __id: 'client:1:nameRenderer(supported:"34hjiS")',
           __module_component_DataCheckerTest4Fragment:
             'PlainUserNameRenderer.react',
           __module_operation_DataCheckerTest4Fragment:
             'DataCheckerTestPlainUserNameRenderer_nameFragment$normalization.graphql',
-          plaintext: 'plain name',
+          __typename: 'PlainUserNameRenderer',
           data: {__ref: 'data'},
+          plaintext: 'plain name',
         },
         'client:root': {
           __id: 'client:root',
@@ -720,8 +762,9 @@ describe('check()', () => {
       const source = RelayRecordSource.create(storeData);
       const target = RelayRecordSource.create();
       const status = check(
-        source,
-        target,
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         createNormalizationSelector(
           getRequest(BarQuery).operation,
           'client:root',
@@ -734,39 +777,36 @@ describe('check()', () => {
         defaultGetDataID,
       );
       expect(loader.get).toBeCalledTimes(1);
-      // $FlowFixMe[prop-missing]
       expect(loader.get.mock.calls[0][0]).toBe(
         'DataCheckerTestPlainUserNameRenderer_nameFragment$normalization.graphql',
       );
       expect(status).toEqual({
-        status: 'available',
         mostRecentlyInvalidatedAt: null,
+        status: 'available',
       });
       expect(target.size()).toBe(0);
     });
 
     it('returns true when the match field/record exist and match a supported type (markdown)', () => {
       // When the type matches MarkdownUserNameRenderer
-      const storeData = {
+      const storeData: RecordSourceJSON = {
         '1': {
           __id: '1',
-          id: '1',
           __typename: 'User',
-          'nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])': {
-            __ref:
-              'client:1:nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])',
+          id: '1',
+          'nameRenderer(supported:"34hjiS")': {
+            __ref: 'client:1:nameRenderer(supported:"34hjiS")',
           },
         },
-        'client:1:nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])': {
-          __id:
-            'client:1:nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])',
-          __typename: 'MarkdownUserNameRenderer',
+        'client:1:nameRenderer(supported:"34hjiS")': {
+          __id: 'client:1:nameRenderer(supported:"34hjiS")',
           __module_component_DataCheckerTest4Fragment:
             'MarkdownUserNameRenderer.react',
           __module_operation_DataCheckerTest4Fragment:
             'DataCheckerTestMarkdownUserNameRenderer_nameFragment$normalization.graphql',
-          markdown: 'markdown payload',
+          __typename: 'MarkdownUserNameRenderer',
           data: {__ref: 'data'},
+          markdown: 'markdown payload',
         },
         'client:root': {
           __id: 'client:root',
@@ -783,8 +823,9 @@ describe('check()', () => {
       const source = RelayRecordSource.create(storeData);
       const target = RelayRecordSource.create();
       const status = check(
-        source,
-        target,
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         createNormalizationSelector(
           getRequest(BarQuery).operation,
           'client:root',
@@ -797,8 +838,8 @@ describe('check()', () => {
         defaultGetDataID,
       );
       expect(status).toEqual({
-        status: 'available',
         mostRecentlyInvalidatedAt: null,
+        status: 'available',
       });
       expect(target.size()).toBe(0);
     });
@@ -807,19 +848,17 @@ describe('check()', () => {
       // The field returned the MarkdownUserNameRenderer type, but the module for that branch
       // has not been loaded. The assumption is that the data cannot have been processed in that
       // case and therefore the markdown field is missing in the store.
-      const storeData = {
+      const storeData: RecordSourceJSON = {
         '1': {
           __id: '1',
-          id: '1',
           __typename: 'User',
-          'nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])': {
-            __ref:
-              'client:1:nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])',
+          id: '1',
+          'nameRenderer(supported:"34hjiS")': {
+            __ref: 'client:1:nameRenderer(supported:"34hjiS")',
           },
         },
-        'client:1:nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])': {
-          __id:
-            'client:1:nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])',
+        'client:1:nameRenderer(supported:"34hjiS")': {
+          __id: 'client:1:nameRenderer(supported:"34hjiS")',
           __typename: 'MarkdownUserNameRenderer',
           // NOTE: markdown/data fields are missing, data not processed.
         },
@@ -832,8 +871,9 @@ describe('check()', () => {
       const source = RelayRecordSource.create(storeData);
       const target = RelayRecordSource.create();
       const status = check(
-        source,
-        target,
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         createNormalizationSelector(
           getRequest(BarQuery).operation,
           'client:root',
@@ -851,27 +891,25 @@ describe('check()', () => {
       );
       // The data for the field isn't in the store yet, so we have to return false
       expect(status).toEqual({
-        status: 'missing',
         mostRecentlyInvalidatedAt: null,
+        status: 'missing',
       });
       expect(target.size()).toBe(0);
     });
 
     it('returns false when the match field/record exist but a scalar field is missing', () => {
       // the `data` field for the MarkdownUserNameRenderer is missing
-      const storeData = {
+      const storeData: RecordSourceJSON = {
         '1': {
           __id: '1',
-          id: '1',
           __typename: 'User',
-          'nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])': {
-            __ref:
-              'client:1:nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])',
+          id: '1',
+          'nameRenderer(supported:"34hjiS")': {
+            __ref: 'client:1:nameRenderer(supported:"34hjiS")',
           },
         },
-        'client:1:nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])': {
-          __id:
-            'client:1:nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])',
+        'client:1:nameRenderer(supported:"34hjiS")': {
+          __id: 'client:1:nameRenderer(supported:"34hjiS")',
           __typename: 'MarkdownUserNameRenderer',
           // NOTE: 'markdown' field missing
           data: {__ref: 'data'},
@@ -891,8 +929,9 @@ describe('check()', () => {
       const source = RelayRecordSource.create(storeData);
       const target = RelayRecordSource.create();
       const status = check(
-        source,
-        target,
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         createNormalizationSelector(
           getRequest(BarQuery).operation,
           'client:root',
@@ -906,27 +945,25 @@ describe('check()', () => {
       );
       // The data for the field 'data' isn't in the store yet, so we have to return false
       expect(status).toEqual({
-        status: 'missing',
         mostRecentlyInvalidatedAt: null,
+        status: 'missing',
       });
       expect(target.size()).toBe(0);
     });
 
     it('returns false when the match field/record exist but a linked field is missing', () => {
       // the `data` field for the MarkdownUserNameRenderer is missing
-      const storeData = {
+      const storeData: RecordSourceJSON = {
         '1': {
           __id: '1',
-          id: '1',
           __typename: 'User',
-          'nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])': {
-            __ref:
-              'client:1:nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])',
+          id: '1',
+          'nameRenderer(supported:"34hjiS")': {
+            __ref: 'client:1:nameRenderer(supported:"34hjiS")',
           },
         },
-        'client:1:nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])': {
-          __id:
-            'client:1:nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])',
+        'client:1:nameRenderer(supported:"34hjiS")': {
+          __id: 'client:1:nameRenderer(supported:"34hjiS")',
           __typename: 'MarkdownUserNameRenderer',
           markdown: 'markdown text',
           // NOTE: 'data' field missing
@@ -940,8 +977,9 @@ describe('check()', () => {
       const source = RelayRecordSource.create(storeData);
       const target = RelayRecordSource.create();
       const status = check(
-        source,
-        target,
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         createNormalizationSelector(
           getRequest(BarQuery).operation,
           'client:root',
@@ -955,26 +993,24 @@ describe('check()', () => {
       );
       // The data for the field 'data' isn't in the store yet, so we have to return false
       expect(status).toEqual({
-        status: 'missing',
         mostRecentlyInvalidatedAt: null,
+        status: 'missing',
       });
       expect(target.size()).toBe(0);
     });
 
     it('returns true when the match field/record exist but do not match a supported type', () => {
-      const storeData = {
+      const storeData: RecordSourceJSON = {
         '1': {
           __id: '1',
-          id: '1',
           __typename: 'User',
-          'nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])': {
-            __ref:
-              'client:1:nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])',
+          id: '1',
+          'nameRenderer(supported:"34hjiS")': {
+            __ref: 'client:1:nameRenderer(supported:"34hjiS")',
           },
         },
-        'client:1:nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])': {
-          __id:
-            'client:1:nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])',
+        'client:1:nameRenderer(supported:"34hjiS")': {
+          __id: 'client:1:nameRenderer(supported:"34hjiS")',
           __typename: 'CustomNameRenderer',
           customField: 'custom value',
         },
@@ -987,8 +1023,9 @@ describe('check()', () => {
       const source = RelayRecordSource.create(storeData);
       const target = RelayRecordSource.create();
       const status = check(
-        source,
-        target,
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         createNormalizationSelector(
           getRequest(BarQuery).operation,
           'client:root',
@@ -1001,19 +1038,19 @@ describe('check()', () => {
         defaultGetDataID,
       );
       expect(status).toEqual({
-        status: 'available',
         mostRecentlyInvalidatedAt: null,
+        status: 'available',
       });
       expect(target.size()).toBe(0);
     });
 
     it('returns true when the match field is non-existent (null)', () => {
-      const storeData = {
+      const storeData: RecordSourceJSON = {
         '1': {
           __id: '1',
-          id: '1',
           __typename: 'User',
-          'nameRenderer(supported:["PlainUserNameRenderer","MarkdownUserNameRenderer"])': null,
+          id: '1',
+          'nameRenderer(supported:"34hjiS")': null,
         },
         'client:root': {
           __id: 'client:root',
@@ -1024,8 +1061,9 @@ describe('check()', () => {
       const source = RelayRecordSource.create(storeData);
       const target = RelayRecordSource.create();
       const status = check(
-        source,
-        target,
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         createNormalizationSelector(
           getRequest(BarQuery).operation,
           'client:root',
@@ -1038,18 +1076,18 @@ describe('check()', () => {
         defaultGetDataID,
       );
       expect(status).toEqual({
-        status: 'available',
         mostRecentlyInvalidatedAt: null,
+        status: 'available',
       });
       expect(target.size()).toBe(0);
     });
 
     it('returns false when the match field is not fetched (undefined)', () => {
-      const storeData = {
+      const storeData: RecordSourceJSON = {
         '1': {
           __id: '1',
-          id: '1',
           __typename: 'User',
+          id: '1',
         },
         'client:root': {
           __id: 'client:root',
@@ -1060,8 +1098,9 @@ describe('check()', () => {
       const source = RelayRecordSource.create(storeData);
       const target = RelayRecordSource.create();
       const status = check(
-        source,
-        target,
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         createNormalizationSelector(
           getRequest(BarQuery).operation,
           'client:root',
@@ -1074,8 +1113,8 @@ describe('check()', () => {
         defaultGetDataID,
       );
       expect(status).toEqual({
-        status: 'missing',
         mostRecentlyInvalidatedAt: null,
+        status: 'missing',
       });
       expect(target.size()).toBe(0);
     });
@@ -1118,20 +1157,23 @@ describe('check()', () => {
       BarQuery = graphql`
         query DataCheckerTest5Query($id: ID!) {
           node(id: $id) {
-            ...DataCheckerTest5Fragment
+            ...DataCheckerTest5Fragment @dangerously_unaliased_fixme
           }
         }
       `;
       const nodes = {
-        DataCheckerTest5PlainUserNameRenderer_name,
         DataCheckerTest5MarkdownUserNameRenderer_name,
+        DataCheckerTest5PlainUserNameRenderer_name,
       };
 
       loader = {
         get: jest.fn(
-          moduleName => nodes[String(moduleName).replace(/\$.*/, '')],
+          (moduleName: unknown) =>
+            // $FlowFixMe[invalid-computed-prop]
+            nodes[String(moduleName).replace(/\$.*/, '')],
         ),
-        load: jest.fn(moduleName =>
+        load: jest.fn((moduleName: unknown) =>
+          // $FlowFixMe[invalid-computed-prop]
           Promise.resolve(nodes[String(moduleName).replace(/\$.*/, '')]),
         ),
       };
@@ -1139,24 +1181,24 @@ describe('check()', () => {
 
     it('returns true when the field/record exists and matches the @module type (plaintext)', () => {
       // When the type matches PlainUserNameRenderer
-      const storeData = {
+      const storeData: RecordSourceJSON = {
         '1': {
           __id: '1',
-          id: '1',
           __typename: 'User',
+          id: '1',
           nameRenderer: {
             __ref: 'client:1:nameRenderer',
           },
         },
         'client:1:nameRenderer': {
           __id: 'client:1:nameRenderer',
-          __typename: 'PlainUserNameRenderer',
           __module_component_DataCheckerTest5Fragment:
             'PlainUserNameRenderer.react',
           __module_operation_DataCheckerTest5Fragment:
             'DataCheckerTest5PlainUserNameRenderer_name$normalization.graphql',
-          plaintext: 'plain name',
+          __typename: 'PlainUserNameRenderer',
           data: {__ref: 'data'},
+          plaintext: 'plain name',
         },
         'client:root': {
           __id: 'client:root',
@@ -1173,8 +1215,9 @@ describe('check()', () => {
       const source = RelayRecordSource.create(storeData);
       const target = RelayRecordSource.create();
       const status = check(
-        source,
-        target,
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         createNormalizationSelector(
           getRequest(BarQuery).operation,
           'client:root',
@@ -1187,37 +1230,36 @@ describe('check()', () => {
         defaultGetDataID,
       );
       expect(loader.get).toBeCalledTimes(1);
-      // $FlowFixMe[prop-missing]
       expect(loader.get.mock.calls[0][0]).toBe(
         'DataCheckerTest5PlainUserNameRenderer_name$normalization.graphql',
       );
       expect(status).toEqual({
-        status: 'available',
         mostRecentlyInvalidatedAt: null,
+        status: 'available',
       });
       expect(target.size()).toBe(0);
     });
 
     it('returns true when the field/record exist and matches the @module type (markdown)', () => {
       // When the type matches MarkdownUserNameRenderer
-      const storeData = {
+      const storeData: RecordSourceJSON = {
         '1': {
           __id: '1',
-          id: '1',
           __typename: 'User',
+          id: '1',
           nameRenderer: {
             __ref: 'client:1:nameRenderer',
           },
         },
         'client:1:nameRenderer': {
           __id: 'client:1:nameRenderer',
-          __typename: 'MarkdownUserNameRenderer',
           __module_component_DataCheckerTest5Fragment:
             'MarkdownUserNameRenderer.react',
           __module_operation_DataCheckerTest5Fragment:
             'DataCheckerTest5MarkdownUserNameRenderer_name$normalization.graphql',
-          markdown: 'markdown payload',
+          __typename: 'MarkdownUserNameRenderer',
           data: {__ref: 'data'},
+          markdown: 'markdown payload',
         },
         'client:root': {
           __id: 'client:root',
@@ -1234,8 +1276,9 @@ describe('check()', () => {
       const source = RelayRecordSource.create(storeData);
       const target = RelayRecordSource.create();
       const status = check(
-        source,
-        target,
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         createNormalizationSelector(
           getRequest(BarQuery).operation,
           'client:root',
@@ -1248,8 +1291,8 @@ describe('check()', () => {
         defaultGetDataID,
       );
       expect(status).toEqual({
-        status: 'available',
         mostRecentlyInvalidatedAt: null,
+        status: 'available',
       });
       expect(target.size()).toBe(0);
     });
@@ -1258,11 +1301,11 @@ describe('check()', () => {
       // The field returned the MarkdownUserNameRenderer type, but the module for that branch
       // has not been loaded. The assumption is that the data cannot have been processed in that
       // case and therefore the markdown field is missing in the store.
-      const storeData = {
+      const storeData: RecordSourceJSON = {
         '1': {
           __id: '1',
-          id: '1',
           __typename: 'User',
+          id: '1',
           nameRenderer: {
             __ref: 'client:1:nameRenderer',
           },
@@ -1281,8 +1324,9 @@ describe('check()', () => {
       const source = RelayRecordSource.create(storeData);
       const target = RelayRecordSource.create();
       const status = check(
-        source,
-        target,
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         createNormalizationSelector(
           getRequest(BarQuery).operation,
           'client:root',
@@ -1300,19 +1344,19 @@ describe('check()', () => {
       );
       // The data for the field isn't in the store yet, so we have to return false
       expect(status).toEqual({
-        status: 'missing',
         mostRecentlyInvalidatedAt: null,
+        status: 'missing',
       });
       expect(target.size()).toBe(0);
     });
 
     it('returns false when the field/record exists but a scalar field is missing', () => {
       // the `data` field for the MarkdownUserNameRenderer is missing
-      const storeData = {
+      const storeData: RecordSourceJSON = {
         '1': {
           __id: '1',
-          id: '1',
           __typename: 'User',
+          id: '1',
           nameRenderer: {
             __ref: 'client:1:nameRenderer',
           },
@@ -1338,8 +1382,9 @@ describe('check()', () => {
       const source = RelayRecordSource.create(storeData);
       const target = RelayRecordSource.create();
       const status = check(
-        source,
-        target,
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         createNormalizationSelector(
           getRequest(BarQuery).operation,
           'client:root',
@@ -1353,19 +1398,19 @@ describe('check()', () => {
       );
       // The data for the field 'data' isn't in the store yet, so we have to return false
       expect(status).toEqual({
-        status: 'missing',
         mostRecentlyInvalidatedAt: null,
+        status: 'missing',
       });
       expect(target.size()).toBe(0);
     });
 
     it('returns false when the field/record exists but a linked field is missing', () => {
       // the `data` field for the MarkdownUserNameRenderer is missing
-      const storeData = {
+      const storeData: RecordSourceJSON = {
         '1': {
           __id: '1',
-          id: '1',
           __typename: 'User',
+          id: '1',
           nameRenderer: {
             __ref: 'client:1:nameRenderer',
           },
@@ -1385,8 +1430,9 @@ describe('check()', () => {
       const source = RelayRecordSource.create(storeData);
       const target = RelayRecordSource.create();
       const status = check(
-        source,
-        target,
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         createNormalizationSelector(
           getRequest(BarQuery).operation,
           'client:root',
@@ -1400,18 +1446,18 @@ describe('check()', () => {
       );
       // The data for the field 'data' isn't in the store yet, so we have to return false
       expect(status).toEqual({
-        status: 'missing',
         mostRecentlyInvalidatedAt: null,
+        status: 'missing',
       });
       expect(target.size()).toBe(0);
     });
 
     it('returns true when the field/record exists but does not match any @module selection', () => {
-      const storeData = {
+      const storeData: RecordSourceJSON = {
         '1': {
           __id: '1',
-          id: '1',
           __typename: 'User',
+          id: '1',
           nameRenderer: {
             __ref: 'client:1:nameRenderer',
           },
@@ -1430,8 +1476,9 @@ describe('check()', () => {
       const source = RelayRecordSource.create(storeData);
       const target = RelayRecordSource.create();
       const status = check(
-        source,
-        target,
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         createNormalizationSelector(
           getRequest(BarQuery).operation,
           'client:root',
@@ -1444,8 +1491,8 @@ describe('check()', () => {
         defaultGetDataID,
       );
       expect(status).toEqual({
-        status: 'available',
         mostRecentlyInvalidatedAt: null,
+        status: 'available',
       });
       expect(target.size()).toBe(0);
     });
@@ -1463,14 +1510,16 @@ describe('check()', () => {
       Query = graphql`
         query DataCheckerTest9Query($id: ID!) {
           node(id: $id) {
-            ...DataCheckerTest6Fragment @defer(label: "TestFragment")
+            ...DataCheckerTest6Fragment
+              @dangerously_unaliased_fixme
+              @defer(label: "TestFragment")
           }
         }
       `;
     });
 
     it('returns true when deferred selections are fetched', () => {
-      const storeData = {
+      const storeData: RecordSourceJSON = {
         '1': {
           __id: '1',
           __typename: 'User',
@@ -1486,8 +1535,9 @@ describe('check()', () => {
       const source = RelayRecordSource.create(storeData);
       const target = RelayRecordSource.create();
       const status = check(
-        source,
-        target,
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         createNormalizationSelector(
           getRequest(Query).operation,
           'client:root',
@@ -1498,19 +1548,19 @@ describe('check()', () => {
         defaultGetDataID,
       );
       expect(status).toEqual({
-        status: 'available',
         mostRecentlyInvalidatedAt: null,
+        status: 'available',
       });
       expect(target.size()).toBe(0);
     });
 
-    it('returns false when deferred selections are not fetched', () => {
-      const storeData = {
+    it('returns available when deferred selections are not fetched (defer is active)', () => {
+      const storeData: RecordSourceJSON = {
         '1': {
           __id: '1',
           __typename: 'User',
           id: '1',
-          // 'name' not fetched
+          // 'name' not fetched — but defer is active so this is expected
         },
         'client:root': {
           __id: 'client:root',
@@ -1521,8 +1571,9 @@ describe('check()', () => {
       const source = RelayRecordSource.create(storeData);
       const target = RelayRecordSource.create();
       const status = check(
-        source,
-        target,
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         createNormalizationSelector(
           getRequest(Query).operation,
           'client:root',
@@ -1533,10 +1584,296 @@ describe('check()', () => {
         defaultGetDataID,
       );
       expect(status).toEqual({
-        status: 'missing',
         mostRecentlyInvalidatedAt: null,
+        status: 'available',
       });
       expect(target.size()).toBe(0);
+    });
+  });
+
+  describe('when @defer directive with if variable is present', () => {
+    let ConditionalDeferQuery: $IMPORTED_TYPE$_Query<any, any>;
+
+    beforeEach(() => {
+      graphql`
+        fragment DataCheckerTestDeferIfFragment on User {
+          id
+          name
+        }
+      `;
+
+      ConditionalDeferQuery = graphql`
+        query DataCheckerTestDeferIfQuery($id: ID!, $shouldDefer: Boolean!) {
+          node(id: $id) {
+            ...DataCheckerTestDeferIfFragment
+              @dangerously_unaliased_fixme
+              @defer(if: $shouldDefer, label: "TestFragment")
+          }
+        }
+      `;
+    });
+
+    it('returns available when deferred selections are missing and defer is active (if: true)', () => {
+      const storeData: RecordSourceJSON = {
+        '1': {
+          __id: '1',
+          __typename: 'User',
+          id: '1',
+          // 'name' not fetched — defer is active so this is expected
+        },
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+          'node(id:"1")': {__ref: '1'},
+        },
+      };
+      const source = RelayRecordSource.create(storeData);
+      const target = RelayRecordSource.create();
+      const status = check(
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+        createNormalizationSelector(
+          getRequest(ConditionalDeferQuery).operation,
+          'client:root',
+          {id: '1', shouldDefer: true},
+        ),
+        [],
+        null,
+        defaultGetDataID,
+      );
+      expect(status).toEqual({
+        mostRecentlyInvalidatedAt: null,
+        status: 'available',
+      });
+    });
+
+    it('returns missing when deferred selections are missing and defer is inactive (if: false)', () => {
+      const storeData: RecordSourceJSON = {
+        '1': {
+          __id: '1',
+          __typename: 'User',
+          id: '1',
+          // 'name' not fetched — defer is inactive so this is genuinely missing
+        },
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+          'node(id:"1")': {__ref: '1'},
+        },
+      };
+      const source = RelayRecordSource.create(storeData);
+      const target = RelayRecordSource.create();
+      const status = check(
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+        createNormalizationSelector(
+          getRequest(ConditionalDeferQuery).operation,
+          'client:root',
+          {id: '1', shouldDefer: false},
+        ),
+        [],
+        null,
+        defaultGetDataID,
+      );
+      expect(status).toEqual({
+        mostRecentlyInvalidatedAt: null,
+        status: 'missing',
+      });
+    });
+
+    it('returns available when all data is present regardless of defer variable', () => {
+      const storeData: RecordSourceJSON = {
+        '1': {
+          __id: '1',
+          __typename: 'User',
+          id: '1',
+          name: 'Alice',
+        },
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+          'node(id:"1")': {__ref: '1'},
+        },
+      };
+      const source = RelayRecordSource.create(storeData);
+      const target = RelayRecordSource.create();
+
+      // Both should return available when data is present
+      const statusTrue = check(
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+        createNormalizationSelector(
+          getRequest(ConditionalDeferQuery).operation,
+          'client:root',
+          {id: '1', shouldDefer: true},
+        ),
+        [],
+        null,
+        defaultGetDataID,
+      );
+      expect(statusTrue).toEqual({
+        mostRecentlyInvalidatedAt: null,
+        status: 'available',
+      });
+
+      const statusFalse = check(
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+        createNormalizationSelector(
+          getRequest(ConditionalDeferQuery).operation,
+          'client:root',
+          {id: '1', shouldDefer: false},
+        ),
+        [],
+        null,
+        defaultGetDataID,
+      );
+      expect(statusFalse).toEqual({
+        mostRecentlyInvalidatedAt: null,
+        status: 'available',
+      });
+    });
+  });
+
+  describe('when @defer contains client extension fields', () => {
+    let DeferWithClientExtQuery;
+
+    beforeEach(() => {
+      graphql`
+        fragment DataCheckerTestDeferClientExtFragment on User {
+          id
+          name
+          nickname
+        }
+      `;
+
+      DeferWithClientExtQuery = graphql`
+        query DataCheckerTestDeferClientExtQuery($id: ID!) {
+          node(id: $id) {
+            ...DataCheckerTestDeferClientExtFragment
+              @dangerously_unaliased_fixme
+              @defer(label: "TestFragment")
+          }
+        }
+      `;
+    });
+
+    it('returns available when server fields present but client extension fields missing (defer active)', () => {
+      // This is the production bug scenario: streaming completed, server
+      // fields are in the store, but client extension fields (like nickname)
+      // are legitimately absent. Without the fix, the missing client extension
+      // field inside the @defer block leaks "missing" to the overall check.
+      const storeData: RecordSourceJSON = {
+        '1': {
+          __id: '1',
+          __typename: 'User',
+          id: '1',
+          name: 'Alice',
+          // 'nickname' is a client extension field — never server-delivered
+        },
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+          'node(id:"1")': {__ref: '1'},
+        },
+      };
+      const source = RelayRecordSource.create(storeData);
+      const target = RelayRecordSource.create();
+      const status = check(
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+        createNormalizationSelector(
+          getRequest(DeferWithClientExtQuery).operation,
+          'client:root',
+          {id: '1'},
+        ),
+        [],
+        null,
+        defaultGetDataID,
+      );
+      expect(status).toEqual({
+        mostRecentlyInvalidatedAt: null,
+        status: 'available',
+      });
+    });
+
+    it('returns available when all fields missing inside active defer', () => {
+      // Before the incremental payload arrives: all fields in the defer block
+      // are missing (both server and client extension). Since defer is active,
+      // this should not cause check() to report "missing".
+      const storeData: RecordSourceJSON = {
+        '1': {
+          __id: '1',
+          __typename: 'User',
+          id: '1',
+          // no 'name', no 'nickname' — defer hasn't delivered yet
+        },
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+          'node(id:"1")': {__ref: '1'},
+        },
+      };
+      const source = RelayRecordSource.create(storeData);
+      const target = RelayRecordSource.create();
+      const status = check(
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+        createNormalizationSelector(
+          getRequest(DeferWithClientExtQuery).operation,
+          'client:root',
+          {id: '1'},
+        ),
+        [],
+        null,
+        defaultGetDataID,
+      );
+      expect(status).toEqual({
+        mostRecentlyInvalidatedAt: null,
+        status: 'available',
+      });
+    });
+
+    it('returns available when all fields present including client extension', () => {
+      const storeData: RecordSourceJSON = {
+        '1': {
+          __id: '1',
+          __typename: 'User',
+          id: '1',
+          name: 'Alice',
+          nickname: 'Ali',
+        },
+        'client:root': {
+          __id: 'client:root',
+          __typename: '__Root',
+          'node(id:"1")': {__ref: '1'},
+        },
+      };
+      const source = RelayRecordSource.create(storeData);
+      const target = RelayRecordSource.create();
+      const status = check(
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+        createNormalizationSelector(
+          getRequest(DeferWithClientExtQuery).operation,
+          'client:root',
+          {id: '1'},
+        ),
+        [],
+        null,
+        defaultGetDataID,
+      );
+      expect(status).toEqual({
+        mostRecentlyInvalidatedAt: null,
+        status: 'available',
+      });
     });
   });
 
@@ -1553,19 +1890,19 @@ describe('check()', () => {
       Query = graphql`
         query DataCheckerTest6Query($id: ID!) {
           node(id: $id) {
-            ...DataCheckerTest7Fragment
+            ...DataCheckerTest7Fragment @dangerously_unaliased_fixme
           }
         }
       `;
     });
 
     it('returns true when streamed selections are fetched', () => {
-      const storeData = {
+      const storeData: RecordSourceJSON = {
         '1': {
           __id: '1',
           __typename: 'Feedback',
-          id: '1',
           actors: {__refs: ['2']},
+          id: '1',
         },
         '2': {
           __id: '2',
@@ -1582,8 +1919,9 @@ describe('check()', () => {
       const source = RelayRecordSource.create(storeData);
       const target = RelayRecordSource.create();
       const status = check(
-        source,
-        target,
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         createNormalizationSelector(
           getRequest(Query).operation,
           'client:root',
@@ -1594,19 +1932,19 @@ describe('check()', () => {
         defaultGetDataID,
       );
       expect(status).toEqual({
-        status: 'available',
         mostRecentlyInvalidatedAt: null,
+        status: 'available',
       });
       expect(target.size()).toBe(0);
     });
 
     it('returns false when streamed selections are not fetched', () => {
-      const storeData = {
+      const storeData: RecordSourceJSON = {
         '1': {
           __id: '1',
           __typename: 'Feedback',
-          id: '1',
           actors: {__refs: ['2']},
+          id: '1',
         },
         '2': {
           __id: '2',
@@ -1623,8 +1961,9 @@ describe('check()', () => {
       const source = RelayRecordSource.create(storeData);
       const target = RelayRecordSource.create();
       const status = check(
-        source,
-        target,
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         createNormalizationSelector(
           getRequest(Query).operation,
           'client:root',
@@ -1635,8 +1974,8 @@ describe('check()', () => {
         defaultGetDataID,
       );
       expect(status).toEqual({
-        status: 'missing',
         mostRecentlyInvalidatedAt: null,
+        status: 'missing',
       });
       expect(target.size()).toBe(0);
     });
@@ -1647,8 +1986,9 @@ describe('check()', () => {
       const source = RelayRecordSource.create(sampleData);
       const target = RelayRecordSource.create();
       const status = check(
-        source,
-        target,
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         createNormalizationSelector(getRequest(Query).operation, ROOT_ID, {
           id: '1',
           size: 32,
@@ -1658,8 +1998,8 @@ describe('check()', () => {
         defaultGetDataID,
       );
       expect(status).toEqual({
-        status: 'available',
         mostRecentlyInvalidatedAt: null,
+        status: 'available',
       });
       expect(target.size()).toBe(0);
     });
@@ -1667,12 +2007,12 @@ describe('check()', () => {
 
   describe('when some data is missing', () => {
     it('returns missing on missing records', () => {
-      const data = {
+      const data: RecordSourceJSON = {
         '1': {
           __id: '1',
-          id: '1',
           __typename: 'User',
           firstName: 'Alice',
+          id: '1',
           'profilePicture(size:32)': {__ref: 'client:3'},
         },
         // missing profilePicture record
@@ -1681,7 +2021,7 @@ describe('check()', () => {
       const target = RelayRecordSource.create();
       const BarFragment = graphql`
         fragment DataCheckerTest8Fragment on User
-          @argumentDefinitions(size: {type: "[Int]"}) {
+        @argumentDefinitions(size: {type: "[Int]"}) {
           id
           firstName
           profilePicture(size: $size) {
@@ -1690,27 +2030,28 @@ describe('check()', () => {
         }
       `;
       const status = check(
-        source,
-        target,
-        createNormalizationSelector((BarFragment: $FlowFixMe), '1', {size: 32}),
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+        createNormalizationSelector(BarFragment as $FlowFixMe, '1', {size: 32}),
         [],
         null,
         defaultGetDataID,
       );
       expect(status).toEqual({
-        status: 'missing',
         mostRecentlyInvalidatedAt: null,
+        status: 'missing',
       });
       expect(target.size()).toBe(0);
     });
 
     it('returns missing on missing fields', () => {
-      const data = {
+      const data: RecordSourceJSON = {
         '1': {
           __id: '1',
-          id: '1',
           __typename: 'User',
           firstName: 'Alice',
+          id: '1',
           'profilePicture(size:32)': {__ref: 'client:3'},
         },
         'client:3': {
@@ -1722,7 +2063,7 @@ describe('check()', () => {
       const target = RelayRecordSource.create();
       const BarFragment = graphql`
         fragment DataCheckerTest9Fragment on User
-          @argumentDefinitions(size: {type: "[Int]"}) {
+        @argumentDefinitions(size: {type: "[Int]"}) {
           id
           firstName
           profilePicture(size: $size) {
@@ -1731,27 +2072,28 @@ describe('check()', () => {
         }
       `;
       const status = check(
-        source,
-        target,
-        createNormalizationSelector((BarFragment: $FlowFixMe), '1', {size: 32}),
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+        createNormalizationSelector(BarFragment as $FlowFixMe, '1', {size: 32}),
         [],
         null,
         defaultGetDataID,
       );
       expect(status).toEqual({
-        status: 'missing',
         mostRecentlyInvalidatedAt: null,
+        status: 'missing',
       });
       expect(target.size()).toBe(0);
     });
 
     it('allows handlers to supplement missing scalar fields', () => {
-      const data = {
+      const data: RecordSourceJSON = {
         '1': {
           __id: '1',
-          id: '1',
           __typename: 'User',
           firstName: 'Alice',
+          id: '1',
           'profilePicture(size:32)': {__ref: 'client:3'},
         },
         'client:3': {
@@ -1764,7 +2106,7 @@ describe('check()', () => {
       const target = RelayRecordSource.create();
       const BarFragment = graphql`
         fragment DataCheckerTest10Fragment on User
-          @argumentDefinitions(size: {type: "[Int]"}) {
+        @argumentDefinitions(size: {type: "[Int]"}) {
           id
           firstName
           profilePicture(size: $size) {
@@ -1773,23 +2115,24 @@ describe('check()', () => {
         }
       `;
       const status = check(
-        source,
-        target,
-        createNormalizationSelector((BarFragment: $FlowFixMe), '1', {size: 32}),
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+        createNormalizationSelector(BarFragment as $FlowFixMe, '1', {size: 32}),
         [
           {
-            kind: 'scalar',
             handle: (field, record, argValues) => {
               return 'thebestimage.uri';
             },
+            kind: 'scalar',
           },
         ],
         null,
         defaultGetDataID,
       );
       expect(status).toEqual({
-        status: 'available',
         mostRecentlyInvalidatedAt: null,
+        status: 'available',
       });
       expect(target.toJSON()).toEqual({
         'client:3': {
@@ -1804,66 +2147,66 @@ describe('check()', () => {
       [
         'undefined',
         {
+          expectedStatus: {mostRecentlyInvalidatedAt: null, status: 'missing'},
           handleReturnValue: undefined,
-          expectedStatus: {status: 'missing', mostRecentlyInvalidatedAt: null},
           updatedHometown: undefined,
         },
       ],
       [
         'null',
         {
-          handleReturnValue: null,
           expectedStatus: {
-            status: 'available',
             mostRecentlyInvalidatedAt: null,
+            status: 'available',
           },
+          handleReturnValue: null,
           updatedHometown: null,
         },
       ],
       [
         "'hometown-exists'",
         {
-          handleReturnValue: 'hometown-exists',
           expectedStatus: {
-            status: 'available',
             mostRecentlyInvalidatedAt: null,
+            status: 'available',
           },
+          handleReturnValue: 'hometown-exists',
           updatedHometown: 'hometown-exists',
         },
       ],
       [
         "'hometown-deleted'",
         {
+          expectedStatus: {mostRecentlyInvalidatedAt: null, status: 'missing'},
           handleReturnValue: 'hometown-deleted',
-          expectedStatus: {status: 'missing', mostRecentlyInvalidatedAt: null},
           updatedHometown: undefined,
         },
       ],
       [
         "'hometown-unknown'",
         {
+          expectedStatus: {mostRecentlyInvalidatedAt: null, status: 'missing'},
           handleReturnValue: 'hometown-unknown',
-          expectedStatus: {status: 'missing', mostRecentlyInvalidatedAt: null},
           updatedHometown: undefined,
         },
       ],
     ])(
       'linked field handler handler that returns %s',
       (_name, {handleReturnValue, expectedStatus, updatedHometown}) => {
-        const data = {
-          user1: {
-            __id: 'user1',
-            id: 'user1',
-            __typename: 'User',
-            firstName: 'Alice',
-            // hometown: missing
-          },
+        const data: RecordSourceJSON = {
+          'hometown-deleted': null,
           'hometown-exists': {
             __id: 'hometown',
             __typename: 'Page',
             name: 'New York City',
           },
-          'hometown-deleted': null,
+          user1: {
+            __id: 'user1',
+            __typename: 'User',
+            firstName: 'Alice',
+            id: 'user1',
+            // hometown: missing
+          },
         };
         const source = RelayRecordSource.create(data);
         const target = RelayRecordSource.create();
@@ -1874,17 +2217,25 @@ describe('check()', () => {
             }
           }
         `;
-        const handle = jest.fn((field, record, argValues) => {
-          return handleReturnValue;
-        });
+        const handle = jest.fn(
+          (
+            field: NormalizationLinkedField | ReaderLinkedField,
+            record: ?ReadOnlyRecordProxy,
+            argValues: Variables,
+          ) => {
+            return handleReturnValue;
+          },
+        );
         const status = check(
-          source,
-          target,
-          createNormalizationSelector((UserFragment: $FlowFixMe), 'user1', {}),
+          () => source,
+          () => target,
+          INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+          createNormalizationSelector(UserFragment as $FlowFixMe, 'user1', {}),
           [
+            // $FlowFixMe[invalid-tuple-arity] Error found while enabling LTI on this file
             {
-              kind: 'linked',
               handle,
+              kind: 'linked',
             },
           ],
           null,
@@ -1896,22 +2247,22 @@ describe('check()', () => {
           updatedHometown === undefined
             ? {}
             : updatedHometown === null
-            ? {
-                user1: {
-                  __id: 'user1',
-                  __typename: 'User',
-                  hometown: null,
-                },
-              }
-            : {
-                user1: {
-                  __id: 'user1',
-                  __typename: 'User',
-                  hometown: {
-                    __ref: updatedHometown,
+              ? {
+                  user1: {
+                    __id: 'user1',
+                    __typename: 'User',
+                    hometown: null,
+                  },
+                }
+              : {
+                  user1: {
+                    __id: 'user1',
+                    __typename: 'User',
+                    hometown: {
+                      __ref: updatedHometown,
+                    },
                   },
                 },
-              },
         );
       },
     );
@@ -1920,101 +2271,101 @@ describe('check()', () => {
       [
         'undefined',
         {
+          expectedStatus: {mostRecentlyInvalidatedAt: null, status: 'missing'},
           handleReturnValue: undefined,
-          expectedStatus: {status: 'missing', mostRecentlyInvalidatedAt: null},
           updatedScreennames: undefined,
         },
       ],
       [
         'null',
         {
-          handleReturnValue: null,
           expectedStatus: {
-            status: 'available',
             mostRecentlyInvalidatedAt: null,
+            status: 'available',
           },
+          handleReturnValue: null,
           updatedScreennames: null,
         },
       ],
       [
         '[]',
         {
-          handleReturnValue: [],
           expectedStatus: {
-            status: 'available',
             mostRecentlyInvalidatedAt: null,
+            status: 'available',
           },
+          handleReturnValue: [],
           updatedScreennames: [],
         },
       ],
       [
         '[undefined]',
         {
+          expectedStatus: {mostRecentlyInvalidatedAt: null, status: 'missing'},
           handleReturnValue: [undefined],
-          expectedStatus: {status: 'missing', mostRecentlyInvalidatedAt: null},
           updatedScreennames: undefined,
         },
       ],
       [
         '[null]',
         {
+          expectedStatus: {mostRecentlyInvalidatedAt: null, status: 'missing'},
           handleReturnValue: [null],
-          expectedStatus: {status: 'missing', mostRecentlyInvalidatedAt: null},
           updatedScreennames: undefined,
         },
       ],
       [
         "['screenname-exists']",
         {
-          handleReturnValue: ['screenname-exists'],
           expectedStatus: {
-            status: 'available',
             mostRecentlyInvalidatedAt: null,
+            status: 'available',
           },
+          handleReturnValue: ['screenname-exists'],
           updatedScreennames: ['screenname-exists'],
         },
       ],
       [
         "['screenname-deleted']",
         {
+          expectedStatus: {mostRecentlyInvalidatedAt: null, status: 'missing'},
           handleReturnValue: ['screenname-deleted'],
-          expectedStatus: {status: 'missing', mostRecentlyInvalidatedAt: null},
           updatedScreennames: undefined,
         },
       ],
       [
         "['screenname-unknown']",
         {
+          expectedStatus: {mostRecentlyInvalidatedAt: null, status: 'missing'},
           handleReturnValue: ['screenname-unknown'],
-          expectedStatus: {status: 'missing', mostRecentlyInvalidatedAt: null},
           updatedScreennames: undefined,
         },
       ],
       [
         "['screenname-exists', 'screenname-unknown']",
         {
+          expectedStatus: {mostRecentlyInvalidatedAt: null, status: 'missing'},
           handleReturnValue: ['screenname-exists', 'screenname-unknown'],
-          expectedStatus: {status: 'missing', mostRecentlyInvalidatedAt: null},
           updatedScreennames: undefined,
         },
       ],
     ])(
       'plural linked field handler handler that returns %s',
       (_name, {handleReturnValue, expectedStatus, updatedScreennames}) => {
-        const data = {
-          user1: {
-            __id: 'user1',
-            id: 'user1',
-            __typename: 'User',
-            firstName: 'Alice',
-            // screennames: missing
-          },
+        const data: RecordSourceJSON = {
+          'screenname-deleted': null,
           'screenname-exists': {
             __id: 'screenname-exists',
             __typename: 'Screenname',
             name: 'Bert',
           },
-          'screenname-deleted': null,
+          user1: {
+            __id: 'user1',
+            __typename: 'User',
+            firstName: 'Alice',
+            id: 'user1',
+            // screennames: missing
+          },
         };
         const source = RelayRecordSource.create(data);
         const target = RelayRecordSource.create();
@@ -2025,17 +2376,26 @@ describe('check()', () => {
             }
           }
         `;
-        const handle = jest.fn((field, record, argValues) => {
-          return handleReturnValue;
-        });
+        const handle = jest.fn(
+          (
+            field: NormalizationLinkedField | ReaderLinkedField,
+            record: ?ReadOnlyRecordProxy,
+            argValues: Variables,
+          ) => {
+            return handleReturnValue;
+          },
+        );
         const status = check(
-          source,
-          target,
-          createNormalizationSelector((UserFragment: $FlowFixMe), 'user1', {}),
+          () => source,
+          () => target,
+          INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+          createNormalizationSelector(UserFragment as $FlowFixMe, 'user1', {}),
           [
+            // $FlowFixMe[invalid-tuple-arity] Error found while enabling LTI on this file
+            // $FlowFixMe[incompatible-type]
             {
-              kind: 'pluralLinked',
               handle,
+              kind: 'pluralLinked',
             },
           ],
           null,
@@ -2047,37 +2407,37 @@ describe('check()', () => {
           updatedScreennames === undefined
             ? {}
             : updatedScreennames === null
-            ? {
-                user1: {
-                  __id: 'user1',
-                  __typename: 'User',
-                  screennames: null,
-                },
-              }
-            : {
-                user1: {
-                  __id: 'user1',
-                  __typename: 'User',
-                  screennames: {
-                    __refs: updatedScreennames,
+              ? {
+                  user1: {
+                    __id: 'user1',
+                    __typename: 'User',
+                    screennames: null,
+                  },
+                }
+              : {
+                  user1: {
+                    __id: 'user1',
+                    __typename: 'User',
+                    screennames: {
+                      __refs: updatedScreennames,
+                    },
                   },
                 },
-              },
         );
       },
     );
 
     it('returns modified records with the target', () => {
-      const data = {
+      const data: RecordSourceJSON = {
         '1': {
           __id: '1',
-          id: '1',
           __typename: 'User',
+          id: '1',
         },
         profile_1_32: {
           __id: 'profile_1_32',
-          id: 'profile_1_32',
           __typename: 'Profile',
+          id: 'profile_1_32',
           uri: 'thebestimage.uri',
         },
       };
@@ -2085,7 +2445,7 @@ describe('check()', () => {
       const target = RelayRecordSource.create();
       const BarFragment = graphql`
         fragment DataCheckerTest13Fragment on User
-          @argumentDefinitions(size: {type: "[Int]"}) {
+        @argumentDefinitions(size: {type: "[Int]"}) {
           id
           firstName
           profilePicture(size: $size) {
@@ -2094,26 +2454,26 @@ describe('check()', () => {
         }
       `;
       const status = check(
-        source,
-        target,
-        createNormalizationSelector((BarFragment: $FlowFixMe), '1', {size: 32}),
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+        createNormalizationSelector(BarFragment as $FlowFixMe, '1', {size: 32}),
         [
           {
-            kind: 'scalar',
             handle: (field, record, argValues) => {
               if (
                 record &&
-                RelayModernRecord.getDataID(record) === '1' &&
+                record?.getDataID() === '1' &&
                 field.name === 'firstName'
               ) {
                 return 'Alice';
               }
             },
+            kind: 'scalar',
           },
           {
-            kind: 'linked',
             handle: (field, record, argValues) => {
-              const id = record && RelayModernRecord.getDataID(record);
+              const id = record?.getDataID();
               if (
                 field.name === 'profilePicture' &&
                 record &&
@@ -2122,14 +2482,15 @@ describe('check()', () => {
                 return `profile_${id}_${argValues.size}`;
               }
             },
+            kind: 'linked',
           },
         ],
         null,
         defaultGetDataID,
       );
       expect(status).toEqual({
-        status: 'available',
         mostRecentlyInvalidatedAt: null,
+        status: 'available',
       });
       expect(target.toJSON()).toEqual({
         '1': {
@@ -2142,12 +2503,12 @@ describe('check()', () => {
     });
 
     it('returns available even when client field is missing', () => {
-      const data = {
+      const data: RecordSourceJSON = {
         '1': {
           __id: '1',
-          id: '1',
           __typename: 'User',
           firstName: 'Alice',
+          id: '1',
           'profilePicture(size:32)': {__ref: 'client:3'},
         },
       };
@@ -2155,7 +2516,7 @@ describe('check()', () => {
       const target = RelayRecordSource.create();
       const BarFragment = graphql`
         fragment DataCheckerTest14Fragment on User
-          @argumentDefinitions(size: {type: "[Int]"}) {
+        @argumentDefinitions(size: {type: "[Int]"}) {
           id
           firstName
           client_actor_field
@@ -2191,16 +2552,17 @@ describe('check()', () => {
         }
       `;
       const status = check(
-        source,
-        target,
-        createNormalizationSelector((BarFragment: $FlowFixMe), '1', {size: 32}),
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+        createNormalizationSelector(BarFragment as $FlowFixMe, '1', {size: 32}),
         [],
         null,
         defaultGetDataID,
       );
       expect(status).toEqual({
-        status: 'available',
         mostRecentlyInvalidatedAt: null,
+        status: 'available',
       });
       expect(target.size()).toBe(0);
     });
@@ -2225,8 +2587,9 @@ describe('check()', () => {
         });
 
         const status = check(
-          source,
-          target,
+          () => source,
+          () => target,
+          INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
           createNormalizationSelector(getRequest(Query).operation, ROOT_ID, {
             id: '1',
             size: 32,
@@ -2238,8 +2601,8 @@ describe('check()', () => {
 
         // Assert mostRecentlyInvalidatedAt matches most recent invalidation epoch
         expect(status).toEqual({
-          status: 'available',
           mostRecentlyInvalidatedAt: 1,
+          status: 'available',
         });
         expect(target.size()).toBe(0);
       });
@@ -2261,8 +2624,9 @@ describe('check()', () => {
         });
 
         const status = check(
-          source,
-          target,
+          () => source,
+          () => target,
+          INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
           createNormalizationSelector(getRequest(Query).operation, ROOT_ID, {
             id: '1',
             size: 32,
@@ -2274,8 +2638,8 @@ describe('check()', () => {
 
         // Assert mostRecentlyInvalidatedAt matches most recent invalidation epoch
         expect(status).toEqual({
-          status: 'available',
           mostRecentlyInvalidatedAt: 1,
+          status: 'available',
         });
         expect(target.size()).toBe(0);
 
@@ -2289,8 +2653,9 @@ describe('check()', () => {
         });
 
         const nextStatus = check(
-          source,
-          target,
+          () => source,
+          () => target,
+          INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
           createNormalizationSelector(getRequest(Query).operation, ROOT_ID, {
             id: '1',
             size: 32,
@@ -2302,8 +2667,8 @@ describe('check()', () => {
 
         // Assert mostRecentlyInvalidatedAt matches most recent invalidation epoch
         expect(nextStatus).toEqual({
-          status: 'available',
           mostRecentlyInvalidatedAt: 2,
+          status: 'available',
         });
         expect(target.size()).toBe(0);
       });
@@ -2313,6 +2678,7 @@ describe('check()', () => {
       beforeEach(() => {
         sampleData = {
           ...sampleData,
+          // $FlowFixMe[prop-missing]
           'client:4': {
             __id: 'client:4',
             __typename: 'Photo',
@@ -2338,8 +2704,9 @@ describe('check()', () => {
         });
 
         const status = check(
-          source,
-          target,
+          () => source,
+          () => target,
+          INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
           createNormalizationSelector(getRequest(Query).operation, ROOT_ID, {
             id: '1',
             size: 32,
@@ -2351,8 +2718,8 @@ describe('check()', () => {
 
         // Assert result is missing
         expect(status).toEqual({
-          status: 'missing',
           mostRecentlyInvalidatedAt: 1,
+          status: 'missing',
         });
         expect(target.size()).toBe(0);
       });
@@ -2374,8 +2741,9 @@ describe('check()', () => {
         });
 
         const status = check(
-          source,
-          target,
+          () => source,
+          () => target,
+          INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
           createNormalizationSelector(getRequest(Query).operation, ROOT_ID, {
             id: '1',
             size: 32,
@@ -2387,8 +2755,8 @@ describe('check()', () => {
 
         // Assert that result is missing
         expect(status).toEqual({
-          status: 'missing',
           mostRecentlyInvalidatedAt: 1,
+          status: 'missing',
         });
         expect(target.size()).toBe(0);
 
@@ -2402,8 +2770,9 @@ describe('check()', () => {
         });
 
         const nextStatus = check(
-          source,
-          target,
+          () => source,
+          () => target,
+          INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
           createNormalizationSelector(getRequest(Query).operation, ROOT_ID, {
             id: '1',
             size: 32,
@@ -2415,21 +2784,22 @@ describe('check()', () => {
 
         // Assert that result is still missing
         expect(nextStatus).toEqual({
-          status: 'missing',
           mostRecentlyInvalidatedAt: 2,
+          status: 'missing',
         });
         expect(target.size()).toBe(0);
       });
 
       it('returns null invalidation epoch when stale record is unreachable', () => {
+        // $FlowFixMe[prop-missing]
         sampleData = {
           // Root record is missing, so none of the descendants are reachable
           '1': {
             __id: '1',
-            id: '1',
             __typename: 'User',
             firstName: 'Alice',
             'friends(first:3)': {__ref: 'client:1'},
+            id: '1',
             'profilePicture(size:32)': {__ref: 'client:4'},
           },
           'client:1': {
@@ -2439,6 +2809,7 @@ describe('check()', () => {
               __refs: [],
             },
           },
+          // $FlowFixMe[prop-missing]
           'client:4': {
             __id: 'client:4',
             __typename: 'Photo',
@@ -2461,8 +2832,9 @@ describe('check()', () => {
         });
 
         const status = check(
-          source,
-          target,
+          () => source,
+          () => target,
+          INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
           createNormalizationSelector(getRequest(Query).operation, ROOT_ID, {
             id: '1',
             size: 32,
@@ -2474,60 +2846,12 @@ describe('check()', () => {
 
         // Assert that result is missing
         expect(status).toEqual({
-          status: 'missing',
           mostRecentlyInvalidatedAt: null,
+          status: 'missing',
         });
         expect(target.size()).toBe(0);
       });
     });
-  });
-
-  it('returns true when a non-Node record is "missing" an id', () => {
-    const TestFragment = graphql`
-      fragment DataCheckerTest15Fragment on Query {
-        maybeNodeInterface {
-          # This "... on Node { id }" selection would be generated if not present
-          ... on Node {
-            id
-          }
-          ... on NonNodeNoID {
-            name
-          }
-        }
-      }
-    `;
-    const data = {
-      'client:root': {
-        __id: 'client:root',
-        __typename: 'Query',
-        maybeNodeInterface: {__ref: 'client:root:maybeNodeInterface'},
-      },
-      'client:root:maybeNodeInterface': {
-        __id: 'client:root:maybeNodeInterface',
-        __typename: 'NonNodeNoID',
-        __isNode: false,
-        name: 'Alice',
-      },
-    };
-    const source = RelayRecordSource.create(data);
-    const target = RelayRecordSource.create();
-    const status = check(
-      source,
-      target,
-      createNormalizationSelector(
-        (TestFragment: $FlowFixMe),
-        'client:root',
-        {},
-      ),
-      [],
-      null,
-      defaultGetDataID,
-    );
-    expect(status).toEqual({
-      status: 'available',
-      mostRecentlyInvalidatedAt: null,
-    });
-    expect(target.size()).toBe(0);
   });
 
   it('returns false when a Node record is missing an id', () => {
@@ -2546,26 +2870,27 @@ describe('check()', () => {
       }
     `;
 
-    const data = {
-      'client:root': {
-        __id: 'client:root',
-        __typename: 'Query',
-        maybeNodeInterface: {__ref: '1'},
-      },
+    const data: RecordSourceJSON = {
       '1': {
         __id: '1',
         __typename: 'User',
         name: 'Alice',
         // no `id` value
       },
+      'client:root': {
+        __id: 'client:root',
+        __typename: 'Query',
+        maybeNodeInterface: {__ref: '1'},
+      },
     };
     const source = RelayRecordSource.create(data);
     const target = RelayRecordSource.create();
     const status = check(
-      source,
-      target,
+      () => source,
+      () => target,
+      INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
       createNormalizationSelector(
-        (TestFragment: $FlowFixMe),
+        TestFragment as $FlowFixMe,
         'client:root',
         {},
       ),
@@ -2574,20 +2899,13 @@ describe('check()', () => {
       defaultGetDataID,
     );
     expect(status).toEqual({
-      status: 'missing',
       mostRecentlyInvalidatedAt: null,
+      status: 'missing',
     });
     expect(target.size()).toBe(0);
   });
 
-  describe('with feature ENABLE_PRECISE_TYPE_REFINEMENT', () => {
-    beforeEach(() => {
-      RelayFeatureFlags.ENABLE_PRECISE_TYPE_REFINEMENT = true;
-    });
-    afterEach(() => {
-      RelayFeatureFlags.ENABLE_PRECISE_TYPE_REFINEMENT = false;
-    });
-
+  describe('precise type refinement', () => {
     it('returns `missing` when a Node record is missing an id', () => {
       const TestFragment = graphql`
         fragment DataCheckerTest17Fragment on Query {
@@ -2603,27 +2921,34 @@ describe('check()', () => {
         }
       `;
 
-      const data = {
+      const typeID = generateTypeID('User');
+      const data: RecordSourceJSON = {
+        '1': {
+          __id: '1',
+          __typename: 'User',
+          name: 'Alice',
+          // no `id` value
+        },
         'client:root': {
           __id: 'client:root',
           __typename: 'Query',
           maybeNodeInterface: {__ref: '1'},
         },
-        '1': {
-          __id: '1',
-          __typename: 'User',
+        // $FlowFixMe[invalid-computed-prop]
+        [typeID]: {
+          __id: typeID,
           __isNode: true,
-          name: 'Alice',
-          // no `id` value
+          __typename: TYPE_SCHEMA_TYPE,
         },
       };
       const source = RelayRecordSource.create(data);
       const target = RelayRecordSource.create();
       const status = check(
-        source,
-        target,
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         createNormalizationSelector(
-          (TestFragment: $FlowFixMe),
+          TestFragment as $FlowFixMe,
           'client:root',
           {},
         ),
@@ -2632,8 +2957,8 @@ describe('check()', () => {
         defaultGetDataID,
       );
       expect(status).toEqual({
-        status: 'missing',
         mostRecentlyInvalidatedAt: null,
+        status: 'missing',
       });
       expect(target.size()).toBe(0);
     });
@@ -2652,27 +2977,34 @@ describe('check()', () => {
         }
       `;
 
-      const data = {
+      const typeID = generateTypeID('User');
+      const data: RecordSourceJSON = {
+        '1': {
+          __id: '1',
+          __typename: 'User',
+          id: '1',
+          name: 'Alice',
+        },
         'client:root': {
           __id: 'client:root',
           __typename: 'Query',
           maybeNodeInterface: {__ref: '1'},
         },
-        '1': {
-          __id: '1',
-          __typename: 'User',
+        // $FlowFixMe[invalid-computed-prop]
+        [typeID]: {
+          __id: typeID,
+          __typename: TYPE_SCHEMA_TYPE,
           // __isNode: true, // dont know if it implements Node or not
-          name: 'Alice',
-          id: '1',
         },
       };
       const source = RelayRecordSource.create(data);
       const target = RelayRecordSource.create();
       const status = check(
-        source,
-        target,
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         createNormalizationSelector(
-          (TestFragment: $FlowFixMe),
+          TestFragment as $FlowFixMe,
           'client:root',
           {},
         ),
@@ -2681,8 +3013,8 @@ describe('check()', () => {
         defaultGetDataID,
       );
       expect(status).toEqual({
-        status: 'missing',
         mostRecentlyInvalidatedAt: null,
+        status: 'missing',
       });
       expect(target.size()).toBe(0);
     });
@@ -2703,31 +3035,33 @@ describe('check()', () => {
       `;
 
       const typeID = generateTypeID('NonNodeNoID');
-      const data = {
-        'client:root': {
-          __id: 'client:root',
-          __typename: 'Query',
-          maybeNodeInterface: {__ref: '1'},
-        },
+      const data: RecordSourceJSON = {
         '1': {
           __id: '1',
           __typename: 'NonNodeNoID',
           // no 'id' bc not a Node
           name: 'Not a Node!',
         },
+        'client:root': {
+          __id: 'client:root',
+          __typename: 'Query',
+          maybeNodeInterface: {__ref: '1'},
+        },
+        // $FlowFixMe[invalid-computed-prop]
         [typeID]: {
           __id: typeID,
-          __typename: TYPE_SCHEMA_TYPE,
           __isNode: false,
+          __typename: TYPE_SCHEMA_TYPE,
         },
       };
       const source = RelayRecordSource.create(data);
       const target = RelayRecordSource.create();
       const status = check(
-        source,
-        target,
+        () => source,
+        () => target,
+        INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
         createNormalizationSelector(
-          (TestFragment: $FlowFixMe),
+          TestFragment as $FlowFixMe,
           'client:root',
           {},
         ),
@@ -2736,306 +3070,260 @@ describe('check()', () => {
         defaultGetDataID,
       );
       expect(status).toEqual({
-        status: 'available',
         mostRecentlyInvalidatedAt: null,
+        status: 'available',
       });
       expect(target.size()).toBe(0);
     });
   });
 
-  describe('with feature ENABLE_REACT_FLIGHT_COMPONENT_FIELD', () => {
-    let FlightQuery;
-    let InnerQuery;
-    let operationLoader;
-
-    const readRoot = () => {
-      return {
-        $$typeof: Symbol.for('react.element'),
-        type: 'div',
-        key: null,
-        ref: null,
-        props: {foo: 1},
-      };
-    };
-
-    beforeEach(() => {
-      RelayFeatureFlags.ENABLE_REACT_FLIGHT_COMPONENT_FIELD = true;
-
-      FlightQuery = graphql`
-        query DataCheckerTestFlightQuery($id: ID!, $count: Int!) {
-          node(id: $id) {
-            ... on Story {
-              flightComponent(condition: true, count: $count, id: $id)
-            }
-          }
+  it('should assign client-only abstract type information to the target source', () => {
+    graphql`
+      fragment DataCheckerTestClient2Interface on ClientInterface {
+        description
+      }
+    `;
+    const clientQuery = graphql`
+      query DataCheckerTestClient2AbstractQuery {
+        client_interface {
+          ...DataCheckerTestClient2Interface
         }
-      `;
-      InnerQuery = graphql`
-        query DataCheckerTestInnerQuery($id: ID!) {
-          node(id: $id) {
-            ... on User {
+      }
+    `;
+    const source = RelayRecordSource.create();
+    const target = RelayRecordSource.create();
+    check(
+      () => source,
+      () => target,
+      INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+      createNormalizationSelector(
+        getRequest(clientQuery).operation,
+        'client:root',
+        {},
+      ),
+      [],
+      null,
+      defaultGetDataID,
+    );
+    expect(target.toJSON()).toEqual({
+      'client:__type:ClientTypeImplementingClientInterface': {
+        __id: 'client:__type:ClientTypeImplementingClientInterface',
+        __isClientInterface: true,
+        __typename: '__TypeSchema',
+      },
+      'client:__type:OtherClientTypeImplementingClientInterface': {
+        __id: 'client:__type:OtherClientTypeImplementingClientInterface',
+        __isClientInterface: true,
+        __typename: '__TypeSchema',
+      },
+    });
+  });
+
+  it('should assign client-only abstract type information to the target source if it is not available in the source', () => {
+    graphql`
+      fragment DataCheckerTestClientInterface on ClientInterface {
+        description
+      }
+    `;
+    const clientQuery = graphql`
+      query DataCheckerTestClientAbstractQuery {
+        client_interface {
+          ...DataCheckerTestClientInterface
+        }
+      }
+    `;
+    const source = RelayRecordSource.create({
+      'client:__type:ClientTypeImplementingClientInterface': {
+        __id: 'client:__type:ClientTypeImplementingClientInterface',
+        __isClientInterface: true,
+        __typename: '__TypeSchema',
+      },
+      'client:__type:OtherClientTypeImplementingClientInterface': {
+        __id: 'client:__type:OtherClientTypeImplementingClientInterface',
+        __isClientInterface: true,
+        __typename: '__TypeSchema',
+      },
+      'client:root': {
+        __id: 'client:root',
+        __typename: '__Root',
+        client_interface: {__ref: 'object-1'},
+      },
+      'object-1': {
+        __id: 'object-1',
+        __typename: 'ClientTypeImplementingClientInterface',
+        id: 'object-1',
+      },
+    });
+    const target = RelayRecordSource.create();
+    check(
+      () => source,
+      () => target,
+      INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+      createNormalizationSelector(
+        getRequest(clientQuery).operation,
+        'client:root',
+        {},
+      ),
+      [],
+      null,
+      defaultGetDataID,
+    );
+    expect(target.toJSON()).toEqual({});
+  });
+
+  describe('exec time resolvers', () => {
+    describe('client query', () => {
+      const Query = graphql`
+        query DataCheckerTestExecQuery @exec_time_resolvers {
+          RelayReaderExecResolversTest_user_one {
+            name
+            best_friend {
               name
+              best_friend {
+                name
+              }
             }
           }
         }
       `;
 
-      operationLoader = {
-        get: jest.fn(() => getRequest(InnerQuery)),
-        load: jest.fn(() => Promise.resolve(getRequest(InnerQuery))),
-      };
-    });
-    afterEach(() => {
-      RelayFeatureFlags.ENABLE_REACT_FLIGHT_COMPONENT_FIELD = false;
+      it('should return available when all data is available', () => {
+        const source = RelayRecordSource.create({
+          '1': {
+            __id: '1',
+            best_friend: {__ref: '2'},
+            name: 'Alice',
+          },
+          '2': {
+            __id: '2',
+            best_fried: {__ref: '3'},
+            name: 'Bob',
+          },
+          '3': {
+            __id: '3',
+            name: 'Zuck',
+          },
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            RelayReaderExecResolversTest_user_one: {__ref: '1'},
+          },
+        });
+        const target = RelayRecordSource.create();
+        const status = check(
+          () => source,
+          () => target,
+          INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+          createNormalizationSelector(getRequest(Query).operation, ROOT_ID, {}),
+          [],
+          null,
+          defaultGetDataID,
+        );
+        expect(status.status).toBe('available');
+      });
+
+      it('should return available when only client data is missing', () => {
+        const source = RelayRecordSource.create({
+          '1': {
+            __id: '1',
+            best_friend: {__ref: '2'},
+            name: 'Alice',
+          },
+          '2': {
+            __id: '2',
+            best_fried: undefined,
+            name: 'Bob',
+          },
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            RelayReaderExecResolversTest_user_one: {__ref: '1'},
+          },
+        });
+        const target = RelayRecordSource.create();
+        const status = check(
+          () => source,
+          () => target,
+          INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+          createNormalizationSelector(getRequest(Query).operation, ROOT_ID, {}),
+          [],
+          null,
+          defaultGetDataID,
+        );
+        expect(status.status).toBe('available');
+      });
     });
 
-    it('returns available when the Flight field is fetched', () => {
-      const data = {
-        '1': {
-          __id: '1',
-          __typename: 'Story',
-          'flight(component:"FlightComponent.server",props:{"condition":true,"count":10,"id":"1"})': {
-            __ref:
-              'client:1:flight(component:"FlightComponent.server",props:{"condition":true,"count":10,"id":"1"})',
+    describe('server and client query', () => {
+      const Query = graphql`
+        query DataCheckerTestExecWithServerDataQuery @exec_time_resolvers {
+          RelayReaderExecResolversTest_user_one {
+            name
+            best_friend {
+              name
+              best_friend {
+                name
+              }
+            }
+          }
+          me {
+            name
+          }
+        }
+      `;
+      it('should return available when server data is available', () => {
+        const source = RelayRecordSource.create({
+          '0': {
+            __id: '0',
+            id: '0',
+            name: 'Zuck',
           },
-          id: '1',
-        },
-        '2': {
-          __id: '2',
-          __typename: 'User',
-          id: '2',
-          name: 'Lauren',
-        },
-        'client:1:flight(component:"FlightComponent.server",props:{"condition":true,"count":10,"id":"1"})': {
-          __id:
-            'client:1:flight(component:"FlightComponent.server",props:{"condition":true,"count":10,"id":"1"})',
-          __typename: 'ReactFlightComponent',
-          queries: [
-            {
-              module: {
-                __dr: 'RelayFlightExampleQuery.graphql',
-              },
-              variables: {
-                id: '2',
-              },
-            },
-          ],
-          tree: {
-            readRoot,
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            RelayReaderExecResolversTest_user_one: undefined,
+            me: {__ref: '0'},
           },
-        },
-        'client:root': {
-          __id: 'client:root',
-          __typename: '__Root',
-          'node(id:"1")': {
-            __ref: '1',
-          },
-          'node(id:"2")': {
-            __ref: '2',
-          },
-        },
-      };
-      const source = RelayRecordSource.create(data);
-      const target = RelayRecordSource.create();
-      const status = check(
-        source,
-        target,
-        createNormalizationSelector(
-          getRequest(FlightQuery).operation,
-          ROOT_ID,
-          {
-            count: 10,
-            id: '1',
-          },
-        ),
-        [],
-        operationLoader,
-        defaultGetDataID,
-      );
-      expect(status).toEqual({
-        status: 'available',
-        mostRecentlyInvalidatedAt: null,
+        });
+        const target = RelayRecordSource.create();
+        const status = check(
+          () => source,
+          () => target,
+          INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+          createNormalizationSelector(getRequest(Query).operation, ROOT_ID, {}),
+          [],
+          null,
+          defaultGetDataID,
+        );
+        expect(status.status).toBe('available');
       });
-      expect(target.size()).toBe(0);
-    });
 
-    it('returns missing when the Flight field exists but has not been processed', () => {
-      const data = {
-        '1': {
-          __id: '1',
-          __typename: 'Story',
-          'flight(component:"FlightComponent.server",props:{"condition":true,"count":10,"id":"1"})': {
-            __ref:
-              'client:1:flight(component:"FlightComponent.server",props:{"condition":true,"count":10,"id":"1"})',
+      it('should return missing when server data is missing', () => {
+        const source = RelayRecordSource.create({
+          '0': {
+            __id: '0',
+            id: '0',
+            name: undefined,
           },
-          id: '1',
-        },
-        'client:1:flight(component:"FlightComponent.server",props:{"condition":true,"count":10,"id":"1"})': {
-          __id:
-            'client:1:flight(component:"FlightComponent.server",props:{"condition":true,"count":10,"id":"1"})',
-          __typename: 'ReactFlightComponent',
-        },
-        'client:root': {
-          __id: 'client:root',
-          __typename: '__Root',
-          'node(id:"1")': {
-            __ref: '1',
+          'client:root': {
+            __id: 'client:root',
+            __typename: '__Root',
+            RelayReaderExecResolversTest_user_one: undefined,
+            me: {__ref: '0'},
           },
-        },
-      };
-      const source = RelayRecordSource.create(data);
-      const target = RelayRecordSource.create();
-      const status = check(
-        source,
-        target,
-        createNormalizationSelector(
-          getRequest(FlightQuery).operation,
-          ROOT_ID,
-          {
-            count: 10,
-            id: '1',
-          },
-        ),
-        [],
-        operationLoader,
-        defaultGetDataID,
-      );
-      expect(status).toEqual({
-        status: 'missing',
-        mostRecentlyInvalidatedAt: null,
+        });
+        const target = RelayRecordSource.create();
+        const status = check(
+          () => source,
+          () => target,
+          INTERNAL_ACTOR_IDENTIFIER_DO_NOT_USE,
+          createNormalizationSelector(getRequest(Query).operation, ROOT_ID, {}),
+          [],
+          null,
+          defaultGetDataID,
+        );
+        expect(status.status).toBe('missing');
       });
-      expect(target.size()).toBe(0);
-    });
-
-    it('returns missing when the Flight field is null in the store', () => {
-      const data = {
-        '1': {
-          __id: '1',
-          __typename: 'Story',
-          'flight(component:"FlightComponent.server",props:{"condition":true,"count":10,"id":"1"})': {
-            __ref:
-              'client:1:flight(component:"FlightComponent.server",props:{"condition":true,"count":10,"id":"1"})',
-          },
-          id: '1',
-        },
-        'client:1:flight(component:"FlightComponent.server",props:{"condition":true,"count":10,"id":"1"})': null,
-        'client:root': {
-          __id: 'client:root',
-          __typename: '__Root',
-          'node(id:"1")': {
-            __ref: '1',
-          },
-        },
-      };
-      const source = RelayRecordSource.create(data);
-      const target = RelayRecordSource.create();
-      const status = check(
-        source,
-        target,
-        createNormalizationSelector(
-          getRequest(FlightQuery).operation,
-          ROOT_ID,
-          {
-            count: 10,
-            id: '1',
-          },
-        ),
-        [],
-        operationLoader,
-        defaultGetDataID,
-      );
-      expect(status).toEqual({
-        status: 'missing',
-        mostRecentlyInvalidatedAt: null,
-      });
-      expect(target.size()).toBe(0);
-    });
-
-    it('returns missing when the Flight field is undefined in the store', () => {
-      const data = {
-        '1': {
-          __id: '1',
-          __typename: 'Story',
-          'flight(component:"FlightComponent.server",props:{"condition":true,"count":10,"id":"1"})': {
-            __ref:
-              'client:1:flight(component:"FlightComponent.server",props:{"condition":true,"count":10,"id":"1"})',
-          },
-          id: '1',
-        },
-        'client:1:flight(component:"FlightComponent.server",props:{"condition":true,"count":10,"id":"1"})': undefined,
-        'client:root': {
-          __id: 'client:root',
-          __typename: '__Root',
-          'node(id:"1")': {
-            __ref: '1',
-          },
-        },
-      };
-      const source = RelayRecordSource.create(data);
-      const target = RelayRecordSource.create();
-      const status = check(
-        source,
-        target,
-        createNormalizationSelector(
-          getRequest(FlightQuery).operation,
-          ROOT_ID,
-          {
-            count: 10,
-            id: '1',
-          },
-        ),
-        [],
-        operationLoader,
-        defaultGetDataID,
-      );
-      expect(status).toEqual({
-        status: 'missing',
-        mostRecentlyInvalidatedAt: null,
-      });
-      expect(target.size()).toBe(0);
-    });
-
-    it('returns missing when the linked ReactFlightClientResponseRecord is missing', () => {
-      const data = {
-        '1': {
-          __id: '1',
-          __typename: 'Story',
-          'flight(component:"FlightComponent.server",props:{"condition":true,"count":10,"id":"1"})': {
-            __ref:
-              'client:1:flight(component:"FlightComponent.server",props:{"condition":true,"count":10,"id":"1"})',
-          },
-          id: '1',
-        },
-        'client:root': {
-          __id: 'client:root',
-          __typename: '__Root',
-          'node(id:"1")': {
-            __ref: '1',
-          },
-        },
-      };
-      const source = RelayRecordSource.create(data);
-      const target = RelayRecordSource.create();
-      const status = check(
-        source,
-        target,
-        createNormalizationSelector(
-          getRequest(FlightQuery).operation,
-          ROOT_ID,
-          {
-            count: 10,
-            id: '1',
-          },
-        ),
-        [],
-        operationLoader,
-        defaultGetDataID,
-      );
-      expect(status).toEqual({
-        status: 'missing',
-        mostRecentlyInvalidatedAt: null,
-      });
-      expect(target.size()).toBe(0);
     });
   });
 });

--- a/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDefer-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernEnvironment-ExecuteWithDefer-test.js
@@ -1,323 +1,384 @@
 /**
- * Copyright (c) Facebook, Inc. and its affiliates.
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @format
  * @flow strict-local
- * @emails oncall+relay
+ * @format
+ * @oncall relay
  */
 
-// flowlint ambiguous-object-type:error
-
 'use strict';
-
-const RelayModernEnvironment = require('../RelayModernEnvironment');
-const RelayModernStore = require('../RelayModernStore');
-const RelayNetwork = require('../../network/RelayNetwork');
-const RelayObservable = require('../../network/RelayObservable');
-const RelayRecordSource = require('../RelayRecordSource');
-
-const warning = require('warning');
+import type {
+  GraphQLResponse,
+  PayloadExtensions,
+} from 'relay-runtime/network/RelayNetworkTypes';
+import type {Sink} from 'relay-runtime/network/RelayObservable';
+import type {
+  HandleFieldPayload,
+  RecordSourceProxy,
+  Snapshot,
+  TaskPriority,
+} from 'relay-runtime/store/RelayStoreTypes';
+import type {RequestParameters} from 'relay-runtime/util/RelayConcreteNode';
+import type {
+  CacheConfig,
+  Variables,
+} from 'relay-runtime/util/RelayRuntimeTypes';
 
 const {
+  MultiActorEnvironment,
+  getActorIdentifier,
+} = require('relay-runtime/multi-actor-environment');
+const RelayNetwork = require('relay-runtime/network/RelayNetwork');
+const RelayObservable = require('relay-runtime/network/RelayObservable');
+const {graphql} = require('relay-runtime/query/GraphQLTag');
+const RelayModernEnvironment = require('relay-runtime/store/RelayModernEnvironment');
+const {
   createOperationDescriptor,
-} = require('../RelayModernOperationDescriptor');
-const {createReaderSelector} = require('../RelayModernSelector');
-const {generateAndCompile} = require('relay-test-utils-internal');
+} = require('relay-runtime/store/RelayModernOperationDescriptor');
+const {
+  createReaderSelector,
+} = require('relay-runtime/store/RelayModernSelector');
+const RelayModernStore = require('relay-runtime/store/RelayModernStore');
+const RelayRecordSource = require('relay-runtime/store/RelayRecordSource');
+const {
+  disallowWarnings,
+  expectToWarn,
+  expectToWarnMany,
+} = require('relay-test-utils-internal');
 
-describe('execute() a query with @defer', () => {
-  let callbacks;
-  let complete;
-  let dataSource;
-  let environment;
-  let error;
-  let fetch;
-  let fragment;
-  let NameHandler;
-  let next;
-  let operation;
-  let query;
-  let selector;
-  let source;
-  let store;
-  let variables;
+disallowWarnings();
 
-  beforeEach(() => {
-    jest.resetModules();
-    jest.mock('warning');
-    jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+describe.each(['RelayModernEnvironment', 'MultiActorEnvironment'])(
+  'execute() a query with @defer',
+  environmentType => {
+    let callbacks;
+    let complete;
+    let dataSource;
+    let environment;
+    let error;
+    let fetch;
+    let fragment;
+    let NameHandler;
+    let next;
+    let operation;
+    let query;
+    let selector;
+    let source;
+    let store;
+    let variables;
+    let handlerProvider;
 
-    ({UserQuery: query, UserFragment: fragment} = generateAndCompile(`
-        query UserQuery($id: ID!) {
-          node(id: $id) {
-            ...UserFragment @defer(label: "UserFragment")
+    describe(environmentType, () => {
+      beforeEach(() => {
+        query = graphql`
+          query RelayModernEnvironmentExecuteWithDeferTestUserQuery($id: ID!) {
+            node(id: $id) {
+              ...RelayModernEnvironmentExecuteWithDeferTestUserFragment
+                @dangerously_unaliased_fixme
+                @defer(label: "UserFragment")
+            }
           }
-        }
+        `;
+        fragment = graphql`
+          fragment RelayModernEnvironmentExecuteWithDeferTestUserFragment on User {
+            id
+            name @__clientField(handle: "name_handler")
+          }
+        `;
+        variables = {id: '1'};
+        operation = createOperationDescriptor(query, variables);
+        selector = createReaderSelector(fragment, '1', {}, operation.request);
 
-        fragment UserFragment on User {
-          id
-          name @__clientField(handle: "name_handler")
-        }
-      `));
-    variables = {id: '1'};
-    operation = createOperationDescriptor(query, variables);
-    selector = createReaderSelector(fragment, '1', {}, operation.request);
+        NameHandler = {
+          update(storeProxy: RecordSourceProxy, payload: HandleFieldPayload) {
+            const record = storeProxy.get(payload.dataID);
+            if (record != null) {
+              const markup = record.getValue(payload.fieldKey);
+              record.setValue(
+                typeof markup === 'string' ? markup.toUpperCase() : null,
+                payload.handleKey,
+              );
+            }
+          },
+        };
 
-    NameHandler = {
-      update(storeProxy, payload) {
-        const record = storeProxy.get(payload.dataID);
-        if (record != null) {
-          const markup = record.getValue(payload.fieldKey);
-          record.setValue(
-            typeof markup === 'string' ? markup.toUpperCase() : null,
-            payload.handleKey,
+        complete = jest.fn<[], unknown>();
+        error = jest.fn<[Error], unknown>();
+        next = jest.fn<[GraphQLResponse], unknown>();
+        callbacks = {complete, error, next};
+        fetch = (
+          _query: RequestParameters,
+          _variables: Variables,
+          _cacheConfig: CacheConfig,
+        ): RelayObservable<GraphQLResponse> => {
+          return RelayObservable.create<GraphQLResponse>(
+            (sink: Sink<GraphQLResponse>) => {
+              dataSource = sink;
+            },
           );
-        }
-      },
-    };
-
-    complete = jest.fn();
-    error = jest.fn();
-    next = jest.fn();
-    callbacks = {complete, error, next};
-    fetch = (_query, _variables, _cacheConfig) => {
-      return RelayObservable.create(sink => {
-        dataSource = sink;
-      });
-    };
-    source = RelayRecordSource.create();
-    store = new RelayModernStore(source);
-
-    environment = new RelayModernEnvironment({
-      network: RelayNetwork.create(fetch),
-      store,
-      handlerProvider: name => {
-        switch (name) {
-          case 'name_handler':
-            return NameHandler;
-        }
-      },
-    });
-  });
-
-  it('calls next() and publishes the initial payload to the store', () => {
-    const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
-    environment.subscribe(initialSnapshot, callback);
-
-    environment.execute({operation}).subscribe(callbacks);
-    const payload = {
-      data: {
-        node: {
-          id: '1',
-          __typename: 'User',
-        },
-      },
-    };
-    dataSource.next(payload);
-    jest.runAllTimers();
-
-    expect(next.mock.calls.length).toBe(1);
-    expect(complete).not.toBeCalled();
-    expect(error).not.toBeCalled();
-    expect(callback.mock.calls.length).toBe(1);
-    const snapshot = callback.mock.calls[0][0];
-    expect(snapshot.isMissingData).toBe(true);
-    expect(snapshot.data).toEqual({
-      id: '1',
-      name: undefined,
-    });
-  });
-
-  it('processes deferred payloads', () => {
-    const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
-    environment.subscribe(initialSnapshot, callback);
-
-    environment.execute({operation}).subscribe(callbacks);
-    dataSource.next({
-      data: {
-        node: {
-          id: '1',
-          __typename: 'User',
-        },
-      },
-    });
-    jest.runAllTimers();
-    next.mockClear();
-    callback.mockClear();
-
-    dataSource.next({
-      data: {
-        id: '1',
-        __typename: 'User',
-        name: 'joe',
-      },
-      label: 'UserQuery$defer$UserFragment',
-      path: ['node'],
-    });
-
-    expect(complete).toBeCalledTimes(0);
-    expect(error).toBeCalledTimes(0);
-    expect(next).toBeCalledTimes(1);
-    expect(callback).toBeCalledTimes(1);
-    const snapshot = callback.mock.calls[0][0];
-    expect(snapshot.isMissingData).toBe(false);
-    expect(snapshot.data).toEqual({
-      id: '1',
-      name: 'JOE',
-    });
-  });
-
-  it('processes deferred payloads mixed with extensions-only payloads', () => {
-    const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
-    environment.subscribe(initialSnapshot, callback);
-
-    environment.execute({operation}).subscribe(callbacks);
-    dataSource.next({
-      data: {
-        node: {
-          id: '1',
-          __typename: 'User',
-        },
-      },
-    });
-    jest.runAllTimers();
-    next.mockClear();
-    callback.mockClear();
-
-    const extensionsPayload = {data: null, extensions: {foo: 'foo'}};
-    dataSource.next(extensionsPayload);
-    expect(callback).toBeCalledTimes(0);
-    expect(next).toBeCalledTimes(1);
-    expect(next.mock.calls[0][0]).toBe(extensionsPayload);
-    next.mockClear();
-
-    dataSource.next({
-      data: {
-        id: '1',
-        __typename: 'User',
-        name: 'joe',
-      },
-      label: 'UserQuery$defer$UserFragment',
-      path: ['node'],
-    });
-
-    expect(complete).toBeCalledTimes(0);
-    expect(error).toBeCalledTimes(0);
-    expect(next).toBeCalledTimes(1);
-    expect(callback).toBeCalledTimes(1);
-    const snapshot = callback.mock.calls[0][0];
-    expect(snapshot.isMissingData).toBe(false);
-    expect(snapshot.data).toEqual({
-      id: '1',
-      name: 'JOE',
-    });
-  });
-
-  describe('when using a scheduler', () => {
-    let taskID;
-    let tasks;
-    let scheduler;
-    let runTask;
-
-    beforeEach(() => {
-      taskID = 0;
-      tasks = new Map();
-      scheduler = {
-        cancel: id => {
-          tasks.delete(id);
-        },
-        schedule: task => {
-          const id = String(taskID++);
-          tasks.set(id, task);
-          return id;
-        },
-      };
-      runTask = () => {
-        for (const [id, task] of tasks) {
-          tasks.delete(id);
-          task();
-          break;
-        }
-      };
-      environment = new RelayModernEnvironment({
-        network: RelayNetwork.create(fetch),
-        scheduler,
-        store,
-        handlerProvider: name => {
+        };
+        source = RelayRecordSource.create();
+        store = new RelayModernStore(source);
+        handlerProvider = (name: string) => {
           switch (name) {
             case 'name_handler':
               return NameHandler;
           }
-        },
+        };
+
+        const multiActorEnvironment = new MultiActorEnvironment({
+          createNetworkForActor: _actorID => RelayNetwork.create(fetch),
+          createStoreForActor: _actorID => store,
+          handlerProvider,
+        });
+        environment =
+          environmentType === 'MultiActorEnvironment'
+            ? multiActorEnvironment.forActor(getActorIdentifier('actor:1234'))
+            : new RelayModernEnvironment({
+                network: RelayNetwork.create(fetch),
+                store,
+                handlerProvider,
+              });
       });
-    });
 
-    it('processes deferred payloads with scheduling', () => {
-      const initialSnapshot = environment.lookup(selector);
-      const callback = jest.fn();
-      environment.subscribe(initialSnapshot, callback);
+      it('calls next() and publishes the initial payload to the store', () => {
+        const initialSnapshot = environment.lookup(selector);
+        const callback = jest.fn<[Snapshot], void>();
+        environment.subscribe(initialSnapshot, callback);
 
-      environment.execute({operation}).subscribe(callbacks);
-      dataSource.next({
-        data: {
-          node: {
+        environment.execute({operation}).subscribe(callbacks);
+        const payload = {
+          data: {
+            node: {
+              id: '1',
+              __typename: 'User',
+            },
+          },
+        };
+        dataSource.next(payload);
+        jest.runAllTimers();
+
+        expect(next.mock.calls.length).toBe(1);
+        expect(complete).not.toBeCalled();
+        expect(error).not.toBeCalled();
+        expect(callback.mock.calls.length).toBe(1);
+        const snapshot = callback.mock.calls[0][0];
+        expect(snapshot.isMissingData).toBe(true);
+        expect(snapshot.data).toEqual({
+          id: '1',
+          name: undefined,
+        });
+      });
+
+      it('processes deferred payloads', () => {
+        const initialSnapshot = environment.lookup(selector);
+        const callback = jest.fn<[Snapshot], void>();
+        environment.subscribe(initialSnapshot, callback);
+
+        environment.execute({operation}).subscribe(callbacks);
+        dataSource.next({
+          data: {
+            node: {
+              id: '1',
+              __typename: 'User',
+            },
+          },
+        });
+        jest.runAllTimers();
+        next.mockClear();
+        callback.mockClear();
+
+        dataSource.next({
+          data: {
             id: '1',
             __typename: 'User',
+            name: 'joe',
           },
-        },
-      });
-      expect(next).toBeCalledTimes(0);
-      expect(callback).toBeCalledTimes(0);
-      expect(tasks.size).toBe(1);
-      runTask();
-      expect(tasks.size).toBe(0);
-      expect(next).toBeCalledTimes(1);
-      expect(callback).toBeCalledTimes(1);
-      jest.runAllTimers();
-      next.mockClear();
-      callback.mockClear();
+          label:
+            'RelayModernEnvironmentExecuteWithDeferTestUserQuery$defer$UserFragment',
+          path: ['node'],
+        });
 
-      dataSource.next({
-        data: {
+        expect(complete).toBeCalledTimes(0);
+        expect(error).toBeCalledTimes(0);
+        expect(next).toBeCalledTimes(1);
+        expect(callback).toBeCalledTimes(1);
+        const snapshot = callback.mock.calls[0][0];
+        expect(snapshot.isMissingData).toBe(false);
+        expect(snapshot.data).toEqual({
           id: '1',
-          __typename: 'User',
-          name: 'joe',
-        },
-        label: 'UserQuery$defer$UserFragment',
-        path: ['node'],
+          name: 'JOE',
+        });
       });
-      expect(next).toBeCalledTimes(0);
-      expect(callback).toBeCalledTimes(0);
-      expect(tasks.size).toBe(1);
-      runTask();
-      expect(tasks.size).toBe(0);
 
-      expect(complete).toBeCalledTimes(0);
-      expect(error).toBeCalledTimes(0);
-      expect(next).toBeCalledTimes(1);
-      expect(callback).toBeCalledTimes(1);
+      it('processes deferred payloads mixed with extensions-only payloads', () => {
+        const initialSnapshot = environment.lookup(selector);
+        const callback = jest.fn<[Snapshot], void>();
+        environment.subscribe(initialSnapshot, callback);
 
-      const snapshot = callback.mock.calls[0][0];
-      expect(snapshot.isMissingData).toBe(false);
-      expect(snapshot.data).toEqual({
-        id: '1',
-        name: 'JOE',
+        environment.execute({operation}).subscribe(callbacks);
+        dataSource.next({
+          data: {
+            node: {
+              id: '1',
+              __typename: 'User',
+            },
+          },
+        });
+        jest.runAllTimers();
+        next.mockClear();
+        callback.mockClear();
+
+        const extensionsPayload: GraphQLResponse = {
+          data: null,
+          extensions: {foo: 'foo'} as PayloadExtensions,
+        };
+        dataSource.next(extensionsPayload);
+        expect(callback).toBeCalledTimes(0);
+        expect(next).toBeCalledTimes(1);
+        expect(next.mock.calls[0][0]).toBe(extensionsPayload);
+        next.mockClear();
+
+        dataSource.next({
+          data: {
+            id: '1',
+            __typename: 'User',
+            name: 'joe',
+          },
+          label:
+            'RelayModernEnvironmentExecuteWithDeferTestUserQuery$defer$UserFragment',
+          path: ['node'],
+        });
+
+        expect(complete).toBeCalledTimes(0);
+        expect(error).toBeCalledTimes(0);
+        expect(next).toBeCalledTimes(1);
+        expect(callback).toBeCalledTimes(1);
+        const snapshot = callback.mock.calls[0][0];
+        expect(snapshot.isMissingData).toBe(false);
+        expect(snapshot.data).toEqual({
+          id: '1',
+          name: 'JOE',
+        });
       });
-    });
 
-    it('processes deferred payloads that are available synchronously within the same scheduler step', () => {
-      const initialSnapshot = environment.lookup(selector);
-      const callback = jest.fn();
-      environment.subscribe(initialSnapshot, callback);
+      it('processes deferred payloads mixed with normalized response payloads', () => {
+        const initialSnapshot = environment.lookup(selector);
+        const callback = jest.fn<[Snapshot], void>();
+        environment.subscribe(initialSnapshot, callback);
 
-      environment.execute({operation}).subscribe(callbacks);
-      dataSource.next([
-        {
+        environment.execute({operation}).subscribe(callbacks);
+        dataSource.next({
+          data: {
+            node: {
+              id: '1',
+              __typename: 'User',
+            },
+          },
+        });
+        jest.runAllTimers();
+        next.mockClear();
+        callback.mockClear();
+
+        const extensionsPayload: GraphQLResponse = {
+          data: {
+            '1': {
+              __id: '1',
+              __typename: 'User',
+              extra_data: 'Zuck',
+            },
+          },
+          extensions: {is_normalized: true} as PayloadExtensions,
+        };
+        dataSource.next(extensionsPayload);
+        expect(callback).toBeCalledTimes(0);
+        expect(next).toBeCalledTimes(1);
+        expect(next.mock.calls[0][0]).toBe(extensionsPayload);
+        next.mockClear();
+
+        dataSource.next({
+          data: {
+            id: '1',
+            __typename: 'User',
+            name: 'joe',
+          },
+          label:
+            'RelayModernEnvironmentExecuteWithDeferTestUserQuery$defer$UserFragment',
+          path: ['node'],
+        });
+
+        expect(complete).toBeCalledTimes(0);
+        expect(error).toBeCalledTimes(0);
+        expect(next).toBeCalledTimes(1);
+        expect(callback).toBeCalledTimes(1);
+        const snapshot = callback.mock.calls[0][0];
+        expect(snapshot.isMissingData).toBe(false);
+        expect(snapshot.data).toEqual({
+          id: '1',
+          name: 'JOE',
+        });
+      });
+
+      it('processes deferred payloads with deduplicated fields', () => {
+        // This functionality prevents Relay from throwing an error when missing
+        // fields are received in a deferred response. This is required for the
+        // latest `@defer` spec proposal, which does not send duplicate fields
+        // in deferred responses. While Relay does not yet attempt to support the latest
+        // spec proposal (https://github.com/graphql/defer-stream-wg/discussions/69),
+        // this option allows users to transform responses into a format that Relay
+        // can accept.
+        environment = new RelayModernEnvironment({
+          network: RelayNetwork.create(fetch),
+          store,
+          handlerProvider,
+          deferDeduplicatedFields: true,
+        });
+
+        const overlappingFieldsQuery = graphql`
+          query RelayModernEnvironmentExecuteWithDeferTestUserOverlappingFieldsQuery(
+            $id: ID!
+          ) {
+            node(id: $id) {
+              ... on User {
+                id
+                name
+                ...RelayModernEnvironmentExecuteWithDeferTestUserOverlappingFieldsFragment
+                  @dangerously_unaliased_fixme
+                  @defer(label: "UserFragment")
+              }
+            }
+          }
+        `;
+        const overlappingFieldsFragment = graphql`
+          fragment RelayModernEnvironmentExecuteWithDeferTestUserOverlappingFieldsFragment on User {
+            name
+            alternate_name
+          }
+        `;
+
+        const overlappingFieldsVariables = {id: '1'};
+        const overlappingFieldsOperation = createOperationDescriptor(
+          overlappingFieldsQuery,
+          overlappingFieldsVariables,
+        );
+        const overlappingFieldsSelector = createReaderSelector(
+          overlappingFieldsFragment,
+          '1',
+          {},
+          overlappingFieldsOperation.request,
+        );
+
+        const initialSnapshot = environment.lookup(overlappingFieldsSelector);
+        const callback = jest.fn<[Snapshot], void>();
+        environment.subscribe(initialSnapshot, callback);
+
+        environment
+          .execute({operation: overlappingFieldsOperation})
+          .subscribe(callbacks);
+        dataSource.next({
           data: {
             node: {
               __typename: 'User',
@@ -325,365 +386,1056 @@ describe('execute() a query with @defer', () => {
               name: 'joe',
             },
           },
-        },
-        {
+        });
+
+        jest.runAllTimers();
+        next.mockClear();
+        callback.mockClear();
+
+        dataSource.next({
+          data: {
+            alternate_name: 'joe2',
+          },
+          label:
+            'RelayModernEnvironmentExecuteWithDeferTestUserOverlappingFieldsQuery$defer$UserFragment',
+          path: ['node'],
+          extensions: {
+            is_final: true,
+          },
+        });
+
+        expect(complete).toBeCalledTimes(0);
+        expect(error).toBeCalledTimes(0);
+        expect(next).toBeCalledTimes(1);
+        expect(callback).toBeCalledTimes(1);
+        const snapshot = callback.mock.calls[0][0];
+        expect(snapshot.isMissingData).toBe(false);
+        expect(snapshot.data).toEqual({
+          name: 'joe',
+          alternate_name: 'joe2',
+        });
+      });
+
+      describe('Query with exec time resolvers', () => {
+        let resolverOperation;
+        beforeEach(() => {
+          const resolverQuery = graphql`
+            query RelayModernEnvironmentExecuteWithDeferTestResolverQuery(
+              $id: ID!
+            ) @exec_time_resolvers {
+              node(id: $id) {
+                ...RelayModernEnvironmentExecuteWithDeferTestUserFragment
+                  @dangerously_unaliased_fixme
+                  @defer(label: "UserFragment")
+              }
+            }
+          `;
+          variables = {id: '1'};
+          resolverOperation = createOperationDescriptor(
+            resolverQuery,
+            variables,
+          );
+          selector = createReaderSelector(
+            fragment,
+            '1',
+            {},
+            resolverOperation.request,
+          );
+        });
+
+        it('goes out of loading state if all initial payloads are received in an exec time query, but stay active when server or client is loading', () => {
+          const initialSnapshot = environment.lookup(selector);
+          const callback = jest.fn<[Snapshot], void>();
+          environment.subscribe(initialSnapshot, callback);
+
+          environment
+            .execute({operation: resolverOperation})
+            .subscribe(callbacks);
+          dataSource.next({
+            data: {
+              node: {
+                id: '1',
+                __typename: 'User',
+              },
+            },
+          });
+          jest.runAllTimers();
+          next.mockClear();
+          callback.mockClear();
+
+          dataSource.next({
+            data: {
+              id: '1',
+              __typename: 'User',
+              name: 'joe',
+            },
+            label:
+              'RelayModernEnvironmentExecuteWithDeferTestResolverQuery$defer$UserFragment',
+            path: ['node'],
+            extensions: {
+              // The server response needs to contain a marker for the final incremental payload
+              is_final: true,
+            },
+          });
+
+          expect(complete).toBeCalledTimes(0);
+          expect(error).toBeCalledTimes(0);
+          expect(next).toBeCalledTimes(1);
+          expect(callback).toBeCalledTimes(1);
+          const snapshot = callback.mock.calls[0][0];
+          expect(snapshot.isMissingData).toBe(false);
+          expect(snapshot.data).toEqual({
+            id: '1',
+            name: 'JOE',
+          });
+
+          // Server payloads have finished, but we are still waiting on the resolver payloads
+          expect(
+            environment.isRequestActive(resolverOperation.request.identifier),
+          ).toBe(true);
+
+          // Finishes the exec time query
+          callback.mockClear();
+          next.mockClear();
+          const extensionsPayload: GraphQLResponse = {
+            data: {
+              '1': {
+                __id: '1',
+                __typename: 'User',
+                // __name_name_handler is where the name gets stored in the current test
+                // due to the usage of the field handler
+                __name_name_handler: 'Zuck',
+              },
+            },
+            extensions: {
+              is_normalized: true,
+              is_final: true,
+            } as PayloadExtensions,
+          };
+          dataSource.next(extensionsPayload);
+          expect(callback).toBeCalledTimes(1);
+          expect(callback.mock.calls[0][0].data).toEqual({
+            id: '1',
+            name: 'Zuck',
+          });
+
+          // At this point, the deferred payload and the exec time query payload
+          // have all been resolved, the query should no longer be treated as pending
+          expect(
+            environment
+              .getOperationTracker()
+              .getPendingOperationsAffectingOwner(resolverOperation.request),
+          ).toBe(null);
+          expect(
+            environment.isRequestActive(resolverOperation.request.identifier),
+          ).toBe(false);
+        });
+
+        it('Stay active when server or client is loading, when client finishes first', () => {
+          const initialSnapshot = environment.lookup(selector);
+          const callback = jest.fn<[Snapshot], void>();
+          environment.subscribe(initialSnapshot, callback);
+
+          environment
+            .execute({operation: resolverOperation})
+            .subscribe(callbacks);
+
+          const extensionsPayload: GraphQLResponse = {
+            data: {
+              '1': {
+                id: '1',
+                __id: '1',
+                __typename: 'User',
+                // __name_name_handler is where the name gets stored in the current test
+                // due to the usage of the field handler
+                __name_name_handler: 'Zuck',
+              },
+            },
+            extensions: {
+              is_normalized: true,
+              is_final: true,
+            } as PayloadExtensions,
+          };
+
+          dataSource.next(extensionsPayload);
+          expect(callback).toBeCalledTimes(1);
+          expect(callback.mock.calls[0][0].data).toEqual({
+            id: '1',
+            name: 'Zuck',
+          });
+          next.mockClear();
+          callback.mockClear();
+
+          // Client payloads have finished, but we are still waiting on the server payloads
+          expect(
+            environment.isRequestActive(resolverOperation.request.identifier),
+          ).toBe(true);
+          expect(
+            environment
+              .getOperationTracker()
+              .getPendingOperationsAffectingOwner(resolverOperation.request),
+          ).not.toBe(null);
+          dataSource.next({
+            data: {
+              node: {
+                id: '1',
+                __typename: 'User',
+              },
+            },
+          });
+          jest.runAllTimers();
+          next.mockClear();
+          callback.mockClear();
+          expect(
+            environment
+              .getOperationTracker()
+              .getPendingOperationsAffectingOwner(resolverOperation.request),
+          ).not.toBe(null);
+
+          dataSource.next({
+            data: {
+              id: '1',
+              __typename: 'User',
+              name: 'joe',
+            },
+            label:
+              'RelayModernEnvironmentExecuteWithDeferTestResolverQuery$defer$UserFragment',
+            path: ['node'],
+            extensions: {
+              // The server response needs to contain a marker for the final incremental payload
+              is_final: true,
+            },
+          });
+
+          expect(complete).toBeCalledTimes(0);
+          expect(error).toBeCalledTimes(0);
+          expect(next).toBeCalledTimes(1);
+          expect(callback).toBeCalledTimes(1);
+          const snapshot = callback.mock.calls[0][0];
+          expect(snapshot.isMissingData).toBe(false);
+          expect(snapshot.data).toEqual({
+            id: '1',
+            name: 'JOE',
+          });
+
+          // At this point, the deferred payload and the exec time query payload
+          // have all been resolved, the query should no longer be treated as pending
+          expect(
+            environment
+              .getOperationTracker()
+              .getPendingOperationsAffectingOwner(resolverOperation.request),
+          ).toBe(null);
+          expect(
+            environment.isRequestActive(resolverOperation.request.identifier),
+          ).toBe(false);
+        });
+
+        it('marks the query as complete after the server completes first then the client finishes with `null` payload', () => {
+          const initialSnapshot = environment.lookup(selector);
+          const callback = jest.fn<[Snapshot], void>();
+          environment.subscribe(initialSnapshot, callback);
+
+          environment
+            .execute({operation: resolverOperation})
+            .subscribe(callbacks);
+
+          // Initial server payload but not complete
+          dataSource.next({
+            data: {
+              node: {
+                id: '1',
+                __typename: 'User',
+              },
+            },
+          });
+          jest.runAllTimers();
+          next.mockClear();
+          callback.mockClear();
+
+          // Empty exec time response but complete the exec time query
+          const extensionsPayload: GraphQLResponse = {
+            data: null,
+            extensions: {
+              is_normalized: true,
+              is_final: true,
+            } as PayloadExtensions,
+          };
+
+          dataSource.next(extensionsPayload);
+          expect(callback).not.toBeCalled();
+          next.mockClear();
+          callback.mockClear();
+
+          // Mark the server response as finished
+          dataSource.next({
+            data: {
+              id: '1',
+              __typename: 'User',
+              name: 'joe',
+            },
+            label:
+              'RelayModernEnvironmentExecuteWithDeferTestResolverQuery$defer$UserFragment',
+            path: ['node'],
+            extensions: {
+              // The server response needs to contain a marker for the final incremental payload
+              is_final: true,
+            },
+          });
+
+          expect(
+            environment
+              .getOperationTracker()
+              .getPendingOperationsAffectingOwner(resolverOperation.request),
+          ).toBe(null);
+          expect(
+            environment.isRequestActive(resolverOperation.request.identifier),
+          ).toBe(false);
+        });
+
+        it('marks the query as complete if there is no server request and the client payload is final', () => {
+          const initialSnapshot = environment.lookup(selector);
+          const callback = jest.fn<[Snapshot], void>();
+          environment.subscribe(initialSnapshot, callback);
+
+          environment
+            .execute({operation: resolverOperation})
+            .subscribe(callbacks);
+
+          const extensionsPayload: GraphQLResponse = {
+            data: {
+              '1': {
+                id: '1',
+                __id: '1',
+                __typename: 'User',
+                // __name_name_handler is where the name gets stored in the current test
+                // due to the usage of the field handler
+                __name_name_handler: 'Zuck',
+              },
+            },
+            extensions: {
+              is_normalized: true,
+              is_final: true,
+              is_client_only: true,
+            } as PayloadExtensions,
+          };
+
+          dataSource.next(extensionsPayload);
+          expect(
+            environment
+              .getOperationTracker()
+              .getPendingOperationsAffectingOwner(resolverOperation.request),
+          ).toBe(null);
+          expect(
+            environment.isRequestActive(resolverOperation.request.identifier),
+          ).toBe(false);
+        });
+
+        it('marks the query as complete if there is no server request and the client payload is final with `null` payload', () => {
+          const initialSnapshot = environment.lookup(selector);
+          const callback = jest.fn<[Snapshot], void>();
+          environment.subscribe(initialSnapshot, callback);
+
+          environment
+            .execute({operation: resolverOperation})
+            .subscribe(callbacks);
+
+          const extensionsPayload: GraphQLResponse = {
+            data: null,
+            extensions: {
+              is_normalized: true,
+              is_final: true,
+              is_client_only: true,
+            } as PayloadExtensions,
+          };
+
+          dataSource.next(extensionsPayload);
+          expect(
+            environment
+              .getOperationTracker()
+              .getPendingOperationsAffectingOwner(resolverOperation.request),
+          ).toBe(null);
+          expect(
+            environment.isRequestActive(resolverOperation.request.identifier),
+          ).toBe(false);
+        });
+      });
+
+      describe('when using a scheduler', () => {
+        let taskID;
+        let tasks;
+        let scheduler;
+        let runTask;
+        const priorityFn = jest.fn();
+
+        beforeEach(() => {
+          taskID = 0;
+          tasks = new Map<string, () => void>();
+          scheduler = {
+            cancel: (id: string) => {
+              tasks.delete(id);
+            },
+            schedule: (task: () => void, priority?: TaskPriority) => {
+              priorityFn(priority);
+              const id = String(taskID++);
+              tasks.set(id, task);
+              return id;
+            },
+          };
+          runTask = () => {
+            for (const [id, task] of tasks) {
+              tasks.delete(id);
+              task();
+              break;
+            }
+          };
+          const multiActorEnvironment = new MultiActorEnvironment({
+            createNetworkForActor: _actorID => RelayNetwork.create(fetch),
+            createStoreForActor: _actorID => store,
+            handlerProvider,
+            scheduler,
+          });
+          environment =
+            environmentType === 'MultiActorEnvironment'
+              ? multiActorEnvironment.forActor(getActorIdentifier('actor:1234'))
+              : new RelayModernEnvironment({
+                  network: RelayNetwork.create(fetch),
+                  store,
+                  handlerProvider,
+                  scheduler,
+                });
+        });
+
+        it('processes deferred payloads with scheduling', () => {
+          const initialSnapshot = environment.lookup(selector);
+          const callback = jest.fn<[Snapshot], void>();
+          environment.subscribe(initialSnapshot, callback);
+
+          environment.execute({operation}).subscribe(callbacks);
+          dataSource.next({
+            data: {
+              node: {
+                id: '1',
+                __typename: 'User',
+              },
+            },
+          });
+          expect(next).toBeCalledTimes(0);
+          expect(callback).toBeCalledTimes(0);
+          expect(tasks.size).toBe(1);
+
+          expect(priorityFn).toBeCalledTimes(1);
+          expect(priorityFn.mock.calls[0][0]).toBe('default');
+          runTask();
+          expect(tasks.size).toBe(0);
+          expect(next).toBeCalledTimes(1);
+          expect(callback).toBeCalledTimes(1);
+          jest.runAllTimers();
+          next.mockClear();
+          callback.mockClear();
+          priorityFn.mockClear();
+
+          dataSource.next({
+            data: {
+              id: '1',
+              __typename: 'User',
+              name: 'joe',
+            },
+            label:
+              'RelayModernEnvironmentExecuteWithDeferTestUserQuery$defer$UserFragment',
+            path: ['node'],
+          });
+          expect(next).toBeCalledTimes(0);
+          expect(callback).toBeCalledTimes(0);
+          expect(tasks.size).toBe(1);
+          expect(priorityFn).toBeCalledTimes(1);
+          expect(priorityFn.mock.calls[0][0]).toBe('low');
+          runTask();
+          expect(tasks.size).toBe(0);
+
+          expect(complete).toBeCalledTimes(0);
+          expect(error).toBeCalledTimes(0);
+          expect(next).toBeCalledTimes(1);
+          expect(callback).toBeCalledTimes(1);
+
+          const snapshot = callback.mock.calls[0][0];
+          expect(snapshot.isMissingData).toBe(false);
+          expect(snapshot.data).toEqual({
+            id: '1',
+            name: 'JOE',
+          });
+        });
+
+        it('processes deferred payloads that are available synchronously within the same scheduler step', () => {
+          const initialSnapshot = environment.lookup(selector);
+          const callback = jest.fn<[Snapshot], void>();
+          environment.subscribe(initialSnapshot, callback);
+
+          environment.execute({operation}).subscribe(callbacks);
+          dataSource.next([
+            {
+              data: {
+                node: {
+                  __typename: 'User',
+                  id: '1',
+                  name: 'joe',
+                },
+              },
+            },
+            {
+              data: {
+                id: '1',
+                __typename: 'User',
+                name: 'joe',
+              },
+              label:
+                'RelayModernEnvironmentExecuteWithDeferTestUserQuery$defer$UserFragment',
+              path: ['node'],
+              extensions: {
+                is_final: true,
+              },
+            },
+          ]);
+          expect(complete).toBeCalledTimes(0);
+          expect(next).toBeCalledTimes(0);
+          expect(callback).toBeCalledTimes(0);
+          expect(tasks.size).toBe(1);
+
+          runTask();
+          expect(tasks.size).toBe(0);
+          expect(complete).toBeCalledTimes(0);
+          expect(next).toBeCalledTimes(1);
+          expect(callback).toBeCalledTimes(1);
+          jest.runAllTimers();
+
+          const snapshot = callback.mock.calls[0][0];
+          expect(snapshot.isMissingData).toBe(false);
+          expect(snapshot.data).toEqual({
+            id: '1',
+            name: 'JOE',
+          });
+        });
+
+        it('cancels processing of deferred payloads with scheduling', () => {
+          const initialSnapshot = environment.lookup(selector);
+          const callback = jest.fn<[Snapshot], void>();
+          environment.subscribe(initialSnapshot, callback);
+
+          const subscription = environment
+            .execute({operation})
+            .subscribe(callbacks);
+          dataSource.next({
+            data: {
+              node: {
+                id: '1',
+                __typename: 'User',
+              },
+            },
+          });
+          expect(next).toBeCalledTimes(0);
+          expect(callback).toBeCalledTimes(0);
+          expect(tasks.size).toBe(1);
+          runTask();
+          expect(next).toBeCalledTimes(1);
+          expect(callback).toBeCalledTimes(1);
+          jest.runAllTimers();
+          next.mockClear();
+          callback.mockClear();
+
+          dataSource.next({
+            data: {
+              id: '1',
+              __typename: 'User',
+              name: 'joe',
+            },
+            label:
+              'RelayModernEnvironmentExecuteWithDeferTestUserQuery$defer$UserFragment',
+            path: ['node'],
+          });
+          expect(next).toBeCalledTimes(0);
+          expect(callback).toBeCalledTimes(0);
+          expect(tasks.size).toBe(1);
+
+          subscription.unsubscribe();
+          expect(tasks.size).toBe(0);
+          expect(complete).toBeCalledTimes(0);
+          expect(error).toBeCalledTimes(0);
+          expect(next).toBeCalledTimes(0);
+          expect(callback).toBeCalledTimes(0);
+        });
+      });
+
+      it('calls complete() when server completes after deferred payload resolves', () => {
+        const initialSnapshot = environment.lookup(selector);
+        const callback = jest.fn<[Snapshot], void>();
+        environment.subscribe(initialSnapshot, callback);
+
+        environment.execute({operation}).subscribe(callbacks);
+        dataSource.next({
+          data: {
+            node: {
+              id: '1',
+              __typename: 'User',
+            },
+          },
+        });
+        jest.runAllTimers();
+
+        dataSource.next({
           data: {
             id: '1',
             __typename: 'User',
             name: 'joe',
           },
-          label: 'UserQuery$defer$UserFragment',
+          label:
+            'RelayModernEnvironmentExecuteWithDeferTestUserQuery$defer$UserFragment',
           path: ['node'],
-          extensions: {
-            is_final: true,
+        });
+
+        expect(complete).toBeCalledTimes(0);
+        expect(error).toBeCalledTimes(0);
+        expect(next).toBeCalledTimes(2);
+        expect(callback).toBeCalledTimes(2);
+
+        dataSource.complete();
+
+        expect(complete).toBeCalledTimes(1);
+        expect(error).toBeCalledTimes(0);
+        expect(next).toBeCalledTimes(2);
+        expect(callback).toBeCalledTimes(2);
+      });
+
+      it('calls complete() when server completes before deferred payload resolves', () => {
+        const initialSnapshot = environment.lookup(selector);
+        const callback = jest.fn<[Snapshot], void>();
+        environment.subscribe(initialSnapshot, callback);
+
+        environment.execute({operation}).subscribe(callbacks);
+        dataSource.next({
+          data: {
+            node: {
+              id: '1',
+              __typename: 'User',
+            },
           },
-        },
-      ]);
-      expect(complete).toBeCalledTimes(0);
-      expect(next).toBeCalledTimes(0);
-      expect(callback).toBeCalledTimes(0);
-      expect(tasks.size).toBe(1);
+        });
+        jest.runAllTimers();
 
-      runTask();
-      expect(tasks.size).toBe(0);
-      expect(complete).toBeCalledTimes(0);
-      expect(next).toBeCalledTimes(1);
-      expect(callback).toBeCalledTimes(2);
-      jest.runAllTimers();
+        expect(complete).toBeCalledTimes(0);
+        expect(error).toBeCalledTimes(0);
+        expect(next).toBeCalledTimes(1);
+        expect(callback).toBeCalledTimes(1);
 
-      const snapshot1 = callback.mock.calls[0][0];
-      expect(snapshot1.isMissingData).toBe(true);
-      expect(snapshot1.data).toEqual({
-        id: '1',
+        dataSource.complete();
+
+        expect(complete).toBeCalledTimes(1);
+        expect(error).toBeCalledTimes(0);
+        expect(next).toBeCalledTimes(1);
+        expect(callback).toBeCalledTimes(1);
       });
 
-      const snapshot2 = callback.mock.calls[1][0];
-      expect(snapshot2.isMissingData).toBe(false);
-      expect(snapshot2.data).toEqual({
-        id: '1',
-        name: 'JOE',
-      });
-    });
+      it('calls error() when server errors after deferred payload resolves', () => {
+        const initialSnapshot = environment.lookup(selector);
+        const callback = jest.fn<[Snapshot], void>();
+        environment.subscribe(initialSnapshot, callback);
 
-    it('cancels processing of deferred payloads with scheduling', () => {
-      const initialSnapshot = environment.lookup(selector);
-      const callback = jest.fn();
-      environment.subscribe(initialSnapshot, callback);
+        environment.execute({operation}).subscribe(callbacks);
+        dataSource.next({
+          data: {
+            node: {
+              id: '1',
+              __typename: 'User',
+            },
+          },
+        });
+        jest.runAllTimers();
 
-      const subscription = environment
-        .execute({operation})
-        .subscribe(callbacks);
-      dataSource.next({
-        data: {
-          node: {
+        dataSource.next({
+          data: {
             id: '1',
             __typename: 'User',
+            name: 'joe',
           },
-        },
+          label:
+            'RelayModernEnvironmentExecuteWithDeferTestUserQuery$defer$UserFragment',
+          path: ['node'],
+        });
+
+        expect(complete).toBeCalledTimes(0);
+        expect(error).toBeCalledTimes(0);
+        expect(next).toBeCalledTimes(2);
+        expect(callback).toBeCalledTimes(2);
+
+        const err = new Error('wtf');
+        dataSource.error(err);
+
+        expect(complete).toBeCalledTimes(0);
+        expect(error).toBeCalledTimes(1);
+        expect(error.mock.calls[0][0]).toBe(err);
+        expect(next).toBeCalledTimes(2);
+        expect(callback).toBeCalledTimes(2);
       });
-      expect(next).toBeCalledTimes(0);
-      expect(callback).toBeCalledTimes(0);
-      expect(tasks.size).toBe(1);
-      runTask();
-      expect(next).toBeCalledTimes(1);
-      expect(callback).toBeCalledTimes(1);
-      jest.runAllTimers();
-      next.mockClear();
-      callback.mockClear();
 
-      dataSource.next({
-        data: {
-          id: '1',
-          __typename: 'User',
-          name: 'joe',
-        },
-        label: 'UserQuery$defer$UserFragment',
-        path: ['node'],
+      it('calls error() when server errors before deferred payload resolves', () => {
+        const initialSnapshot = environment.lookup(selector);
+        const callback = jest.fn<[Snapshot], void>();
+        environment.subscribe(initialSnapshot, callback);
+
+        environment.execute({operation}).subscribe(callbacks);
+        dataSource.next({
+          data: {
+            node: {
+              id: '1',
+              __typename: 'User',
+            },
+          },
+        });
+        jest.runAllTimers();
+
+        expect(complete).toBeCalledTimes(0);
+        expect(error).toBeCalledTimes(0);
+        expect(next).toBeCalledTimes(1);
+        expect(callback).toBeCalledTimes(1);
+
+        const err = new Error('wtf');
+        dataSource.error(err);
+
+        expect(complete).toBeCalledTimes(0);
+        expect(error).toBeCalledTimes(1);
+        expect(error.mock.calls[0][0]).toBe(err);
+        expect(next).toBeCalledTimes(1);
+        expect(callback).toBeCalledTimes(1);
       });
-      expect(next).toBeCalledTimes(0);
-      expect(callback).toBeCalledTimes(0);
-      expect(tasks.size).toBe(1);
 
-      subscription.unsubscribe();
-      expect(tasks.size).toBe(0);
-      expect(complete).toBeCalledTimes(0);
-      expect(error).toBeCalledTimes(0);
-      expect(next).toBeCalledTimes(0);
-      expect(callback).toBeCalledTimes(0);
-    });
-  });
+      it('calls error() when deferred payload is missing data', () => {
+        const initialSnapshot = environment.lookup(selector);
+        const callback = jest.fn<[Snapshot], void>();
+        environment.subscribe(initialSnapshot, callback);
 
-  it('calls complete() when server completes after deferred payload resolves', () => {
-    const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
-    environment.subscribe(initialSnapshot, callback);
+        environment.execute({operation}).subscribe(callbacks);
+        dataSource.next({
+          data: {
+            node: {
+              id: '1',
+              __typename: 'User',
+            },
+          },
+        });
+        jest.runAllTimers();
 
-    environment.execute({operation}).subscribe(callbacks);
-    dataSource.next({
-      data: {
-        node: {
+        expect(complete).toBeCalledTimes(0);
+        expect(error).toBeCalledTimes(0);
+        expect(next).toBeCalledTimes(1);
+        expect(callback).toBeCalledTimes(1);
+
+        dataSource.next({
+          errors: [
+            {
+              message: 'wtf',
+              locations: [],
+              severity: 'ERROR',
+            },
+          ],
+          label:
+            'RelayModernEnvironmentExecuteWithDeferTestUserQuery$defer$UserFragment',
+          path: ['node'],
+        });
+
+        expect(complete).toBeCalledTimes(0);
+        expect(error).toBeCalledTimes(1);
+        expect(error.mock.calls[0][0].message).toContain(
+          'No data returned for operation `RelayModernEnvironmentExecuteWithDeferTestUserQuery`',
+        );
+        expect(next).toBeCalledTimes(1);
+        expect(callback).toBeCalledTimes(1);
+      });
+
+      it('warns if executed in non-streaming mode and processes deferred selections', () => {
+        const initialSnapshot = environment.lookup(selector);
+        const callback = jest.fn<[Snapshot], void>();
+        environment.subscribe(initialSnapshot, callback);
+
+        environment.execute({operation}).subscribe(callbacks);
+        const payload: GraphQLResponse = {
+          data: {
+            node: {
+              id: '1',
+              __typename: 'User',
+              name: 'Alice',
+            },
+          },
+          extensions: {
+            is_final: true,
+          } as PayloadExtensions,
+        };
+        expectToWarn(
+          'RelayModernEnvironment: Operation `RelayModernEnvironmentExecuteWithDeferTestUserQuery` contains @defer/@stream ' +
+            'directives but was executed in non-streaming mode. See ' +
+            'https://fburl.com/relay-incremental-delivery-non-streaming-warning.',
+          () => {
+            dataSource.next(payload);
+          },
+        );
+        jest.runAllTimers();
+
+        expect(next.mock.calls.length).toBe(1);
+        expect(complete).not.toBeCalled();
+        expect(error).not.toBeCalled();
+
+        expect(callback.mock.calls.length).toBe(1);
+        const snapshot = callback.mock.calls[0][0];
+        expect(snapshot.isMissingData).toBe(false);
+        expect(snapshot.data).toEqual({
           id: '1',
-          __typename: 'User',
-        },
-      },
+          name: 'ALICE',
+        });
+      });
+
+      it('warns if nested defer is executed in non-streaming mode and processes deferred selections', () => {
+        const query = graphql`
+          query RelayModernEnvironmentExecuteWithDeferTestNestedUserQuery(
+            $id: ID!
+          ) {
+            node(id: $id) {
+              ...RelayModernEnvironmentExecuteWithDeferTestNestedUserFragment
+                @dangerously_unaliased_fixme
+                @defer(label: "UserFragment")
+            }
+          }
+        `;
+        const fragment = graphql`
+          fragment RelayModernEnvironmentExecuteWithDeferTestNestedUserFragment on User {
+            id
+            ...RelayModernEnvironmentExecuteWithDeferTestNestedInnerUserFragment
+              @defer
+          }
+        `;
+        const fragmentInner = graphql`
+          fragment RelayModernEnvironmentExecuteWithDeferTestNestedInnerUserFragment on User {
+            name
+            ...RelayModernEnvironmentExecuteWithDeferTestNestedInnerInner2UserFragment
+              @defer
+          }
+        `;
+        const fragmentInnerInner2 = graphql`
+          fragment RelayModernEnvironmentExecuteWithDeferTestNestedInnerInner2UserFragment on User {
+            lastName
+          }
+        `;
+        variables = {id: '1'};
+        operation = createOperationDescriptor(query, variables);
+        selector = createReaderSelector(fragment, '1', {}, operation.request);
+
+        const initialSnapshot = environment.lookup(selector);
+        const callback = jest.fn<[Snapshot], void>();
+        environment.subscribe(initialSnapshot, callback);
+
+        environment.execute({operation}).subscribe(callbacks);
+        const payload: GraphQLResponse = {
+          data: {
+            node: {
+              id: '1',
+              __typename: 'User',
+              name: 'Alice',
+              lastName: 'Bob',
+            },
+          },
+          extensions: {
+            is_final: true,
+          } as PayloadExtensions,
+        };
+
+        expectToWarnMany(
+          [
+            'RelayModernEnvironment: Operation `RelayModernEnvironmentExecuteWithDeferTestNestedUserQuery` contains @defer/@stream ' +
+              'directives but was executed in non-streaming mode. See ' +
+              'https://fburl.com/relay-incremental-delivery-non-streaming-warning.',
+            'RelayModernEnvironment: Operation `RelayModernEnvironmentExecuteWithDeferTestNestedUserQuery` contains @defer/@stream ' +
+              'directives but was executed in non-streaming mode. See ' +
+              'https://fburl.com/relay-incremental-delivery-non-streaming-warning.',
+            'RelayModernEnvironment: Operation `RelayModernEnvironmentExecuteWithDeferTestNestedUserQuery` contains @defer/@stream ' +
+              'directives but was executed in non-streaming mode. See ' +
+              'https://fburl.com/relay-incremental-delivery-non-streaming-warning.',
+          ],
+          () => {
+            dataSource.next(payload);
+          },
+        );
+
+        expect(complete).not.toBeCalled();
+        expect(error).not.toBeCalled();
+        expect(next.mock.calls.length).toBe(1);
+
+        expect(callback.mock.calls.length).toBe(1);
+        const snapshot = callback.mock.calls[0][0];
+        expect(snapshot.isMissingData).toBe(false);
+        expect(snapshot.data?.id).toBe('1');
+
+        const innerSelector = createReaderSelector(
+          fragmentInner,
+          '1',
+          {},
+          operation.request,
+        );
+        const innerSnapshot = environment.lookup(innerSelector);
+        expect(innerSnapshot.isMissingData).toBe(false);
+        expect(innerSnapshot.data?.name).toEqual('Alice');
+
+        const innerInner2Selector = createReaderSelector(
+          fragmentInnerInner2,
+          '1',
+          {},
+          operation.request,
+        );
+        const innerInner2Snapshot = environment.lookup(innerInner2Selector);
+        expect(innerInner2Snapshot.isMissingData).toBe(false);
+        expect(innerInner2Snapshot.data).toEqual({
+          lastName: 'Bob',
+        });
+      });
     });
-    jest.runAllTimers();
 
-    dataSource.next({
-      data: {
-        id: '1',
-        __typename: 'User',
-        name: 'joe',
-      },
-      label: 'UserQuery$defer$UserFragment',
-      path: ['node'],
-    });
+    describe('environment.check() with @defer containing client extension fields', () => {
+      let deferWithClientExtQuery;
 
-    expect(complete).toBeCalledTimes(0);
-    expect(error).toBeCalledTimes(0);
-    expect(next).toBeCalledTimes(2);
-    expect(callback).toBeCalledTimes(2);
+      beforeEach(() => {
+        graphql`
+          fragment RelayModernEnvironmentExecuteWithDeferTestClientExtFragment on User {
+            id
+            name
+            nickname
+          }
+        `;
+        deferWithClientExtQuery = graphql`
+          query RelayModernEnvironmentExecuteWithDeferTestClientExtQuery(
+            $id: ID!
+          ) {
+            node(id: $id) {
+              ...RelayModernEnvironmentExecuteWithDeferTestClientExtFragment
+                @dangerously_unaliased_fixme
+                @defer(label: "ClientExtFragment")
+            }
+          }
+        `;
+      });
 
-    dataSource.complete();
-
-    expect(complete).toBeCalledTimes(1);
-    expect(error).toBeCalledTimes(0);
-    expect(next).toBeCalledTimes(2);
-    expect(callback).toBeCalledTimes(2);
-  });
-
-  it('calls complete() when server completes before deferred payload resolves', () => {
-    const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
-    environment.subscribe(initialSnapshot, callback);
-
-    environment.execute({operation}).subscribe(callbacks);
-    dataSource.next({
-      data: {
-        node: {
+      it('check() returns available after streaming completes even when client extension fields are missing', () => {
+        // This is the production bug: after streaming completes, all
+        // server-delivered fields are in the store, but client extension
+        // fields (like `nickname`) are legitimately absent. Without the fix,
+        // DataChecker traverses into the Defer block, finds the client
+        // extension field missing, and that "missing" status leaks out
+        // because Defer has no save/restore (unlike ClientExtension which
+        // does save/restore).
+        const op = createOperationDescriptor(deferWithClientExtQuery, {
           id: '1',
-          __typename: 'User',
-        },
-      },
-    });
-    jest.runAllTimers();
+        });
+        environment.retain(op);
+        environment.execute({operation: op}).subscribe(callbacks);
 
-    expect(complete).toBeCalledTimes(0);
-    expect(error).toBeCalledTimes(0);
-    expect(next).toBeCalledTimes(1);
-    expect(callback).toBeCalledTimes(1);
+        // Initial payload
+        dataSource.next({
+          data: {
+            node: {
+              id: '1',
+              __typename: 'User',
+            },
+          },
+          hasNext: true,
+        });
+        jest.runAllTimers();
 
-    dataSource.complete();
+        // Incremental payload — server-delivered deferred fields arrive
+        // but client extension field `nickname` is never server-delivered
+        dataSource.next({
+          data: {
+            id: '1',
+            __typename: 'User',
+            name: 'Alice',
+          },
+          label:
+            'RelayModernEnvironmentExecuteWithDeferTestClientExtQuery$defer$ClientExtFragment',
+          path: ['node'],
+          hasNext: false,
+        });
+        jest.runAllTimers();
+        dataSource.complete();
 
-    expect(complete).toBeCalledTimes(1);
-    expect(error).toBeCalledTimes(0);
-    expect(next).toBeCalledTimes(1);
-    expect(callback).toBeCalledTimes(1);
-  });
+        // With the fix: check() should return "available" because the Defer
+        // block isolates missing fields (client extensions are expected to be
+        // absent from server responses).
+        expect(environment.check(op)).toEqual(
+          expect.objectContaining({status: 'available'}),
+        );
+      });
 
-  it('calls error() when server errors after deferred payload resolves', () => {
-    const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
-    environment.subscribe(initialSnapshot, callback);
-
-    environment.execute({operation}).subscribe(callbacks);
-    dataSource.next({
-      data: {
-        node: {
+      it('check() returns available before incremental payload arrives (defer is active)', () => {
+        // Before the deferred payload arrives, ALL fields in the Defer block
+        // are missing. With the fix, active Defer isolates this so check()
+        // doesn't report the whole operation as missing.
+        const op = createOperationDescriptor(deferWithClientExtQuery, {
           id: '1',
-          __typename: 'User',
-        },
-      },
-    });
-    jest.runAllTimers();
+        });
+        environment.retain(op);
+        environment.execute({operation: op}).subscribe(callbacks);
 
-    dataSource.next({
-      data: {
-        id: '1',
-        __typename: 'User',
-        name: 'joe',
-      },
-      label: 'UserQuery$defer$UserFragment',
-      path: ['node'],
-    });
+        // Only initial payload — deferred fields haven't arrived yet
+        dataSource.next({
+          data: {
+            node: {
+              id: '1',
+              __typename: 'User',
+            },
+          },
+          hasNext: true,
+        });
+        jest.runAllTimers();
 
-    expect(complete).toBeCalledTimes(0);
-    expect(error).toBeCalledTimes(0);
-    expect(next).toBeCalledTimes(2);
-    expect(callback).toBeCalledTimes(2);
+        // With the fix: active @defer means missing deferred fields are
+        // expected (they'll arrive via incremental delivery).
+        expect(environment.check(op)).toEqual(
+          expect.objectContaining({status: 'available'}),
+        );
+      });
 
-    const err = new Error('wtf');
-    dataSource.error(err);
-
-    expect(complete).toBeCalledTimes(0);
-    expect(error).toBeCalledTimes(1);
-    expect(error.mock.calls[0][0]).toBe(err);
-    expect(next).toBeCalledTimes(2);
-    expect(callback).toBeCalledTimes(2);
-  });
-
-  it('calls error() when server errors before deferred payload resolves', () => {
-    const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
-    environment.subscribe(initialSnapshot, callback);
-
-    environment.execute({operation}).subscribe(callbacks);
-    dataSource.next({
-      data: {
-        node: {
+      it('check() returns available when defer is inactive and all server fields present', () => {
+        // When @defer is not conditional (always active), this tests the
+        // scenario where data was written via a different code path (e.g.,
+        // a non-deferred query wrote the same fields). The non-deferred
+        // fields are present, client extensions are absent but isolated.
+        const op = createOperationDescriptor(deferWithClientExtQuery, {
           id: '1',
-          __typename: 'User',
-        },
-      },
+        });
+        environment.retain(op);
+        environment.execute({operation: op}).subscribe(callbacks);
+
+        // Initial + deferred payload arrive together
+        dataSource.next({
+          data: {
+            node: {
+              id: '1',
+              __typename: 'User',
+            },
+          },
+          hasNext: true,
+        });
+        dataSource.next({
+          data: {
+            id: '1',
+            __typename: 'User',
+            name: 'Alice',
+          },
+          label:
+            'RelayModernEnvironmentExecuteWithDeferTestClientExtQuery$defer$ClientExtFragment',
+          path: ['node'],
+          hasNext: false,
+        });
+        jest.runAllTimers();
+        dataSource.complete();
+
+        expect(environment.check(op)).toEqual(
+          expect.objectContaining({status: 'available'}),
+        );
+      });
     });
-    jest.runAllTimers();
-
-    expect(complete).toBeCalledTimes(0);
-    expect(error).toBeCalledTimes(0);
-    expect(next).toBeCalledTimes(1);
-    expect(callback).toBeCalledTimes(1);
-
-    const err = new Error('wtf');
-    dataSource.error(err);
-
-    expect(complete).toBeCalledTimes(0);
-    expect(error).toBeCalledTimes(1);
-    expect(error.mock.calls[0][0]).toBe(err);
-    expect(next).toBeCalledTimes(1);
-    expect(callback).toBeCalledTimes(1);
-  });
-
-  it('calls error() when deferred payload is missing data', () => {
-    const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
-    environment.subscribe(initialSnapshot, callback);
-
-    environment.execute({operation}).subscribe(callbacks);
-    dataSource.next({
-      data: {
-        node: {
-          id: '1',
-          __typename: 'User',
-        },
-      },
-    });
-    jest.runAllTimers();
-
-    expect(complete).toBeCalledTimes(0);
-    expect(error).toBeCalledTimes(0);
-    expect(next).toBeCalledTimes(1);
-    expect(callback).toBeCalledTimes(1);
-
-    dataSource.next({
-      errors: [
-        {
-          message: 'wtf',
-          locations: [],
-          severity: 'ERROR',
-        },
-      ],
-      label: 'UserQuery$defer$UserFragment',
-      path: ['node'],
-    });
-
-    expect(complete).toBeCalledTimes(0);
-    expect(error).toBeCalledTimes(1);
-    expect(error.mock.calls[0][0].message).toContain(
-      'No data returned for operation `UserQuery`',
-    );
-    expect(next).toBeCalledTimes(1);
-    expect(callback).toBeCalledTimes(1);
-  });
-
-  it('warns if executed in non-streaming mode and processes deferred selections', () => {
-    const initialSnapshot = environment.lookup(selector);
-    const callback = jest.fn();
-    environment.subscribe(initialSnapshot, callback);
-
-    environment.execute({operation}).subscribe(callbacks);
-    const payload = {
-      data: {
-        node: {
-          id: '1',
-          __typename: 'User',
-          name: 'Alice',
-        },
-      },
-      extensions: {
-        is_final: true,
-      },
-    };
-    dataSource.next(payload);
-    jest.runAllTimers();
-
-    expect(next.mock.calls.length).toBe(1);
-    expect(complete).not.toBeCalled();
-    expect(error).not.toBeCalled();
-    expect(callback.mock.calls.length).toBe(2);
-    const snapshot = callback.mock.calls[0][0];
-    expect(snapshot.isMissingData).toBe(true);
-    expect(snapshot.data).toEqual({
-      id: '1',
-      name: undefined, // not initially published
-    });
-    const snapshot2 = callback.mock.calls[1][0];
-    expect(snapshot2.isMissingData).toBe(false);
-    expect(snapshot2.data).toEqual({
-      id: '1',
-      name: 'ALICE',
-    });
-    expect(warning).toHaveBeenCalledWith(
-      false,
-      'RelayModernEnvironment: Operation `%s` contains @defer/@stream ' +
-        'directives but was executed in non-streaming mode. See ' +
-        'https://fburl.com/relay-incremental-delivery-non-streaming-warning.',
-      'UserQuery',
-    );
-  });
-
-  it('warns if executed in non-streaming mode and skips deferred selections if cancelled', () => {
-    const initialSnapshot = environment.lookup(selector);
-    let subscription = null;
-    const callback = jest.fn(() => {
-      if (subscription != null) {
-        subscription.unsubscribe();
-        subscription = null;
-      }
-    });
-    environment.subscribe(initialSnapshot, callback);
-
-    subscription = environment.execute({operation}).subscribe(callbacks);
-    const payload = {
-      data: {
-        node: {
-          id: '1',
-          __typename: 'User',
-          name: 'Alice',
-        },
-      },
-      extensions: {
-        is_final: true,
-      },
-    };
-    dataSource.next(payload);
-    jest.runAllTimers();
-
-    expect(next).not.toBeCalled();
-    expect(complete).not.toBeCalled();
-    expect(error).not.toBeCalled();
-    expect(callback.mock.calls.length).toBe(1);
-    const snapshot = callback.mock.calls[0][0];
-    expect(snapshot.isMissingData).toBe(true);
-    expect(snapshot.data).toEqual({
-      id: '1',
-      name: undefined, // not initially published
-    });
-    expect(warning).not.toHaveBeenCalledWith(
-      false,
-      'RelayModernEnvironment: Operation `%s` contains @defer/@stream ' +
-        'directives but was executed in non-streaming mode. See ' +
-        'https://fburl.com/relay-incremental-delivery-non-streaming-warning.',
-      'UserQuery',
-    );
-  });
-});
+  },
+);

--- a/packages/relay-runtime/store/__tests__/__generated__/DataCheckerTestDeferIfFragment.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/DataCheckerTestDeferIfFragment.graphql.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type DataCheckerTestDeferIfFragment$fragmentType: FragmentType;
+export type DataCheckerTestDeferIfFragment$data = {|
+  +id: string,
+  +name: ?string,
+  +$fragmentType: DataCheckerTestDeferIfFragment$fragmentType,
+|};
+export type DataCheckerTestDeferIfFragment$key = {
+  +$data?: DataCheckerTestDeferIfFragment$data,
+  +$fragmentSpreads: DataCheckerTestDeferIfFragment$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "DataCheckerTestDeferIfFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*:: as any*/).hash = "datachecker_test_defer_if_fragment";
+}
+
+module.exports = ((node/*:: as any*/)/*:: as Fragment<
+  DataCheckerTestDeferIfFragment$fragmentType,
+  DataCheckerTestDeferIfFragment$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/DataCheckerTestDeferIfQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/DataCheckerTestDeferIfQuery.graphql.js
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<>>
+ * @flow
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { DataCheckerTestDeferIfFragment$fragmentType } from "./DataCheckerTestDeferIfFragment.graphql";
+export type DataCheckerTestDeferIfQuery$variables = {|
+  id: string,
+  shouldDefer: boolean,
+|};
+export type DataCheckerTestDeferIfQuery$data = {|
+  +node: ?{|
+    +$fragmentSpreads: DataCheckerTestDeferIfFragment$fragmentType,
+  |},
+|};
+export type DataCheckerTestDeferIfQuery = {|
+  response: DataCheckerTestDeferIfQuery$data,
+  variables: DataCheckerTestDeferIfQuery$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "shouldDefer"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "DataCheckerTestDeferIfQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "kind": "Defer",
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "DataCheckerTestDeferIfFragment"
+              }
+            ]
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Operation",
+    "name": "DataCheckerTestDeferIfQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          {
+            "if": "shouldDefer",
+            "kind": "Defer",
+            "label": "DataCheckerTestDeferIfQuery$defer$TestFragment",
+            "selections": [
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  (v2/*:: as any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "name",
+                    "storageKey": null
+                  }
+                ],
+                "type": "User",
+                "abstractKey": null
+              }
+            ]
+          },
+          (v2/*:: as any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "datachecker_test_defer_if_query",
+    "id": null,
+    "metadata": {},
+    "name": "DataCheckerTestDeferIfQuery",
+    "operationKind": "query",
+    "text": "query DataCheckerTestDeferIfQuery(\n  $id: ID!\n  $shouldDefer: Boolean!\n) {\n  node(id: $id) {\n    __typename\n    ...DataCheckerTestDeferIfFragment @defer(if: $shouldDefer, label: \"DataCheckerTestDeferIfQuery$defer$TestFragment\")\n    id\n  }\n}\n\nfragment DataCheckerTestDeferIfFragment on User {\n  id\n  name\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*:: as any*/).hash = "datachecker_test_defer_if_query";
+}
+
+module.exports = ((node/*:: as any*/)/*:: as Query<
+  DataCheckerTestDeferIfQuery$variables,
+  DataCheckerTestDeferIfQuery$data,
+>*/);


### PR DESCRIPTION
When @defer is active (unconditional or if: true), the DataChecker now saves/restores _recordWasMissing before traversing deferred selections. This prevents missing fields inside active @defer blocks (such as client extension fields that are never server-delivered) from causing check() to incorrectly report the operation as "missing".

This mirrors the existing pattern used by the ClientExtension case.