### PR TITLE
Scope provided-variable memoization to the network instead of the process

### DIFF
--- a/packages/relay-runtime/network/RelayNetwork.js
+++ b/packages/relay-runtime/network/RelayNetwork.js
@@ -48,6 +48,7 @@ function create(
     const operationVariables = withProvidedVariables(
       variables,
       request.providedVariables,
+      network,
     );
     if (request.operationKind === 'subscription') {
       invariant(
@@ -83,7 +84,10 @@ function create(
     );
   }
 
-  return {execute};
+  // `execute` memoizes provided variable values per network, so it needs the
+  // network it belongs to. It only runs once this is assigned.
+  const network: INetwork = {execute};
+  return network;
 }
 
 module.exports = {create};

--- a/packages/relay-runtime/network/__tests__/RelayNetwork-test.js
+++ b/packages/relay-runtime/network/__tests__/RelayNetwork-test.js
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+import type {RequestParameters} from '../../util/RelayConcreteNode';
+import type {CacheConfig, Variables} from '../../util/RelayRuntimeTypes';
+import type {
+  GraphQLResponse,
+  LogRequestInfoFunction,
+  UploadableMap,
+} from '../RelayNetworkTypes';
+
+const withProvidedVariables = require('../../util/withProvidedVariables');
+const RelayNetwork = require('../RelayNetwork');
+const {disallowWarnings, expectToWarn} = require('relay-test-utils-internal');
+
+disallowWarnings();
+
+const PROVIDED_VARIABLE_NAME = '__relay_internal__pv__provideRequestValue';
+
+function createRequestParameters(get: () => unknown): RequestParameters {
+  return {
+    cacheID: 'RelayNetworkTestQuery',
+    id: null,
+    metadata: {},
+    name: 'RelayNetworkTestQuery',
+    operationKind: 'query',
+    providedVariables: {[PROVIDED_VARIABLE_NAME]: {get}},
+    text: 'query RelayNetworkTestQuery { me { id } }',
+  };
+}
+
+describe('RelayNetwork', () => {
+  describe('provided variables', () => {
+    let fetch;
+    let params;
+
+    beforeEach(() => {
+      let nextValue = 0;
+      const get = () => nextValue++;
+      params = createRequestParameters(get);
+      fetch = jest.fn(
+        (
+          _params: RequestParameters,
+          _variables: Variables,
+          _cacheConfig: CacheConfig,
+          _uploadables: ?UploadableMap,
+          _logRequestInfo: ?LogRequestInfoFunction,
+        ): GraphQLResponse => ({data: {}}),
+      );
+    });
+
+    it('reuses the value a provider returned on the first execute', () => {
+      const network = RelayNetwork.create(fetch);
+
+      network.execute(params, {}, {}).subscribe({});
+      expectToWarn(
+        'Relay: Expected function `get` for provider ' +
+          `\`${PROVIDED_VARIABLE_NAME}\`` +
+          ' to be a pure function, but got conflicting return values `1` and `0`',
+        () => {
+          network.execute(params, {}, {}).subscribe({});
+        },
+      );
+
+      expect(fetch.mock.calls.length).toBe(2);
+      expect(fetch.mock.calls[0][1]).toEqual({[PROVIDED_VARIABLE_NAME]: 0});
+      expect(fetch.mock.calls[1][1]).toEqual({[PROVIDED_VARIABLE_NAME]: 0});
+    });
+
+    it('resolves providers independently for each network', () => {
+      // disallowWarnings() also asserts that resolving the provider again for
+      // a second network does not report it as impure
+      RelayNetwork.create(fetch).execute(params, {}, {}).subscribe({});
+      RelayNetwork.create(fetch).execute(params, {}, {}).subscribe({});
+
+      expect(fetch.mock.calls.length).toBe(2);
+      expect(fetch.mock.calls[0][1]).toEqual({[PROVIDED_VARIABLE_NAME]: 0});
+      expect(fetch.mock.calls[1][1]).toEqual({[PROVIDED_VARIABLE_NAME]: 1});
+    });
+
+    it('resolves providers again after the test only cache reset', () => {
+      const network = RelayNetwork.create(fetch);
+
+      network.execute(params, {}, {}).subscribe({});
+      if (withProvidedVariables.tests_only_resetDebugCache !== undefined) {
+        withProvidedVariables.tests_only_resetDebugCache();
+      }
+      network.execute(params, {}, {}).subscribe({});
+
+      expect(fetch.mock.calls.length).toBe(2);
+      expect(fetch.mock.calls[0][1]).toEqual({[PROVIDED_VARIABLE_NAME]: 0});
+      expect(fetch.mock.calls[1][1]).toEqual({[PROVIDED_VARIABLE_NAME]: 1});
+    });
+  });
+});

--- a/packages/relay-runtime/util/RelayConcreteNode.d.ts
+++ b/packages/relay-runtime/util/RelayConcreteNode.d.ts
@@ -111,10 +111,10 @@ export const RelayConcreteNode: {
     VARIABLE: 'Variable';
 };
 
-export interface ProvidedVariablesType {
-    readonly [key: string]: { get(): unknown };
-}
-
 export interface ProvidedVariableType {
     get(): unknown;
+}
+
+export interface ProvidedVariablesType {
+    readonly [key: string]: ProvidedVariableType;
 }

--- a/packages/relay-runtime/util/RelayConcreteNode.js
+++ b/packages/relay-runtime/util/RelayConcreteNode.js
@@ -40,7 +40,9 @@ export type NormalizationRootNode =
 
 export type ProvidedVariableType = {get(): unknown};
 
-export type ProvidedVariablesType = {readonly [key: string]: {get(): unknown}};
+export type ProvidedVariablesType = {
+  readonly [key: string]: ProvidedVariableType,
+};
 
 /**
  * Contains the parameters required for executing a GraphQL request.

--- a/packages/relay-runtime/util/withProvidedVariables.d.ts
+++ b/packages/relay-runtime/util/withProvidedVariables.d.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import { Network } from '../network/RelayNetworkTypes';
 import { ProvidedVariablesType } from './RelayConcreteNode';
 import { Variables } from './RelayRuntimeTypes';
 
@@ -12,6 +13,7 @@ interface WithProvidedVariablesFn {
     (
         userSuppliedVariables: Variables,
         providedVariables: ProvidedVariablesType | null | undefined,
+        network?: Network | null,
     ): Variables;
     tests_only_resetDebugCache: undefined | (() => void);
 }

--- a/packages/relay-runtime/util/withProvidedVariables.js
+++ b/packages/relay-runtime/util/withProvidedVariables.js
@@ -11,26 +11,56 @@
 
 'use strict';
 
+import type {INetwork} from '../network/RelayNetworkTypes';
 import type {ProvidedVariablesType} from './RelayConcreteNode';
 import type {Variables} from './RelayRuntimeTypes';
 
 const areEqual = require('areEqual');
 const warning = require('warning');
 
+type ProviderValueCache =
+  Map<() => unknown, unknown> | WeakMap<() => unknown, unknown>;
+
 const WEAKMAP_SUPPORTED = typeof WeakMap === 'function';
-let debugCache:
-  | Map<unknown, unknown>
-  | Map<() => unknown, unknown>
-  | WeakMap<interface {} | ReadonlyArray<unknown>, unknown>
-  | WeakMap<() => unknown, unknown> = WEAKMAP_SUPPORTED
+
+function createProviderValueCache(): ProviderValueCache {
+  return WEAKMAP_SUPPORTED ? new WeakMap() : new Map();
+}
+
+/**
+ * Provider values are memoized per network rather than for the lifetime of the
+ * module: a server process serves many requests, and each of them builds its
+ * own network, so pinning the first value a provider ever returned would leak
+ * one request's state into every later one. Without WeakMap there is no way to
+ * scope values to a network without retaining every network, so they stay
+ * process wide in that case.
+ */
+let cachesByNetwork: ?WeakMap<INetwork, ProviderValueCache> = WEAKMAP_SUPPORTED
   ? new WeakMap()
-  : new Map();
+  : null;
+let processWideCache: ProviderValueCache = createProviderValueCache();
+
+function getProviderValueCache(network: ?INetwork): ProviderValueCache {
+  const caches = cachesByNetwork;
+  if (network == null || caches == null) {
+    return processWideCache;
+  }
+  const cached = caches.get(network);
+  if (cached != null) {
+    return cached;
+  }
+  const cache = createProviderValueCache();
+  caches.set(network, cache);
+  return cache;
+}
 
 function withProvidedVariables(
   userSuppliedVariables: Variables,
   providedVariables: ?ProvidedVariablesType,
+  network?: ?INetwork,
 ): Variables {
   if (providedVariables != null) {
+    const cache = getProviderValueCache(network);
     const operationVariables: {[string]: unknown} = {};
     // $FlowFixMe[unsafe-object-assign]
     Object.assign(operationVariables, userSuppliedVariables);
@@ -40,11 +70,11 @@ function withProvidedVariables(
 
       // people like to ignore these warnings, so use the cache to
       // enforce that we only compute the value the first time
-      if (!debugCache.has(providerFunction)) {
-        debugCache.set(providerFunction, providerResult);
+      if (!cache.has(providerFunction)) {
+        cache.set(providerFunction, providerResult);
         operationVariables[varName] = providerResult;
       } else {
-        const cachedResult = debugCache.get(providerFunction);
+        const cachedResult = cache.get(providerFunction);
 
         if (__DEV__) {
           warning(
@@ -69,7 +99,8 @@ function withProvidedVariables(
 withProvidedVariables.tests_only_resetDebugCache = (
   __DEV__
     ? () => {
-        debugCache = WEAKMAP_SUPPORTED ? new WeakMap() : new Map();
+        processWideCache = createProviderValueCache();
+        cachesByNetwork = WEAKMAP_SUPPORTED ? new WeakMap() : null;
       }
     : undefined
 ) as void | (() => void);

--- a/website/docs/api-reference/graphql/graphql-directives.mdx
+++ b/website/docs/api-reference/graphql/graphql-directives.mdx
@@ -76,7 +76,10 @@ To add a provided variable:
   `@argumentDefinitions`
 - ensure that `[JSModule].relayprovider.js` exists and exports a `get()`
   function
-  - `get` should return the same value on every call for a given run.
+  - `get` should return the same value on every call for a given run. Its value
+    is resolved once per network and reused for every operation that network
+    executes, so a server that serves several requests from one process should
+    build a network per request.
 
 ```graphql
 fragment TodoItem_item on TodoList


### PR DESCRIPTION
## Summary

`withProvidedVariables` pins each provider's first return value in a
module-level cache keyed by the `get` function, to enforce purity. That's fine
in a browser tab, but wrong on a server, where one process serves many
requests/viewers. A provider that reads per-request state (auth/session,
locale, experiment bucket) legitimately returns a different value per request,
and today that causes two problems:

1. The first request's value is pinned and reused for every later request, so
   subsequent requests resolve with stale variables.
2. Dev builds emit a spurious pure-function warning, since the value differs
   across requests:

```text
Relay: Expected function `get` for provider `…` to be a pure function, but got conflicting return values `…` and `…`
```

## Approach

Replace the process-wide cache with a module-private `WeakMap` of per-network
caches. `RelayNetwork.create` passes the network it just built as the cache
owner, so provider values are memoized for the life of that network rather than
the life of the process. Purity is still enforced within a network, which is the
scope where it's meaningful. Where `WeakMap` is unavailable, values stay process
wide rather than retaining every network forever.

The cache is keyed on the network rather than the environment because
`RelayNetwork.create().execute` is the only caller of `withProvidedVariables`,
and it has no reference to an environment — threading one in would mean changing
the public `INetwork.execute` signature. Since an environment owns a network, a
server that builds an environment per request gets the same isolation.

## Backwards compatibility

The new `network` parameter is optional, and omitting it preserves today's
process-wide behavior. The publicly exported `withProvidedVariables` and any
custom `INetwork` implementation keep working unchanged. A custom network can
opt in by passing itself as the third argument.

## Test plan

- New `RelayNetwork-test.js` covers memoization within a single network,
  isolation across two networks, and the purity warning still firing within a
  network.
- Full suite green on top of current `main`: `yarn jest` (244 suites, 3740
  tests), `yarn typecheck`, `yarn lint`, `yarn prettier-check`,
  `yarn test-dependencies`.
