### PR TITLE
Fix CI: Gate DaemonCommandFailed behind cfg(unix)

### DIFF
--- a/compiler/crates/relay-bin/src/errors.rs
+++ b/compiler/crates/relay-bin/src/errors.rs
@@ -24,6 +24,7 @@ pub enum Error {
     #[error("Unable to run relay codemod. Error details: \n{details}")]
     CodemodError { details: String },
 
+    #[cfg(unix)]
     #[error("Daemon command failed")]
     DaemonCommandFailed,
 }


### PR DESCRIPTION
## Summary

The `DaemonCommandFailed` error variant in `relay-bin/src/errors.rs` is only used in the `#[cfg(unix)]` `log_daemon_response` function. On Windows, this triggers `-D dead-code` and fails the build.

Gates the variant behind `#[cfg(unix)]` to match its usage site.

## Failing Jobs

- **Build Rust Compiler (windows-latest)** — `error: variant 'DaemonCommandFailed' is never constructed`
- **Rust Tests (macos-latest / ubuntu-latest / windows-latest)** — cascading failures from out-of-date Cargo.lock (separate issue, PR #5313 exists)

## Test Plan

- `cargo check -p relay` passes locally
- The Cargo.lock issue is tracked separately in #5313