### PR TITLE
Add TypeScript declarations for relay-test-utils

### DIFF
--- a/packages/relay-test-utils/index.d.ts
+++ b/packages/relay-test-utils/index.d.ts
@@ -1,0 +1,133 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import type {
+  CacheConfig,
+  ConcreteRequest,
+  EnvironmentConfig,
+  GraphQLResponse,
+  GraphQLSingularResponse,
+  GraphQLTaggedNode,
+  IEnvironment,
+  OperationDescriptor,
+  Variables,
+} from 'relay-runtime';
+
+export type MockResolverContext = Readonly<{
+  parentType: string | null | undefined;
+  name: string | null | undefined;
+  alias: string | null | undefined;
+  path: readonly string[] | null | undefined;
+  args: Readonly<Record<string, unknown>> | null | undefined;
+}>;
+
+export type MockResolver = (context: MockResolverContext, generateId: () => number) => unknown;
+
+export type MockResolvers = Readonly<Record<string, MockResolver>>;
+
+export type MockPayloadGeneratorOptions = Readonly<{
+  mockClientData?: boolean | undefined;
+}>;
+
+export type MockPayloadGeneratorDeferOptions = MockPayloadGeneratorOptions &
+  Readonly<{
+    generateDeferredPayload?: boolean | undefined;
+  }>;
+
+export interface RelayMockPayloadGenerator {
+  generate(
+    operation: OperationDescriptor,
+    mockResolvers?: MockResolvers | null | undefined,
+    options?: MockPayloadGeneratorOptions | null | undefined,
+  ): GraphQLSingularResponse;
+  generateWithDefer(
+    operation: OperationDescriptor,
+    mockResolvers: MockResolvers | null | undefined,
+    options: MockPayloadGeneratorOptions & Readonly<{ generateDeferredPayload: true }>,
+  ): readonly GraphQLSingularResponse[];
+  generateWithDefer(
+    operation: OperationDescriptor,
+    mockResolvers?: MockResolvers | null | undefined,
+    options?: MockPayloadGeneratorDeferOptions | null | undefined,
+  ): GraphQLResponse;
+}
+
+export const MockPayloadGenerator: RelayMockPayloadGenerator;
+
+type ConcreteRequestOrOperation = ConcreteRequest | OperationDescriptor;
+
+export type OperationMockResolver = (
+  operation: OperationDescriptor,
+) => GraphQLSingularResponse | Error | null | undefined;
+
+export interface MockFunctions {
+  clearCache(): void;
+  cachePayload(
+    request: ConcreteRequestOrOperation,
+    variables: Variables,
+    payload: GraphQLSingularResponse,
+  ): void;
+  isLoading(
+    request: ConcreteRequestOrOperation,
+    variables: Variables,
+    cacheConfig?: CacheConfig,
+  ): boolean;
+  reject(request: ConcreteRequestOrOperation, error: Error | string): void;
+  nextValue(request: ConcreteRequestOrOperation, payload: GraphQLSingularResponse): void;
+  complete(request: ConcreteRequestOrOperation): void;
+  resolve(
+    request: ConcreteRequestOrOperation,
+    payload: readonly GraphQLSingularResponse[] | GraphQLSingularResponse,
+  ): void;
+  getAllOperations(): readonly OperationDescriptor[];
+  findOperation(findFn: (operation: OperationDescriptor) => boolean): OperationDescriptor;
+  queuePendingOperation(query: GraphQLTaggedNode, variables: Variables): void;
+  getMostRecentOperation(): OperationDescriptor;
+  resolveMostRecentOperation(
+    payload: GraphQLResponse | ((operation: OperationDescriptor) => GraphQLResponse),
+  ): void;
+  rejectMostRecentOperation(
+    error: Error | string | ((operation: OperationDescriptor) => Error | string),
+  ): void;
+  queueOperationResolver(resolver: OperationMockResolver): void;
+}
+
+export interface RelayMockEnvironment extends IEnvironment {
+  readonly mock: MockFunctions;
+  readonly mockClear: () => void;
+}
+
+export interface RelayModernMockEnvironment {
+  createMockEnvironment(config?: Partial<EnvironmentConfig>): RelayMockEnvironment;
+}
+
+export const MockEnvironment: RelayModernMockEnvironment;
+
+export function createMockEnvironment(config?: Partial<EnvironmentConfig>): RelayMockEnvironment;
+
+export function unwrapContainer<TComponent>(ComponentClass: {
+  readonly __ComponentClass?: TComponent | undefined;
+  readonly displayName?: string | undefined;
+  readonly name?: string | undefined;
+}): TComponent;
+
+type FragmentDataFromResolverArgument<T> = T extends {
+  readonly ' $data'?: infer Data | undefined;
+}
+  ? NonNullable<Data>
+  : T extends {
+      readonly $data?: infer Data | undefined;
+    }
+  ? NonNullable<Data>
+  : unknown;
+
+type StripFragmentType<T> = Omit<T, ' $fragmentType' | '$fragmentType'>;
+
+export function testResolver<TKey, TRet>(
+  resolver: (rootKey: TKey) => TRet,
+  fragmentData: StripFragmentType<FragmentDataFromResolverArgument<TKey>>,
+): TRet;

--- a/packages/relay-test-utils/index.js
+++ b/packages/relay-test-utils/index.js
@@ -17,7 +17,7 @@
 
 const RelayMockPayloadGenerator = require('./RelayMockPayloadGenerator');
 const RelayModernMockEnvironment = require('./RelayModernMockEnvironment');
-const testResolver = require('./RelayResolverTestUtils');
+const {testResolver} = require('./RelayResolverTestUtils');
 const unwrapContainer = require('./unwrapContainer');
 
 export type {MockResolvers} from './RelayMockPayloadGenerator';

--- a/packages/relay-test-utils/package.json
+++ b/packages/relay-test-utils/package.json
@@ -24,5 +24,6 @@
     "": "./"
   },
   "main": "index.js",
+  "types": "index.d.ts",
   "haste_commonjs": true
 }


### PR DESCRIPTION
## Summary

Adds first-class TypeScript declarations for the public `relay-test-utils` entrypoint, mirroring the package metadata and declaration-copying setup already used by `relay-runtime` and `react-relay`.

This covers `MockPayloadGenerator`, `createMockEnvironment`, the mock environment helper API, mock resolver types, `unwrapContainer`, and `testResolver`.

## Validation

- `npx prettier --write packages/relay-test-utils/index.js packages/relay-test-utils/package.json packages/relay-test-utils/index.d.ts`
- Temporary TypeScript consumer compiled with `typescript@5.8.3`
- Negative `testResolver` type checks rejected extra fields and wrong scalar types
- `node scripts/testDependencies.js`
- `npm run build:clean`
- `npm run build`
- Verified `dist/relay-test-utils/index.d.ts` is generated and `dist/relay-test-utils/package.json` contains `"types": "index.d.ts"`
- `npm pack --dry-run --json` from `dist/relay-test-utils` includes `index.d.ts`
- `npm pack --pack-destination <tmp> --json ./dist/relay-test-utils`, extracted the generated tarball, and compiled a TypeScript consumer against the packaged `relay-test-utils` contents
