### PR TITLE
QueryResource: don't resurrect disposed cache entries in next/error

### DIFF
--- a/packages/react-relay/relay-hooks/QueryResource.js
+++ b/packages/react-relay/relay-hooks/QueryResource.js
@@ -437,6 +437,15 @@ class QueryResourceImpl {
       }
     }
 
+    // Tracks whether this call has ever populated a cache entry for
+    // `cacheIdentifier`. Used by the `next`/`error` callbacks below to
+    // distinguish "entry not yet created" (synchronous observable that
+    // fires during `.subscribe()`, before the post-subscribe creation
+    // path at the bottom runs) from "entry was created and has since
+    // been disposed" (StrictMode / navigation / suspended-and-discarded
+    // — in which case we must NOT resurrect it).
+    let entryHasBeenCreated = false;
+
     // NOTE: If this value is false, we will cache a promise for this
     // query, which means we will suspend here at this query root.
     // If it's true, we will cache the query resource and allow rendering to
@@ -452,6 +461,7 @@ class QueryResourceImpl {
         this._clearCacheEntry,
       );
       this._cache.set(cacheIdentifier, cacheEntry);
+      entryHasBeenCreated = true;
     }
 
     if (shouldFetch) {
@@ -479,13 +489,45 @@ class QueryResourceImpl {
           }
         },
         next: () => {
-          const cacheEntry = this._getOrCreateCacheEntry(
-            cacheIdentifier,
-            operation,
-            queryAvailability,
-            queryResult,
-            networkSubscription,
-          );
+          // Do not resurrect a cache entry that has already been
+          // disposed. This can happen when a fetch is in flight during
+          // React Strict Mode's mount/unmount/mount cycle (or Offscreen
+          // / fast refresh): `prepareWithIdentifier` creates the entry,
+          // the strict-mode effect cleanup in `useLazyLoadQueryNode`
+          // disposes it, and `forceUpdate` produces a *new* entry with
+          // a different cacheBreaker. If we resurrected the original
+          // entry here, it would re-enter the LRU with no permanent
+          // retain (no useEffect ever attached to it), survive the
+          // component's eventual unmount, and be reused by a later
+          // mount that computes the same cacheIdentifier — pointing at
+          // records the GC has since reclaimed.
+          //
+          // The store still receives the data via normalization; any
+          // *live* cache entry sharing this fetch (deduped through
+          // `fetchQuery`) receives its own `next` and updates its value
+          // correctly. Dropping the update on a disposed entry is the
+          // right behavior.
+          //
+          // We must still create the entry on the *first* `next` if
+          // the observable fires synchronously inside `.subscribe()`
+          // (e.g. cached/mocked transports): in that case the
+          // post-subscribe creation path below hasn't run yet, and no
+          // entry has ever existed for this fetch — there is nothing
+          // to resurrect.
+          let cacheEntry = this._cache.get(cacheIdentifier);
+          if (cacheEntry == null) {
+            if (entryHasBeenCreated) {
+              return;
+            }
+            cacheEntry = this._getOrCreateCacheEntry(
+              cacheIdentifier,
+              operation,
+              queryAvailability,
+              queryResult,
+              networkSubscription,
+            );
+            entryHasBeenCreated = true;
+          }
           cacheEntry.processedPayloadsCount += 1;
           cacheEntry.setValue(queryResult);
           resolveNetworkPromise();
@@ -497,13 +539,23 @@ class QueryResourceImpl {
           }
         },
         error: error => {
-          const cacheEntry = this._getOrCreateCacheEntry(
-            cacheIdentifier,
-            operation,
-            queryAvailability,
-            error,
-            networkSubscription,
-          );
+          // See the comment on `next` above: do not resurrect a
+          // disposed cache entry, but do create the entry on a
+          // first-time synchronous fire.
+          let cacheEntry = this._cache.get(cacheIdentifier);
+          if (cacheEntry == null) {
+            if (entryHasBeenCreated) {
+              return;
+            }
+            cacheEntry = this._getOrCreateCacheEntry(
+              cacheIdentifier,
+              operation,
+              queryAvailability,
+              error,
+              networkSubscription,
+            );
+            entryHasBeenCreated = true;
+          }
 
           // If, this is the first thing we receive for the query,
           // before any other payload handled is error, we will cache and
@@ -562,6 +614,7 @@ class QueryResourceImpl {
           this._clearCacheEntry,
         );
         this._cache.set(cacheIdentifier, cacheEntry);
+        entryHasBeenCreated = true;
       }
     } else {
       const observerComplete = observer?.complete;

--- a/packages/react-relay/relay-hooks/__tests__/QueryResource-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/QueryResource-test.js
@@ -2216,6 +2216,147 @@ describe('QueryResource', () => {
     });
   });
 
+  describe('prepare, when a fetch lands after the cache entry has been disposed', () => {
+    // Regression test: a cache entry that has been disposed (e.g. by
+    // an expired temporary retain on a render that never committed —
+    // StrictMode cleanup, navigation away mid-fetch, suspended subtree
+    // discarded by concurrent rendering) must NOT be resurrected by a
+    // late `next` or `error` from its still-live network subscription.
+    // Resurrecting it would leave a refcount-0 zombie in the LRU with
+    // no useEffect to dispose it, which a later mount computing the
+    // same cacheIdentifier would happily reuse — bypassing the fetch
+    // path and potentially reading store records that have since been
+    // GC'd.
+    it.each([
+      ['network-only', 'full'],
+      ['network-only', 'partial'],
+      ['store-and-network', 'full'],
+      ['store-and-network', 'partial'],
+      ['store-or-network', 'full'],
+      ['store-or-network', 'partial'],
+    ])(
+      'does not resurrect the entry on late `next` (fetchPolicy: %s, renderPolicy: %s)',
+      (testFetchPolicy: FetchPolicy, testRenderPolicy: RenderPolicy) => {
+        let sink;
+        const lateFetchObservable = Observable.create<$FlowFixMe>(s => {
+          sink = s;
+        });
+
+        // Initial render: creates the cache entry and starts the fetch.
+        // No `QueryResource.retain` is called — simulates a render
+        // whose commit never happens.
+        try {
+          QueryResource.prepare(
+            queryMissingData,
+            lateFetchObservable,
+            testFetchPolicy,
+            testRenderPolicy,
+          );
+        } catch (thrown) {
+          // Network-only (and any path with no committed data) throws
+          // a Promise to suspend; that's fine for this test.
+          expect(typeof thrown.then).toBe('function');
+        }
+        expect(
+          QueryResource.TESTS_ONLY__getCacheEntry(
+            queryMissingData,
+            testFetchPolicy,
+            testRenderPolicy,
+          ),
+        ).not.toBeUndefined();
+
+        // Temporary retain expires (the render never committed) — the
+        // cache entry is disposed.
+        jest.runAllTimers();
+        expect(release).toBeCalledTimes(1);
+        expect(
+          QueryResource.TESTS_ONLY__getCacheEntry(
+            queryMissingData,
+            testFetchPolicy,
+            testRenderPolicy,
+          ),
+        ).toBeUndefined();
+
+        // Late payload after dispose. The subscription is still alive
+        // (regular, non-live queries don't unsubscribe on dispose so
+        // that other live entries deduped onto the same fetch can
+        // receive their value). The disposed entry must stay disposed.
+        if (sink == null) {
+          throw new Error('Expected sink to be defined');
+        }
+        environment.commitPayload(queryMissingData, {
+          node: {
+            __typename: 'User',
+            id: '4',
+            name: 'User 4',
+          },
+        });
+        const snapshot = environment.lookup(queryMissingData.fragment);
+        sink.next(snapshot as $FlowFixMe);
+        sink.complete();
+
+        expect(
+          QueryResource.TESTS_ONLY__getCacheEntry(
+            queryMissingData,
+            testFetchPolicy,
+            testRenderPolicy,
+          ),
+        ).toBeUndefined();
+      },
+    );
+
+    it('does not resurrect the entry on late `error`', () => {
+      fetchPolicy = 'network-only';
+      renderPolicy = 'partial';
+
+      let sink;
+      const lateErrorFetchObservable = Observable.create<$FlowFixMe>(s => {
+        sink = s;
+      });
+
+      try {
+        QueryResource.prepare(
+          queryMissingData,
+          lateErrorFetchObservable,
+          fetchPolicy,
+          renderPolicy,
+        );
+      } catch (thrown) {
+        expect(typeof thrown.then).toBe('function');
+      }
+      expect(
+        QueryResource.TESTS_ONLY__getCacheEntry(
+          queryMissingData,
+          fetchPolicy,
+          renderPolicy,
+        ),
+      ).not.toBeUndefined();
+
+      jest.runAllTimers();
+      expect(release).toBeCalledTimes(1);
+      expect(
+        QueryResource.TESTS_ONLY__getCacheEntry(
+          queryMissingData,
+          fetchPolicy,
+          renderPolicy,
+        ),
+      ).toBeUndefined();
+
+      if (sink == null) {
+        throw new Error('Expected sink to be defined');
+      }
+      sink.error(new Error('Oops'));
+
+      expect(
+        QueryResource.TESTS_ONLY__getCacheEntry(
+          queryMissingData,
+          fetchPolicy,
+          renderPolicy,
+        ),
+      ).toBeUndefined();
+    });
+  });
+
   describe('retain', () => {
     beforeEach(() => {
       fetchPolicy = 'store-or-network';


### PR DESCRIPTION
When a QueryResource cache entry is disposed while its fetch is still in flight, the `next` and `error` callbacks in `_fetchAndSaveQuery` call `_getOrCreateCacheEntry`, which silently recreates the entry in the LRU under the same cacheIdentifier. The resurrected entry has refcount 0 — no permanent retain was ever attached to it by `QueryResource.retain`, and no useEffect cleanup will ever fire. It outlives navigation, sits in the LRU until evicted by capacity, and gets reused on a later mount that happens to compute the same cacheIdentifier.

Reusing the zombie skips `prepareWithIdentifier`'s `_fetchAndSaveQuery` path entirely: no `environment.check`, no fetch. By the time the zombie is reused, the store records uniquely retained by this query have likely been freed — released to the GC buffer when the original entry was disposed, then reclaimed by a later GC sweep triggered by an unrelated operation. The fragment reader walks into the data, hits a missing pageInfo or `@connection`-key tracker record (or any record selected only by this query), and returns `undefined` for the affected field. The application sees `useLazyLoadQuery` return a data ref whose fields are unexpectedly undefined, with no fetch, no error, and no suspension to recover.

Several scenarios can dispose an entry while its fetch is in flight:

- **React StrictMode**, where the mount/cleanup/mount cycle of `useLazyLoadQueryNode` synchronously disposes the cache entry created during the initial render, then the `maybeHiddenOrFastRefresh` path triggers a `forceUpdate` that creates a new entry under a different cacheBreaker. The original fetch is still alive on the deduped observable; when it lands, the disposed entry is resurrected alongside the new one being updated. This is the most reliable trigger and is what made the bug observable to us.

- **Navigating away mid-fetch**. A user clicks into a route that cache-misses, the fetch starts, the user navigates away before it completes. The route unmounts, the cache entry is disposed. When the fetch lands, the disposed entry is resurrected.

- **Concurrent rendering discarding a suspended subtree**. A component throws a Promise from `useLazyLoadQuery`; React suspends. A parent transitions away before the fetch completes; the suspended render never commits. The temporary retain expires after `TEMPORARY_RETAIN_DURATION_MS` (5 minutes) and the entry is disposed. The fetch — started synchronously inside `_fetchAndSaveQuery` *before* the component suspended — continues to completion and resurrects the entry.

- **Offscreen / fast refresh**, which produce similar dispose-while- fetching cycles. The `maybeHiddenOrFastRefresh` comment in `useLazyLoadQueryNode` already calls these out as the rationale for its forceUpdate path.

In all of these, the dispose path in `createCacheEntry`'s `SuspenseResource` only unsubscribes the network observable for live queries; for regular queries the subscription stays alive precisely so late payloads can land. That is what allows the `next`/`error` callbacks to fire on a disposed entry. Cancelling the subscription on dispose is not the right fix — the fetch is deduped via `fetchQueryDeduped` and may also be attached to a *live* cache entry sharing the same fetch identifier (most obviously the post-`forceUpdate` entry in the StrictMode case), which still needs to receive its `next`.

The fix is to make `next` and `error` bail when the cache entry has been disposed, while still allowing them to *create* the entry on a first-time synchronous fire. The store still receives the data via the normalizer (`execute.normalize.*`), so any live entry for the same fetch is updated correctly; only the zombie write is skipped.

A naive `this._cache.get(cacheIdentifier) == null → bail` check conflates two different states: "the entry has been disposed" (the zombie case we want to suppress) and "the entry has not yet been created" (a synchronous observable that fires `next`/`error` *during* the `.subscribe()` call, before the post-subscribe creation block at the bottom of `_fetchAndSaveQuery` runs). The latter happens with cached or mocked transports — `network-only` with a synchronous fetch observable is the canonical case, and the test suite exercises it directly. Bailing there would drop the only payload the entry will ever see, leaving the post-subscribe block to cache a `networkPromise` that never resolves; the component then suspends indefinitely on success, or sees a Promise instead of the Error on failure.

To distinguish the two states, `_fetchAndSaveQuery` tracks a local `entryHasBeenCreated` flag, flipped to true at each site that populates the LRU for this `cacheIdentifier` (the `shouldAllowRender` block, the first-fire branch inside `next`/`error`, and the post-subscribe `networkPromise` creation). The callbacks bail only when the entry is missing *and* was previously created. First-time synchronous fires fall through to `_getOrCreateCacheEntry` exactly as before.

For an `error` arriving after the entry has been disposed, the error is dropped instead of being cached for later re-throw. This is correct: the entry has no useEffect retainers, so there is no consumer to read a cached error. A fresh mount with the same cacheIdentifier will trigger a new fetch and observe the error (or success) on its own.

The StrictMode case is easy to reproduce and likely accounts for most of the dev-time pain. The prod-side triggers (mid-fetch navigation, suspended-and-discarded renders) are observed in the wild but rare: they leave a zombie behind only if the user later revisits a mount that computes the same cacheIdentifier, *and* the records the query uniquely retains have been GC'd in the meantime. Most apps don't notice because most records are co-retained by multiple operations and survive GC regardless. Apps with at least one query that uniquely retains some records (e.g. a `@connection(key: ...)` selection whose records aren't selected by any other live query — common in chat-style features) will eventually hit it.