### PR TITLE
Fix nested `@catch`: stop inner-handled errors from propagating

### DIFF
--- a/packages/relay-runtime/store/RelayReader.js
+++ b/packages/relay-runtime/store/RelayReader.js
@@ -441,7 +441,10 @@ class RelayReader {
         value = this._asResult(_value);
         break;
       case 'NULL':
-        if (this._fieldErrors != null && this._fieldErrors.length > 0) {
+        if (
+          this._fieldErrors != null &&
+          this._fieldErrors.some(e => !e.handled)
+        ) {
           value = null;
         }
         break;
@@ -479,12 +482,16 @@ class RelayReader {
    * responsibility to ensure that errors are marked as handled.
    */
   _asResult<T>(value: T): Result<T, unknown> {
-    if (this._fieldErrors == null || this._fieldErrors.length === 0) {
+    // Errors already handled by an inner @catch must not influence this
+    // @catch's outcome — they have been consumed by their own boundary and
+    // are only flowing through `_fieldErrors` for logging.
+    const unhandled = this._fieldErrors?.filter(e => !e.handled);
+    if (unhandled == null || unhandled.length === 0) {
       return {ok: true, value};
     }
 
     // TODO: Should we be hiding log level events here?
-    const errors = this._fieldErrors
+    const errors = unhandled
       .map(error => {
         switch (error.kind) {
           case 'relay_field_payload.error':

--- a/packages/relay-runtime/store/__tests__/RelayReader-CatchFields-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayReader-CatchFields-test.js
@@ -904,4 +904,114 @@ describe('RelayReader @catch', () => {
       },
     ]);
   });
+
+  it('nested @catch(to: RESULT): server error on inner field should be handled by the inner @catch, not bubble to the outer @catch', () => {
+    const source = RelayRecordSource.create({
+      'client:root': {
+        __id: 'client:root',
+        __typename: '__Root',
+        me: {__ref: '1'},
+      },
+      '1': {
+        __id: '1',
+        id: '1',
+        __typename: 'User',
+        lastName: null,
+        __errors: {
+          lastName: [
+            {
+              message: 'There was an error!',
+              path: ['me', 'lastName'],
+            },
+          ],
+        },
+      },
+    });
+
+    const FooQuery = graphql`
+      query RelayReaderCatchFieldsTestNestedResultQuery {
+        me @catch(to: RESULT) {
+          lastName @catch(to: RESULT)
+        }
+      }
+    `;
+    const operation = createOperationDescriptor(FooQuery, {id: '1'});
+    const {data, fieldErrors} = read(source, operation.fragment, null);
+    expect(data).toEqual({
+      me: {
+        ok: true,
+        value: {
+          lastName: {
+            ok: false,
+            errors: [
+              {
+                path: ['me', 'lastName'],
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    expect(fieldErrors).toEqual([
+      {
+        error: {message: 'There was an error!', path: ['me', 'lastName']},
+        fieldPath: 'me.lastName',
+        handled: true,
+        kind: 'relay_field_payload.error',
+        owner: 'RelayReaderCatchFieldsTestNestedResultQuery',
+        shouldThrow: false,
+      },
+    ]);
+  });
+
+  it('nested @catch(to: NULL): server error on inner field should be nulled by the inner @catch, leaving the outer field intact', () => {
+    const source = RelayRecordSource.create({
+      'client:root': {
+        __id: 'client:root',
+        __typename: '__Root',
+        me: {__ref: '1'},
+      },
+      '1': {
+        __id: '1',
+        id: '1',
+        __typename: 'User',
+        lastName: null,
+        __errors: {
+          lastName: [
+            {
+              message: 'There was an error!',
+              path: ['me', 'lastName'],
+            },
+          ],
+        },
+      },
+    });
+
+    const FooQuery = graphql`
+      query RelayReaderCatchFieldsTestNestedNullQuery {
+        me @catch(to: NULL) {
+          lastName @catch(to: NULL)
+        }
+      }
+    `;
+    const operation = createOperationDescriptor(FooQuery, {id: '1'});
+    const {data, fieldErrors} = read(source, operation.fragment, null);
+    expect(data).toEqual({
+      me: {
+        lastName: null,
+      },
+    });
+
+    expect(fieldErrors).toEqual([
+      {
+        error: {message: 'There was an error!', path: ['me', 'lastName']},
+        fieldPath: 'me.lastName',
+        handled: true,
+        kind: 'relay_field_payload.error',
+        owner: 'RelayReaderCatchFieldsTestNestedNullQuery',
+        shouldThrow: false,
+      },
+    ]);
+  });
 });

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderCatchFieldsTestNestedNullQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderCatchFieldsTestNestedNullQuery.graphql.js
@@ -1,0 +1,116 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<ce01d94a0d6d20f99f7627c38fb98982>>
+ * @flow
+ * @lightSyntaxTransform
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+export type RelayReaderCatchFieldsTestNestedNullQuery$variables = {||};
+export type RelayReaderCatchFieldsTestNestedNullQuery$data = {|
+  +me: ?{|
+    +lastName: ?string,
+  |},
+|};
+export type RelayReaderCatchFieldsTestNestedNullQuery = {|
+  response: RelayReaderCatchFieldsTestNestedNullQuery$data,
+  variables: RelayReaderCatchFieldsTestNestedNullQuery$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lastName",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RelayReaderCatchFieldsTestNestedNullQuery",
+    "selections": [
+      {
+        "kind": "CatchField",
+        "field": {
+          "alias": null,
+          "args": null,
+          "concreteType": "User",
+          "kind": "LinkedField",
+          "name": "me",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "CatchField",
+              "field": (v0/*:: as any*/),
+              "to": "NULL"
+            }
+          ],
+          "storageKey": null
+        },
+        "to": "NULL"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "RelayReaderCatchFieldsTestNestedNullQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          (v0/*:: as any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "2c315504ac774ed5e88367d3e2345856",
+    "id": null,
+    "metadata": {},
+    "name": "RelayReaderCatchFieldsTestNestedNullQuery",
+    "operationKind": "query",
+    "text": "query RelayReaderCatchFieldsTestNestedNullQuery {\n  me {\n    lastName\n    id\n  }\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*:: as any*/).hash = "66a2c59d970a93665fcbbb90c9d8c17c";
+}
+
+module.exports = ((node/*:: as any*/)/*:: as Query<
+  RelayReaderCatchFieldsTestNestedNullQuery$variables,
+  RelayReaderCatchFieldsTestNestedNullQuery$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayReaderCatchFieldsTestNestedResultQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayReaderCatchFieldsTestNestedResultQuery.graphql.js
@@ -1,0 +1,117 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<a2771dff88aa4ccb7e6e8316990cfb48>>
+ * @flow
+ * @lightSyntaxTransform
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { Result } from "relay-runtime";
+export type RelayReaderCatchFieldsTestNestedResultQuery$variables = {||};
+export type RelayReaderCatchFieldsTestNestedResultQuery$data = {|
+  +me: Result<?{|
+    +lastName: Result<?string, unknown>,
+  |}, unknown>,
+|};
+export type RelayReaderCatchFieldsTestNestedResultQuery = {|
+  response: RelayReaderCatchFieldsTestNestedResultQuery$data,
+  variables: RelayReaderCatchFieldsTestNestedResultQuery$variables,
+|};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lastName",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RelayReaderCatchFieldsTestNestedResultQuery",
+    "selections": [
+      {
+        "kind": "CatchField",
+        "field": {
+          "alias": null,
+          "args": null,
+          "concreteType": "User",
+          "kind": "LinkedField",
+          "name": "me",
+          "plural": false,
+          "selections": [
+            {
+              "kind": "CatchField",
+              "field": (v0/*:: as any*/),
+              "to": "RESULT"
+            }
+          ],
+          "storageKey": null
+        },
+        "to": "RESULT"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "RelayReaderCatchFieldsTestNestedResultQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          (v0/*:: as any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "f9e292ecc5dd08b5d8be80b0da603841",
+    "id": null,
+    "metadata": {},
+    "name": "RelayReaderCatchFieldsTestNestedResultQuery",
+    "operationKind": "query",
+    "text": "query RelayReaderCatchFieldsTestNestedResultQuery {\n  me {\n    lastName\n    id\n  }\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*:: as any*/).hash = "91b7b93adcadec991cfe6f6bb03fcc1d";
+}
+
+module.exports = ((node/*:: as any*/)/*:: as Query<
+  RelayReaderCatchFieldsTestNestedResultQuery$variables,
+  RelayReaderCatchFieldsTestNestedResultQuery$data,
+>*/);


### PR DESCRIPTION
Fixes #5339

## The bug

When `@catch` directives are nested, a field error handled by the **inner** `@catch` is also counted by the **outer** `@catch`, so the outer boundary fires even though, from its perspective, the inner field resolved successfully.

- `@catch(to: RESULT)`: the outer field becomes `{ ok: false }` instead of `{ ok: true, value: … }`.
- `@catch(to: NULL)`: the whole outer object is nulled instead of just the inner field.

It compiles fine and fails silently at runtime. Full write-up and a runnable reproduction are in the linked issue (repro: https://github.com/christiansany/relay-playground/pull/1).

## The fix

In `RelayReader`, whether a `@catch` boundary "saw" an error was based on `_fieldErrors` being non-empty — but that list also contains errors already marked `handled` by an inner `@catch` (they flow through only for logging). The fix excludes already-handled errors when deciding an outer boundary's outcome:

- `_asResult` now builds its result from the **unhandled** errors only (`{ ok: true }` when none remain).
- The `NULL` path nulls the field only when there is an **unhandled** error (`_fieldErrors.some(e => !e.handled)`).

An inner `@catch` consumes its error and the outer boundary no longer reacts to it. Errors that are genuinely unhandled at a given level still propagate exactly as before.

## Tests

Added regression tests in `RelayReader-CatchFields-test.js` covering both targets with a server error on the inner field:

- nested `@catch(to: RESULT)` → outer `me` is `{ ok: true, value: { lastName: { ok: false, … } } }` (inner catches, outer succeeds).
- nested `@catch(to: NULL)` → `{ me: { lastName: null } }` (only the inner field nulled).

In both cases the error is still surfaced once in `fieldErrors` with `handled: true`.

## Testing

- New tests pass; existing `RelayReader-CatchFields` tests remain green.
- Runtime-only change in `RelayReader.js` (10 lines); no API or compiler changes.
