### PR TITLE
Allow @stream on scalar lists

### DIFF
--- a/compiler/Cargo.lock
+++ b/compiler/Cargo.lock
@@ -217,9 +217,9 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
@@ -227,7 +227,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.4",
  "cpufeatures 0.3.0",
  "rand_core",
 ]
@@ -251,7 +251,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
  "terminal_size",
  "unicase",
  "unicode-width",
@@ -321,7 +321,7 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a06aeb73f470f66dcdbf7223caeebb85984942f22f1adb2a088cf9668146bbbc"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.4",
  "wasm-bindgen",
 ]
 
@@ -427,11 +427,11 @@ dependencies = [
 
 [[package]]
 name = "dashmap"
-version = "6.1.0"
+version = "6.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.4",
  "crossbeam-utils",
  "hashbrown 0.14.5",
  "lock_api",
@@ -783,7 +783,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.4",
  "libc",
  "r-efi",
  "rand_core",
@@ -940,9 +940,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -974,9 +974,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -1050,9 +1050,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1259,7 +1259,7 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "arbitrary",
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "rayon",
  "serde",
  "serde_core",
@@ -1280,7 +1280,7 @@ version = "0.1.0"
 dependencies = [
  "bincode",
  "fnv",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "indexmap",
  "once_cell",
  "parking_lot",
@@ -1355,13 +1355,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.4",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
@@ -1397,19 +1396,18 @@ checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 dependencies = [
  "value-bag",
 ]
@@ -1486,7 +1484,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.4",
  "digest",
 ]
 
@@ -1577,7 +1575,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
 dependencies = [
  "bitflags 2.8.0",
- "cfg-if 1.0.0",
+ "cfg-if 1.0.4",
  "foreign-types",
  "libc",
  "once_cell",
@@ -1660,15 +1658,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.4",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
@@ -2021,6 +2019,7 @@ dependencies = [
  "sha1",
  "sha2",
  "signedsource",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "walkdir",
@@ -2328,7 +2327,7 @@ dependencies = [
  "rmp-serde",
  "schema-flatbuffer",
  "serde",
- "strsim 0.10.0",
+ "strsim",
  "thiserror 2.0.18",
  "tokio",
 ]
@@ -2591,7 +2590,7 @@ version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.4",
  "cpufeatures 0.2.16",
  "digest",
 ]
@@ -2602,7 +2601,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.4",
  "cpufeatures 0.2.16",
  "digest",
 ]
@@ -2685,35 +2684,28 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.27.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
 ]
 
@@ -3051,9 +3043,9 @@ checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "typetag"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be2212c8a9b9bcfca32024de14998494cf9a5dfa59ea1b829de98bac374b86bf"
+checksum = "c5a897b12c6c1151ad0b138b8db50252dc301f93bc3b027db05eec82aeed298c"
 dependencies = [
  "erased-serde",
  "inventory",
@@ -3064,9 +3056,9 @@ dependencies = [
 
 [[package]]
 name = "typetag-impl"
-version = "0.2.21"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27a7a9b72ba121f6f1f6c3632b85604cac41aedb5ddc70accbebb6cac83de846"
+checksum = "cf808357c6ed7e13ba0f3277ec8d8f21b2d501274895104263985330c726c1c5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3232,11 +3224,11 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 1.0.4",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
@@ -3245,9 +3237,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3255,9 +3247,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3265,9 +3257,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3278,9 +3270,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]

--- a/compiler/crates/relay-codegen/src/build_ast.rs
+++ b/compiler/crates/relay-codegen/src/build_ast.rs
@@ -936,7 +936,19 @@ impl<'schema, 'builder, 'config> CodegenBuilder<'schema, 'builder, 'config> {
                         CodegenVariant::Normalization => vec![self.build_type_discriminator(field)],
                     }
                 } else {
-                    self.build_scalar_field_and_handles(context, field)
+                    let stream = field.directives.named(
+                        self.project_config
+                            .schema_config
+                            .defer_stream_interface
+                            .stream_name,
+                    );
+
+                    match stream {
+                        Some(stream) => {
+                            vec![self.build_stream_on_scalar(context, field, stream)]
+                        }
+                        None => self.build_scalar_field_and_handles(context, field),
+                    }
                 }
             }
         }
@@ -1920,6 +1932,59 @@ impl<'schema, 'builder, 'config> CodegenBuilder<'schema, 'builder, 'config> {
                         .stream_name,
                 ),
                 ..linked_field.to_owned()
+            },
+        );
+        let next_selections = Primitive::Key(self.array(next_selections));
+        Primitive::Key(match self.variant {
+            CodegenVariant::Reader => self.object(object! {
+                kind: Primitive::String(CODEGEN_CONSTANTS.stream),
+                selections: next_selections,
+            }),
+            CodegenVariant::Normalization => {
+                let StreamDirective {
+                    if_arg,
+                    label_arg,
+                    use_customized_batch_arg: _,
+                    initial_count_arg: _,
+                } = StreamDirective::from(
+                    stream,
+                    &self.project_config.schema_config.defer_stream_interface,
+                );
+                let if_variable_name = if_arg.and_then(|arg| match &arg.value.item {
+                    // `true` is the default, remove as the AST is typed just as a variable name string
+                    // `false` constant values should've been transformed away in skip_unreachable_node
+                    Value::Constant(ConstantValue::Boolean(true)) => None,
+                    Value::Variable(var) => Some(var.name.item),
+                    other => panic!("unexpected value for @stream if argument: {other:?}"),
+                });
+                let label_name = label_arg.unwrap().value.item.expect_string_literal();
+                self.object(object! {
+                     if_: Primitive::string_or_null(if_variable_name.map(|variable_name| variable_name.0)),
+                     kind: Primitive::String(CODEGEN_CONSTANTS.stream),
+                     label: Primitive::String(label_name),
+                     selections: next_selections,
+                 })
+            }
+        })
+    }
+
+    fn build_stream_on_scalar(
+        &mut self,
+        context: &mut ContextualMetadata,
+        scalar_field: &ScalarField,
+        stream: &Directive,
+    ) -> Primitive {
+        let next_selections = self.build_scalar_field_and_handles(
+            context,
+            &ScalarField {
+                directives: remove_directive(
+                    &scalar_field.directives,
+                    self.project_config
+                        .schema_config
+                        .defer_stream_interface
+                        .stream_name,
+                ),
+                ..scalar_field.to_owned()
             },
         );
         let next_selections = Primitive::Key(self.array(next_selections));

--- a/compiler/crates/relay-codegen/tests/defer_stream/fixtures/fragment-with-stream-on-scalar-list-field.expected
+++ b/compiler/crates/relay-codegen/tests/defer_stream/fixtures/fragment-with-stream-on-scalar-list-field.expected
@@ -1,0 +1,85 @@
+==================================== INPUT ====================================
+query QueryWithFragmentWithStreamOnScalarList($id: ID!) {
+  node(id: $id) {
+    id
+    ...UserFragment
+  }
+}
+
+fragment UserFragment on User {
+  id
+  emailAddresses @stream(initialCount: 1)
+}
+==================================== OUTPUT ===================================
+{
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "id"
+    }
+  ],
+  "kind": "Operation",
+  "name": "QueryWithFragmentWithStreamOnScalarList",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "id",
+          "variableName": "id"
+        }
+      ],
+      "concreteType": null,
+      "kind": "LinkedField",
+      "name": "node",
+      "plural": false,
+      "selections": [
+        {
+          "args": null,
+          "kind": "FragmentSpread",
+          "name": "UserFragment"
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "id",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ]
+}
+
+{
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "UserFragment",
+  "selections": [
+    {
+      "kind": "Stream",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "emailAddresses",
+          "storageKey": null
+        }
+      ]
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+}

--- a/compiler/crates/relay-codegen/tests/defer_stream/fixtures/fragment-with-stream-on-scalar-list-field.graphql
+++ b/compiler/crates/relay-codegen/tests/defer_stream/fixtures/fragment-with-stream-on-scalar-list-field.graphql
@@ -1,0 +1,11 @@
+query QueryWithFragmentWithStreamOnScalarList($id: ID!) {
+  node(id: $id) {
+    id
+    ...UserFragment
+  }
+}
+
+fragment UserFragment on User {
+  id
+  emailAddresses @stream(initialCount: 1)
+}

--- a/compiler/crates/relay-codegen/tests/defer_stream_test.rs
+++ b/compiler/crates/relay-codegen/tests/defer_stream_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<1202650c9e42a6b47175ff4550f58ab5>>
+ * @generated SignedSource<<9602bd522b394ff8a13ae5f756f3035a>>
  */
 
 mod defer_stream;
@@ -24,4 +24,11 @@ async fn fragment_with_stream_default_label() {
     let input = include_str!("defer_stream/fixtures/fragment-with-stream-default-label.graphql");
     let expected = include_str!("defer_stream/fixtures/fragment-with-stream-default-label.expected");
     test_fixture(transform_fixture, file!(), "fragment-with-stream-default-label.graphql", "defer_stream/fixtures/fragment-with-stream-default-label.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn fragment_with_stream_on_scalar_list_field() {
+    let input = include_str!("defer_stream/fixtures/fragment-with-stream-on-scalar-list-field.graphql");
+    let expected = include_str!("defer_stream/fixtures/fragment-with-stream-on-scalar-list-field.expected");
+    test_fixture(transform_fixture, file!(), "fragment-with-stream-on-scalar-list-field.graphql", "defer_stream/fixtures/fragment-with-stream-on-scalar-list-field.expected", input, expected).await;
 }

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-on-scalar-list-field.expected
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-on-scalar-list-field.expected
@@ -1,0 +1,193 @@
+==================================== INPUT ====================================
+query streamOnScalarListField_QueryWithStreamQuery($id: ID!) {
+  node(id: $id) {
+    id
+    ...streamOnScalarListField_UserFragment @alias
+  }
+}
+
+fragment streamOnScalarListField_UserFragment on User {
+  id
+  emailAddresses @stream(initialCount: 1, label: "StreamedEmailAddressesLabel")
+}
+==================================== OUTPUT ===================================
+{
+  "fragment": {
+    "argumentDefinitions": [
+      {
+        "defaultValue": null,
+        "kind": "LocalArgument",
+        "name": "id"
+      }
+    ],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "streamOnScalarListField_QueryWithStreamQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": [
+          {
+            "kind": "Variable",
+            "name": "id",
+            "variableName": "id"
+          }
+        ],
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "fragment": {
+              "kind": "InlineFragment",
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "streamOnScalarListField_UserFragment"
+                }
+              ],
+              "type": "User",
+              "abstractKey": null
+            },
+            "kind": "AliasedInlineFragmentSpread",
+            "name": "streamOnScalarListField_UserFragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [
+      {
+        "defaultValue": null,
+        "kind": "LocalArgument",
+        "name": "id"
+      }
+    ],
+    "kind": "Operation",
+    "name": "streamOnScalarListField_QueryWithStreamQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": [
+          {
+            "kind": "Variable",
+            "name": "id",
+            "variableName": "id"
+          }
+        ],
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          },
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "if": null,
+                "kind": "Stream",
+                "label": "streamOnScalarListField_UserFragment$stream$StreamedEmailAddressesLabel",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "emailAddresses",
+                    "storageKey": null
+                  }
+                ]
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "fff4bbd2685193f2e5fc717df664fccc",
+    "id": null,
+    "metadata": {},
+    "name": "streamOnScalarListField_QueryWithStreamQuery",
+    "operationKind": "query",
+    "text": null
+  }
+}
+
+QUERY:
+
+query streamOnScalarListField_QueryWithStreamQuery(
+  $id: ID!
+) {
+  node(id: $id) {
+    __typename
+    id
+    ...streamOnScalarListField_UserFragment
+  }
+}
+
+fragment streamOnScalarListField_UserFragment on User {
+  id
+  emailAddresses @stream(label: "streamOnScalarListField_UserFragment$stream$StreamedEmailAddressesLabel", initialCount: 1)
+}
+
+
+{
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "streamOnScalarListField_UserFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "kind": "Stream",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "emailAddresses",
+          "storageKey": null
+        }
+      ]
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+}

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-on-scalar-list-field.graphql
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts/fixtures/stream-on-scalar-list-field.graphql
@@ -1,0 +1,11 @@
+query streamOnScalarListField_QueryWithStreamQuery($id: ID!) {
+  node(id: $id) {
+    id
+    ...streamOnScalarListField_UserFragment @alias
+  }
+}
+
+fragment streamOnScalarListField_UserFragment on User {
+  id
+  emailAddresses @stream(initialCount: 1, label: "StreamedEmailAddressesLabel")
+}

--- a/compiler/crates/relay-compiler/tests/compile_relay_artifacts_test.rs
+++ b/compiler/crates/relay-compiler/tests/compile_relay_artifacts_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<a0afe2b86cc3e80c53e8ac9f7e5bb66f>>
+ * @generated SignedSource<<59d80b792d083f89367a04b4195ea195>>
  */
 
 mod compile_relay_artifacts;
@@ -1984,6 +1984,13 @@ async fn stream_if_arguments() {
     let input = include_str!("compile_relay_artifacts/fixtures/stream_if_arguments.graphql");
     let expected = include_str!("compile_relay_artifacts/fixtures/stream_if_arguments.expected");
     test_fixture(transform_fixture, file!(), "stream_if_arguments.graphql", "compile_relay_artifacts/fixtures/stream_if_arguments.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn stream_on_scalar_list_field() {
+    let input = include_str!("compile_relay_artifacts/fixtures/stream-on-scalar-list-field.graphql");
+    let expected = include_str!("compile_relay_artifacts/fixtures/stream-on-scalar-list-field.expected");
+    test_fixture(transform_fixture, file!(), "stream-on-scalar-list-field.graphql", "compile_relay_artifacts/fixtures/stream-on-scalar-list-field.expected", input, expected).await;
 }
 
 #[tokio::test]

--- a/compiler/crates/relay-transforms/src/defer_stream.rs
+++ b/compiler/crates/relay-transforms/src/defer_stream.rs
@@ -268,6 +268,98 @@ impl DeferStreamTransform<'_> {
             next_stream,
         )))
     }
+
+    fn transform_stream_on_scalar(
+        &mut self,
+        scalar_field: &ScalarField,
+        stream: &Directive,
+        defer_stream_interface: &DeferStreamInterface,
+    ) -> Result<Transformed<Selection>, Diagnostic> {
+        let schema_field = self.program.schema.field(scalar_field.definition.item);
+        if !schema_field.type_.is_list() {
+            return Err(Diagnostic::error(
+                ValidationMessage::StreamFieldIsNotAList {
+                    field_name: schema_field.name.item,
+                },
+                stream.name.location,
+            ));
+        }
+
+        let StreamDirective {
+            if_arg,
+            label_arg,
+            initial_count_arg,
+            use_customized_batch_arg: _,
+        } = StreamDirective::from(stream, defer_stream_interface);
+
+        let get_next_selection = |directives| {
+            Transformed::Replace(Selection::ScalarField(Arc::new(ScalarField {
+                directives,
+                ..scalar_field.clone()
+            })))
+        };
+        if is_literal_false_arg(if_arg) {
+            return Ok(get_next_selection(remove_directive(
+                &scalar_field.directives,
+                stream.name.item,
+            )));
+        }
+
+        if initial_count_arg.is_none() {
+            return Err(Diagnostic::error(
+                ValidationMessage::StreamInitialCountRequired,
+                stream.name.location,
+            ));
+        }
+
+        let label_value = get_literal_string_argument(stream, label_arg)?;
+        let label = label_value.unwrap_or_else(|| {
+            get_applied_fragment_name(
+                FragmentDefinitionName(scalar_field.alias_or_name(&self.program.schema)),
+                &scalar_field.arguments,
+            )
+            .0
+        });
+        let transformed_label = transform_label(
+            self.current_document_name
+                .expect("We expect the parent name to be defined here."),
+            defer_stream_interface.stream_name,
+            label,
+        );
+        self.record_label(transformed_label, stream);
+        let next_label_value = Value::Constant(ConstantValue::String(transformed_label));
+        let next_label_arg = Argument {
+            name: WithLocation {
+                item: defer_stream_interface.label_arg,
+                location: label_arg.map_or(stream.name.location, |arg| arg.name.location),
+            },
+            value: WithLocation {
+                item: next_label_value,
+                location: label_arg.map_or(stream.name.location, |arg| arg.value.location),
+            },
+        };
+
+        let mut next_arguments = Vec::with_capacity(3);
+        next_arguments.push(next_label_arg);
+        if let Some(if_arg) = if_arg {
+            next_arguments.push(if_arg.clone());
+        }
+        if let Some(initial_count_arg) = initial_count_arg {
+            next_arguments.push(initial_count_arg.clone());
+        }
+
+        let next_stream = Directive {
+            name: stream.name,
+            arguments: next_arguments,
+            data: None,
+            location: stream.location,
+        };
+
+        Ok(get_next_selection(replace_directive(
+            &scalar_field.directives,
+            next_stream,
+        )))
+    }
 }
 
 impl Transformer<'_> for DeferStreamTransform<'_> {
@@ -336,20 +428,24 @@ impl Transformer<'_> for DeferStreamTransform<'_> {
         }
     }
 
-    /// Validates @stream is not allowed on scalar fields.
+    /// Transforms @stream on scalar fields.
+    /// Transform of scalar field with @stream is delegated to `transform_stream_on_scalar`.
     fn transform_scalar_field(&mut self, scalar_field: &ScalarField) -> Transformed<Selection> {
-        let stream_directive = &scalar_field
+        let stream_directive = scalar_field
             .directives
             .named(self.defer_stream_interface.stream_name);
-        if let Some(directive) = stream_directive {
-            self.errors.push(Diagnostic::error(
-                ValidationMessage::InvalidStreamOnScalarField {
-                    field_name: scalar_field.alias_or_name(&self.program.schema),
-                },
-                directive.location,
-            ));
+        if let Some(stream) = stream_directive {
+            match self.transform_stream_on_scalar(scalar_field, stream, self.defer_stream_interface)
+            {
+                Ok(transformed) => transformed,
+                Err(err) => {
+                    self.errors.push(err);
+                    self.default_transform_scalar_field(scalar_field)
+                }
+            }
+        } else {
+            self.default_transform_scalar_field(scalar_field)
         }
-        self.default_transform_scalar_field(scalar_field)
     }
 
     /// Transform of linked field with @stream is delegated to `transform_stream`.
@@ -429,9 +525,6 @@ enum ValidationMessage {
         "Invalid use of @defer on an inline fragment. Relay only supports @defer on fragment spreads."
     )]
     InvalidDeferOnInlineFragment,
-
-    #[error("Invalid use of @stream on scalar field '{field_name}'")]
-    InvalidStreamOnScalarField { field_name: StringKey },
 
     #[error(
         "Expected the '{arg_name}' value to @{directive_name} to be a string literal if provided."

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-on-scalar-field.invalid.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-on-scalar-field.invalid.expected
@@ -12,10 +12,10 @@ fragment UserFragment on User {
   name @stream(initialCount: 1, label: $label)
 }
 ==================================== ERROR ====================================
-✖︎ Invalid use of @stream on scalar field 'name'
+✖︎ Field 'name' is not of list type, therefore cannot use @stream directive.
 
   fragment-with-stream-on-scalar-field.invalid.graphql:11:8
    10 │   id
    11 │   name @stream(initialCount: 1, label: $label)
-      │        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+      │        ^^^^^^^
    12 │ }

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-on-scalar-list-field.expected
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-on-scalar-list-field.expected
@@ -1,0 +1,26 @@
+==================================== INPUT ====================================
+query QueryWithFragmentWithStreamOnScalarList($id: ID!) {
+  node(id: $id) {
+    id
+    ...UserFragment
+  }
+}
+
+fragment UserFragment on User {
+  id
+  emailAddresses @stream(initialCount: 1, label: "StreamedEmailAddressesLabel")
+}
+==================================== OUTPUT ===================================
+query QueryWithFragmentWithStreamOnScalarList(
+  $id: ID!
+) {
+  node(id: $id) {
+    id
+    ...UserFragment
+  }
+}
+
+fragment UserFragment on User {
+  id
+  emailAddresses @stream(label: "UserFragment$stream$StreamedEmailAddressesLabel", initialCount: 1)
+}

--- a/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-on-scalar-list-field.graphql
+++ b/compiler/crates/relay-transforms/tests/defer_stream/fixtures/fragment-with-stream-on-scalar-list-field.graphql
@@ -1,0 +1,11 @@
+query QueryWithFragmentWithStreamOnScalarList($id: ID!) {
+  node(id: $id) {
+    id
+    ...UserFragment
+  }
+}
+
+fragment UserFragment on User {
+  id
+  emailAddresses @stream(initialCount: 1, label: "StreamedEmailAddressesLabel")
+}

--- a/compiler/crates/relay-transforms/tests/defer_stream_test.rs
+++ b/compiler/crates/relay-transforms/tests/defer_stream_test.rs
@@ -4,7 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  *
- * @generated SignedSource<<5a6476f3b75666c15c6b256baace7519>>
+ * @generated SignedSource<<2844ae864606a72a71da598a4b7517af>>
  */
 
 mod defer_stream;
@@ -108,6 +108,13 @@ async fn fragment_with_stream_on_scalar_field_invalid() {
     let input = include_str!("defer_stream/fixtures/fragment-with-stream-on-scalar-field.invalid.graphql");
     let expected = include_str!("defer_stream/fixtures/fragment-with-stream-on-scalar-field.invalid.expected");
     test_fixture(transform_fixture, file!(), "fragment-with-stream-on-scalar-field.invalid.graphql", "defer_stream/fixtures/fragment-with-stream-on-scalar-field.invalid.expected", input, expected).await;
+}
+
+#[tokio::test]
+async fn fragment_with_stream_on_scalar_list_field() {
+    let input = include_str!("defer_stream/fixtures/fragment-with-stream-on-scalar-list-field.graphql");
+    let expected = include_str!("defer_stream/fixtures/fragment-with-stream-on-scalar-list-field.expected");
+    test_fixture(transform_fixture, file!(), "fragment-with-stream-on-scalar-list-field.graphql", "defer_stream/fixtures/fragment-with-stream-on-scalar-list-field.expected", input, expected).await;
 }
 
 #[tokio::test]

--- a/packages/relay-runtime/store/OperationExecutor.js
+++ b/packages/relay-runtime/store/OperationExecutor.js
@@ -45,6 +45,7 @@ import type {
   NormalizationLinkedField,
   NormalizationOperation,
   NormalizationRootNode,
+  NormalizationScalarField,
   NormalizationSelectableNode,
   NormalizationSplitOperation,
 } from '../util/NormalizationNode';
@@ -1484,11 +1485,26 @@ class Executor<TMutation extends MutationParameters> {
     const {parentID, node, variables, actorIdentifier} = placeholder;
     const prevActorIdentifier = this._actorIdentifier;
     this._actorIdentifier = actorIdentifier ?? this._actorIdentifier;
-    // Find the LinkedField where @stream was applied
+    // Find the field where @stream was applied
     const field = node.selections[0];
     invariant(
-      field != null && field.kind === 'LinkedField' && field.plural === true,
+      field != null &&
+        (field.kind === 'LinkedField' || field.kind === 'ScalarField'),
       'OperationExecutor: Expected @stream to be used on a plural field.',
+    );
+    if (field.kind === 'ScalarField') {
+      return this._processStreamScalarResponse(
+        parentID,
+        field,
+        variables,
+        path,
+        response,
+        prevActorIdentifier,
+      );
+    }
+    invariant(
+      field.plural === true,
+      'OperationExecutor: Expected @stream to be used on a plural LinkedField.',
     );
     const {
       fieldPayloads,
@@ -1557,6 +1573,114 @@ class Executor<TMutation extends MutationParameters> {
         handleFieldsRelayPayload,
       );
     }
+
+    this._actorIdentifier = prevActorIdentifier;
+    return relayPayload;
+  }
+
+  /**
+   * Process a single streamed scalar value for a @stream field on a list of
+   * scalars. Unlike linked fields, scalar values are stored directly in the
+   * parent record's value array — no separate records are created.
+   */
+  _processStreamScalarResponse(
+    parentID: DataID,
+    field: NormalizationScalarField,
+    variables: Variables,
+    path: ReadonlyArray<unknown>,
+    response: GraphQLResponseWithData,
+    prevActorIdentifier: ActorIdentifier,
+  ): RelayResponsePayload {
+    const {data} = response;
+    const storageKey = getStorageKey(field, variables);
+
+    // Load the version of the parent record from which this incremental data
+    // was derived
+    const parentEntry = this._source.get(parentID);
+    invariant(
+      parentEntry != null,
+      'OperationExecutor: Expected the parent record `%s` for @stream ' +
+        'scalar data to exist.',
+      parentID,
+    );
+    const {record: parentRecord, fieldPayloads} = parentEntry;
+
+    // Load the field value (items) that were created by *this* query executor
+    // in order to check if there have been any concurrent modifications by
+    // some other operation.
+    const prevValues = RelayModernRecord.getValue(parentRecord, storageKey);
+    invariant(
+      Array.isArray(prevValues),
+      'OperationExecutor: Expected record `%s` to have fetched scalar ' +
+        'field `%s` with @stream.',
+      parentID,
+      field.name,
+    );
+
+    // Determine the index in the field of the new item
+    const finalPathEntry = path[path.length - 1];
+    const itemIndex = parseInt(finalPathEntry, 10);
+    invariant(
+      itemIndex === finalPathEntry && itemIndex >= 0,
+      'OperationExecutor: Expected path for @stream to end in a ' +
+        'positive integer index, got `%s`',
+      finalPathEntry,
+    );
+
+    // Update the cached version of the parent record to reflect the new value:
+    // this is used when subsequent stream payloads arrive to see if there
+    // have been concurrent modifications to the list
+    const nextParentRecord = RelayModernRecord.clone(parentRecord);
+    const nextValues = [...prevValues];
+    nextValues[itemIndex] = data;
+    RelayModernRecord.setValue(nextParentRecord, storageKey, nextValues);
+    this._source.set(parentID, {
+      fieldPayloads,
+      record: nextParentRecord,
+    });
+
+    // Publish the new value and update the parent record to set
+    // field[index] = value *if* the parent record hasn't been concurrently
+    // modified.
+    const relayPayload: RelayResponsePayload = {
+      errors: null,
+      fieldPayloads: [],
+      followupPayloads: null,
+      incrementalPlaceholders: null,
+      isFinal: false,
+      source: RelayRecordSource.create(),
+    };
+    this._getPublishQueueAndSaveActor().commitPayload(
+      this._operation,
+      relayPayload,
+      store => {
+        const currentParentRecord = store.get(parentID);
+        if (currentParentRecord == null) {
+          // parent has since been deleted, stream data is stale
+          return;
+        }
+        const currentItems = currentParentRecord.getValue(storageKey);
+        if (!Array.isArray(currentItems)) {
+          // field has since been deleted, stream data is stale
+          return;
+        }
+        if (
+          currentItems.length !== prevValues.length ||
+          currentItems.some(
+            (currentItem, index) => prevValues[index] !== currentItem,
+          )
+        ) {
+          // field has been modified by something other than this query,
+          // stream data is stale
+          return;
+        }
+        // parent.field has not been concurrently modified:
+        // update `parent.field[index] = value`
+        const nextItems = [...currentItems];
+        nextItems[itemIndex] = data;
+        currentParentRecord.setValue(nextItems, storageKey);
+      },
+    );
 
     this._actorIdentifier = prevActorIdentifier;
     return relayPayload;


### PR DESCRIPTION
The `@stream` directive is currently only supported on lists of objects, but it should also be supported on lists of scalars.

Currently when `@stream` is used on a list of scalars, relay-compiler throws a InvalidStreamOnScalarField error.

So with a schema like this:

```graphql
type Query {
  stringChunks: [String!]!
}
```

You can't do this:

```graphql
query MyQuery {
  stringChunks @stream(initialCount: 1) # this could work but currently throws an error
}
```

So you have to modify your schema like this:

```graphql
type WrappedString {
  value: String!
}

type Query {
  stringChunks: [WrappedString!]!
}
```

And do this:

```graphql
query MyQuery {
  stringChunks @stream(initialCount: 1) {
    value
  }
}
```

This PR makes the necessary changes so `@stream` can be used on scalar lists.

Fixes #3755 