### PR TITLE
Fix circular EntryPoint type aliases in react-relay bundled .d.ts

### DIFF
--- a/packages/react-relay/ReactRelayTypes.d.ts
+++ b/packages/react-relay/ReactRelayTypes.d.ts
@@ -178,20 +178,20 @@ export type PreloadQueryStatus = Readonly<{
  * TExtraProps - a bag of extra props that you may define in `entrypoint` file
  * and they will be passed to the EntryPointComponent as `extraProps`
  */
-type InternalEntryPointRepresentation<
+interface InternalEntryPointRepresentation<
     TEntryPointParams extends Record<string, unknown>,
     TPreloadedQueries extends Record<string, OperationType>,
     TNestedEntryPoints extends Record<string, unknown>,
     TRuntimeProps extends Record<string, unknown>,
     TExtraProps extends Record<string, unknown> | null,
-> = Readonly<{
+> extends Readonly<{
     root: JSResourceReference<
         EntryPointComponent<TPreloadedQueries, TNestedEntryPoints, TRuntimeProps, TExtraProps>
     >;
     getPreloadProps: (
         entryPointParams: TEntryPointParams,
     ) => PreloadProps<TEntryPointParams, TPreloadedQueries, TNestedEntryPoints, TExtraProps>;
-}>;
+}> {}
 
 type ThinQueryParamsObject<TPreloadedQueries extends Record<string, OperationType> = Record<string, never>> = {
     [K in keyof TPreloadedQueries]: ThinQueryParams<TPreloadedQueries[K]>;
@@ -229,12 +229,12 @@ export type PreloadProps<
     queries?: ThinQueryParamsObject<TPreloadedQueries> | undefined;
 }>;
 
-export type EntryPointProps<TPreloadedQueries, TNestedEntryPoints, TRuntimeProps, TExtraProps> = Readonly<{
+export interface EntryPointProps<TPreloadedQueries, TNestedEntryPoints, TRuntimeProps, TExtraProps> extends Readonly<{
     entryPoints: PreloadedEntryPoints<TNestedEntryPoints>;
     extraProps: TExtraProps;
     props: TRuntimeProps;
     queries: PreloadedQueries<TPreloadedQueries>;
-}>;
+}> {}
 
 export type EntryPointComponent<
     TPreloadedQueries extends Record<string, OperationType>,


### PR DESCRIPTION
Relay 21 started shipping its own bundled `ReactRelayTypes.d.ts`, meaning we do not need to use `@types/react-relay` anymore. :partying_face: 

However, `InternalEntryPointRepresentation` and `EntryPointProps` both participate in a circular reference:

```
EntryPointComponent
  -> nested entrypoint constraint (EntryPoint<any, any>)
  -> InternalEntryPointRepresentation
  -> EntryPointComponent
```

TypeScript resolves `type` aliases eagerly, so this cycle collapses - consumers see `Type 'EntryPoint' is not generic`, and any conditional that infers an `EntryPointComponent<...>` through a `JSResourceReference` collapses its inferred parameter to `never`.

In `@types/react-relay` these two types were both declared as interfaces, which are lazily resolved by name (and therefore tolerate the recursion). This means that when projects jump from 20 to 21, they may see type check failures.

We thus change these `type` aliases to `interface`, leaving the shape unchanged to limit the blast radius of what is technically a breaking change.

Please see https://github.com/AlexandreCarlton/relay-21-entrypoint-type-check-reproduction for a minimal reproducible example.