### PR TITLE
Add missing EnvironmentConfig TypeScript type field

### DIFF
--- a/packages/relay-runtime/store/RelayModernEnvironment.d.ts
+++ b/packages/relay-runtime/store/RelayModernEnvironment.d.ts
@@ -35,6 +35,7 @@ export interface EnvironmentConfig {
     readonly configName?: string | undefined;
     readonly handlerProvider?: HandlerProvider | null | undefined;
     readonly treatMissingFieldsAsNull?: boolean | undefined;
+    readonly deferDeduplicatedFields?: boolean | undefined,
     readonly log?: LogFunction | null | undefined;
     readonly operationLoader?: OperationLoader | null | undefined;
     readonly network: Network;


### PR DESCRIPTION
The Flow type for `EnvironmentConfig` has `deferDeduplicatedFields` but the TypeScript type is missing it. This PR adds it.