### PR TITLE
Fix TodoMVC example commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ The [relay-examples](https://github.com/relayjs/relay-examples) repository conta
 git clone https://github.com/relayjs/relay-examples.git
 cd relay-examples/todo
 yarn
-yarn build
-yarn start
+yarn grats
+yarn relay
+yarn dev
 ```
 
-Then, just point your browser at `http://localhost:3000`.
+Then, just point your browser at `http://localhost:5173`.
 
 ## Contribute
 


### PR DESCRIPTION
# Summary:
The "Example" section told users to run `yarn build` and `yarn start`,
but the relay-examples/todo app has no `start` script and uses Vite. Running
`yarn start` fails with "Couldn't find a script named start". Updated the
instructions to the actual scripts (`yarn grats`, `yarn relay`, `yarn dev`). Found in the [TodoMVC README](https://github.com/relayjs/relay-examples/tree/main/todo)
and corrected the URL to the Vite dev server port `5173`.

# Test Plan:
Followed the updated steps in a fresh clone of relay-examples/todo; the app
serves at http://localhost:5173.