### PR TITLE
Fix CI: Enable flow_modern_syntax in OSS test config

### DIFF
--- a/scripts/config.tests.json
+++ b/scripts/config.tests.json
@@ -69,6 +69,9 @@
         },
         "allow_legacy_relay_resolver_tag": {
           "kind": "enabled"
+        },
+        "flow_modern_syntax": {
+          "kind": "enabled"
         }
       },
       "language": "flow",


### PR DESCRIPTION
## Summary

- The "Compiler output check" CI job has been failing on all recent commits since `045f228` ("Implement feature flag to gate rollout of flow modern syntax")
- That commit added a `flow_modern_syntax` feature flag and enabled it in the Rust test fixtures, but did not add it to `scripts/config.tests.json`
- When CI regenerates Flow artifacts using `config.tests.json`, it produces classic Flow syntax (`+` for readonly, `{||}` for exact objects) while the committed files use modern syntax (`readonly`, `{}`)
- This adds `"flow_modern_syntax": {"kind": "enabled"}` to the feature flags in `scripts/config.tests.json` to match

## Test plan

- CI should pass on this PR — the "Compiler output check" job should no longer show diffs in generated Flow files