### PR TITLE
Show config help hint on config parse errors

### DIFF
--- a/compiler/crates/relay-bin/src/errors.rs
+++ b/compiler/crates/relay-bin/src/errors.rs
@@ -18,6 +18,9 @@ pub enum Error {
     #[error("{0}")]
     ConfigError(relay_compiler::errors::Error),
 
+    #[error("{source}\n\nHint: You can dump the config JSON schema with:\n  relay-compiler config-json-schema\n\nFor documentation, see:\n  https://relay.dev/docs/getting-started/compiler-config/")]
+    ConfigErrorWithHint { source: Box<Error> },
+
     #[error("Unable to run relay compiler. Error details: \n{details}")]
     CompilerError { details: String },
 

--- a/compiler/crates/relay-bin/src/errors.rs
+++ b/compiler/crates/relay-bin/src/errors.rs
@@ -18,7 +18,9 @@ pub enum Error {
     #[error("{0}")]
     ConfigError(relay_compiler::errors::Error),
 
-    #[error("{source}\n\nHint: You can dump the config JSON schema with:\n  relay-compiler config-json-schema\n\nFor documentation, see:\n  https://relay.dev/docs/getting-started/compiler-config/")]
+    #[error(
+        "{source}\n\nHint: You can dump the config JSON schema with:\n  relay-compiler config-json-schema\n\nFor documentation, see:\n  https://relay.dev/docs/getting-started/compiler-config/"
+    )]
     ConfigErrorWithHint { source: Box<Error> },
 
     #[error("Unable to run relay compiler. Error details: \n{details}")]

--- a/compiler/crates/relay-bin/src/main.rs
+++ b/compiler/crates/relay-bin/src/main.rs
@@ -278,11 +278,23 @@ async fn main() {
 }
 
 fn get_config(config_path: Option<PathBuf>) -> Result<Config, Error> {
-    match config_path {
-        Some(config_path) => Config::load(config_path).map_err(Error::ConfigError),
-        None => Config::search(&current_dir().expect("Unable to get current working directory."))
-            .map_err(Error::ConfigError),
-    }
+    let result = match config_path {
+        Some(config_path) => Config::load(config_path),
+        None => Config::search(&current_dir().expect("Unable to get current working directory.")),
+    };
+    result.map_err(|err| {
+        let is_config_error = matches!(
+            err,
+            CompilerError::ConfigError { .. } | CompilerError::ConfigFileValidation { .. }
+        );
+        let mut err = Error::ConfigError(err);
+        if is_config_error {
+            err = Error::ConfigErrorWithHint {
+                source: Box::new(err),
+            };
+        }
+        err
+    })
 }
 
 fn configure_logger(output: OutputKind, terminal_mode: TerminalMode) {


### PR DESCRIPTION
## Summary

Relay config is quite extensive and as a result and be quite confusing. Our error messages are pretty good, but both humans and agents are easily confused. This allows us to give direct access to what config options exist:

1. Agents can invoke the compiler and parse/explore the json schema
2. Humans can visit our docs (which are generated from the json schema)

Example output on a config error:
```
Unable to initialize relay compiler configuration. Error details:
Error searching config: Invalid config file: ...

Hint: You can dump the config JSON schema with:
  relay-compiler config-json-schema

For documentation, see:
  https://relay.dev/docs/getting-started/compiler-config/
```

## Test plan

- [ ] CI passes
- [ ] Manually verify with an invalid `relay.config.json` that the hint appears