### PR TITLE
fix: correct duplicated-word typos in comments and docs

### DIFF
--- a/compiler/crates/docblock-shared/src/lib.rs
+++ b/compiler/crates/docblock-shared/src/lib.rs
@@ -149,7 +149,7 @@ pub static LIVE_FIELD: LazyLock<StringKey> = LazyLock::new(|| "live".intern());
 /// context.
 pub static SEMANTIC_NON_NULL_FIELD: LazyLock<StringKey> =
     LazyLock::new(|| "semanticNonNull".intern());
-/// Resolver models are are JS values that back a resolver type. In the
+/// Resolver models are JS values that back a resolver type. In the
 /// Relay runtime they are currently modeled as hidden fields on their
 /// parent type. This is the name of that field.
 ///

--- a/compiler/crates/graphql-ir/src/ir.rs
+++ b/compiler/crates/graphql-ir/src/ir.rs
@@ -484,7 +484,7 @@ impl Hash for InlineFragment {
 impl InlineFragment {
     /// Get the alias of this inline fragment from the optional `@alias` directive.
     /// If the `as` argument is not present, the type condition is used as the fallback.
-    /// Is is an error to omit the `as` argument if the inline fragment does not
+    /// It is an error to omit the `as` argument if the inline fragment does not
     /// have a type condition.
     pub fn alias(&self, schema: &SDLSchema) -> DiagnosticsResult<Option<WithLocation<StringKey>>> {
         if let Some(directive) = self.directives.named(DirectiveName(intern!("alias"))) {

--- a/compiler/crates/intern/src/atomic_arena.rs
+++ b/compiler/crates/intern/src/atomic_arena.rs
@@ -361,7 +361,7 @@ impl<'a, T> AtomicArena<'a, T> {
         )
     }
 
-    /// Returns `Ref` to the the added value, which can safely be
+    /// Returns `Ref` to the added value, which can safely be
     /// passed to `get`.  `self.get(self.add(t)) == &t`
     pub fn add(&self, element: T) -> Ref<'a, T> {
         let (biased_index, _) = self.add_get(element);

--- a/compiler/crates/relay-compiler/src/get_programs.rs
+++ b/compiler/crates/relay-compiler/src/get_programs.rs
@@ -28,7 +28,7 @@ type RelayPrograms = (
 type ProgramsResult = Result<RelayPrograms>;
 
 /// Many CLI tools use `get_programs` to compile Relay programs as a prerequisite to other operations.
-/// In those cases it's often not practical to to continue if the programs
+/// In those cases it's often not practical to continue if the programs
 /// cannot be created. In those cases, it makes sense to exit the process with
 /// an error code.
 pub fn assert_programs(programs_result: ProgramsResult) -> RelayPrograms {

--- a/compiler/crates/relay-lsp/src/server/lsp_state_resources.rs
+++ b/compiler/crates/relay-lsp/src/server/lsp_state_resources.rs
@@ -177,7 +177,7 @@ impl<TPerfLogger: PerfLogger + 'static, TSchemaDocumentation: SchemaDocumentatio
 
                 // SC Update completed, we need to abort current subscription, and re-initialize resource for LSP
                 if compiler_state.source_control_update_status.is_completed() {
-                    debug!("Watchman indicated the the source control update has completed!");
+                    debug!("Watchman indicated the source control update has completed!");
                     subscription_handle.abort();
                     continue 'outer;
                 }

--- a/compiler/crates/relay-transforms/src/apply_fragment_arguments.rs
+++ b/compiler/crates/relay-transforms/src/apply_fragment_arguments.rs
@@ -485,7 +485,7 @@ impl ApplyFragmentArgumentsTransform<'_, '_, '_> {
             return;
         }
 
-        // We do not need to to write normalization files for base fragments
+        // We do not need to write normalization files for base fragments
         let is_base = self.base_fragment_names.contains(&fragment.name.item);
         if !is_base && !self.no_inline_feature.is_enabled_for(fragment.name.item.0) {
             self.errors.push(Diagnostic::error(

--- a/compiler/crates/relay-transforms/src/match_/match_transform.rs
+++ b/compiler/crates/relay-transforms/src/match_/match_transform.rs
@@ -705,7 +705,7 @@ impl<'program, 'flag> MatchTransform<'program, 'flag> {
                 // where there are multiple selections with `@module` in the same document.
                 //
                 // If the directive does not have a `key` argument, and is not on a field with a
-                // `supported` argument, then it is is not doing anything and is
+                // `supported` argument, then it is not doing anything and is
                 // therefore an error.
                 if key_arg.is_none() {
                     return Err(Diagnostic::error(

--- a/compiler/crates/relay-transforms/src/match_/split_module_import.rs
+++ b/compiler/crates/relay-transforms/src/match_/split_module_import.rs
@@ -98,7 +98,7 @@ impl Transformer<'_> for SplitModuleImportTransform<'_, '_> {
 
     fn transform_inline_fragment(&mut self, fragment: &InlineFragment) -> Transformed<Selection> {
         if let Some(module_metadata) = self.inline_module_metadata(fragment) {
-            // We do not need to to write normalization files for base fragments.
+            // We do not need to write normalization files for base fragments.
             // This is because when we process the base project, the normalization fragment will
             // be written, and we do not want to emit multiple normalization fragments with
             // the same name. If we did, Haste would complain about a duplicate module definition.

--- a/compiler/crates/relay-transforms/src/util.rs
+++ b/compiler/crates/relay-transforms/src/util.rs
@@ -77,7 +77,7 @@ pub fn replace_directive(directives: &[Directive], replacement: Directive) -> Ve
 }
 
 /// The function that will return a variable name for an argument
-/// it it uses a variable (and it the argument is available)
+/// if it uses a variable (and if the argument is available)
 pub fn extract_variable_name(argument: Option<&Argument>) -> Option<StringKey> {
     match argument {
         Some(arg) => match &arg.value.item {

--- a/packages/relay-runtime/experimental.js
+++ b/packages/relay-runtime/experimental.js
@@ -37,7 +37,7 @@ export type IdOf<A extends string, Typename extends void | string = void> = [
  * https://relay.dev/docs/next/guides/relay-resolvers/return-types/#javascript-values
  *
  * Note: This type forces the value to be non-maybe. This is required in order
- * to allow the Relay compiler to to "see", via static analysis, if the field
+ * to allow the Relay compiler to "see", via static analysis, if the field
  * can return null or not. If the field is nullable, you can type it as
  * returning `?RelayResolverValue<T>`.
  */

--- a/packages/relay-runtime/multi-actor-environment/MultiActorEnvironmentTypes.js
+++ b/packages/relay-runtime/multi-actor-environment/MultiActorEnvironmentTypes.js
@@ -54,7 +54,7 @@ export interface IActorEnvironment extends IEnvironment {
   readonly actorIdentifier: ActorIdentifier;
 
   /**
-   * TODO: this needs to move the the MultiActorEnvironment with different API.
+   * TODO: this needs to move to the MultiActorEnvironment with different API.
    */
   getPublishQueue(): RelayPublishQueue;
 

--- a/packages/relay-runtime/store/RelayStoreTypes.d.ts
+++ b/packages/relay-runtime/store/RelayStoreTypes.d.ts
@@ -118,7 +118,7 @@ export type Snapshot = TypedSnapshot<SelectorData>;
  * - `root`: a selector intended for processing server results or retaining
  *   response data in the store.
  * - `fragment`: a selector intended for use in reading or subscribing to
- *   the results of the the operation.
+ *   the results of the operation.
  */
 export interface OperationDescriptor {
     readonly fragment: SingularReaderSelector;

--- a/packages/relay-runtime/store/RelayStoreTypes.js
+++ b/packages/relay-runtime/store/RelayStoreTypes.js
@@ -156,7 +156,7 @@ export type Snapshot = {
  * - `root`: a selector intended for processing server results or retaining
  *   response data in the store.
  * - `fragment`: a selector intended for use in reading or subscribing to
- *   the results of the the operation.
+ *   the results of the operation.
  */
 export type OperationDescriptor = {
   readonly fragment: SingularReaderSelector,

--- a/packages/relay-runtime/store/live-resolvers/resolverDataInjector.js
+++ b/packages/relay-runtime/store/live-resolvers/resolverDataInjector.js
@@ -29,7 +29,7 @@ type ResolverFn = ($FlowFixMe, ?$FlowFixMe, ResolverContext) => unknown;
  * - (optional) fieldName: individual field that needs to be read out of the fragment.
  *
  * This will not call the `resolverFn` if the fragment data for it is null/undefined.
- * The the compiler generates calls to this function, ensuring the correct set of arguments.
+ * The compiler generates calls to this function, ensuring the correct set of arguments.
  */
 function resolverDataInjector<
   TFragmentType extends FragmentType,

--- a/website/docs/api-reference/types/MutationConfig.mdx
+++ b/website/docs/api-reference/types/MutationConfig.mdx
@@ -9,7 +9,7 @@ import UploadableMap from './UploadableMap.mdx';
   * `mutation`: `GraphQLTaggedNode`. A mutation specified using a GraphQL literal
   * `onError`: *_[Optional]_* `(Error) => void`. An optional callback executed if the mutation results in an error.
   * `onCompleted`: *_[Optional]_* `($ElementType<TMutationConfig, 'response'>) => void`. An optional callback that is executed when the mutation completes.
-    * The value passed to `onCompleted` is the the mutation fragment, as read out from the store, **after** updaters and declarative mutation directives are applied. This means that data from within unmasked fragments will not be read, and records that were deleted (e.g. by `@deleteRecord`) may also be null.
+    * The value passed to `onCompleted` is the mutation fragment, as read out from the store, **after** updaters and declarative mutation directives are applied. This means that data from within unmasked fragments will not be read, and records that were deleted (e.g. by `@deleteRecord`) may also be null.
   * `onUnsubscribe`: *_[Optional]_* `() => void`. An optional callback that is executed when the mutation is unsubscribed, which occurs when the returned `Disposable` is disposed.
   * `optimisticResponse`: *_[Optional]_* An object whose type matches the raw response type of the mutation. Make sure you decorate your mutation with `@raw_response_type` if you are using this field.
   * `optimisticUpdater`: *_[Optional]_* [`SelectorStoreUpdater`](#type-selectorstoreupdater). A callback that is executed when `commitMutation` is called, after the `optimisticResponse` has been normalized into the store.

--- a/website/docs/guided-tour/updating-data/graphql-mutations.mdx
+++ b/website/docs/guided-tour/updating-data/graphql-mutations.mdx
@@ -137,7 +137,7 @@ const [commitMutation, isMutationInFlight] = useMutation<
 We may want to update some state in response to the mutation succeeding or failing. For example, we might want to alert the user if the mutation failed. The `UseMutationConfig` object passed to `commitMutation` can include the following fields to handle such cases:
 
 * `onCompleted`, a callback that is executed when the mutation completes. It is passed the mutation response (stopping at fragment spread boundaries).
-  * The value passed to `onCompleted` is the the mutation fragment, as read out from the store, **after** updaters and declarative mutation directives are applied. This means that data from within unmasked fragments will not be read, and records that were deleted (e.g. by `@deleteRecord`) may also be null.
+  * The value passed to `onCompleted` is the mutation fragment, as read out from the store, **after** updaters and declarative mutation directives are applied. This means that data from within unmasked fragments will not be read, and records that were deleted (e.g. by `@deleteRecord`) may also be null.
 * `onError`, a callback that is executed when the mutation errors. It is passed the error that occurred.
 
 ## Declarative mutation directives

--- a/website/docs/guided-tour/updating-data/updating-connections.mdx
+++ b/website/docs/guided-tour/updating-data/updating-connections.mdx
@@ -331,7 +331,7 @@ function updater(store: RecordSourceSelectorProxy) {
 ```
 
 
-Once we have a new edge record, we can add it to the the connection using `ConnectionHandler.insertEdgeAfter` or `ConnectionHandler.insertEdgeBefore`:
+Once we have a new edge record, we can add it to the connection using `ConnectionHandler.insertEdgeAfter` or `ConnectionHandler.insertEdgeBefore`:
 
 ```js
 const {ConnectionHandler} = require('relay-runtime');

--- a/website/docs/guides/relay-resolvers/introduction.mdx
+++ b/website/docs/guides/relay-resolvers/introduction.mdx
@@ -56,7 +56,7 @@ function Greeting() {
 ```
 
 :::note
-If your query contains only client-defined fields, you will need to use a a different query API to fetch data. Note how this example uses `useClientQuery` instead of `useLazyLoadQuery` or `usePreloadedQuery`. If your query also contains server data, you can use the standard `useLazyLoadQuery` or `usePreloadedQuery` APIs.
+If your query contains only client-defined fields, you will need to use a different query API to fetch data. Note how this example uses `useClientQuery` instead of `useLazyLoadQuery` or `usePreloadedQuery`. If your query also contains server data, you can use the standard `useLazyLoadQuery` or `usePreloadedQuery` APIs.
 
 We intend to remove this requirement in future versions of Relay.
 :::

--- a/website/docs/tutorial/intro.mdx
+++ b/website/docs/tutorial/intro.mdx
@@ -29,7 +29,7 @@ This downloads a template project to get started from and starts the server. (If
 When you run `npm run dev`, several processes are started:
 
 * A Webpack-based HTTP server that serves up the front-end code.
-* A basic GraphQL server that that front-end will query to retrieve information.
+* A basic GraphQL server that the front-end will query to retrieve information.
 * The Relay compiler, which processes the GraphQL in your app and generates additional files that Relay uses at runtime, as well as TypeScript types representing the inputs and results of your queries. It will automatically regenerate when you save changes in your files.
 
 In the terminal output, these three processes’ log output are marked with tags: `[webpack]` in yellow, `[server]` in green, and `[relay]` in blue. Keep a look out for errors marked with `[relay]` as these are helpful if your GraphQL has any mistakes.


### PR DESCRIPTION
## Summary

Fixes a batch of **duplicated-word typos** in code comments and documentation. These are all self-evident repeated-word mistakes (e.g. "the the", "to to", "is is", "are are", "a a") that hurt readability. **No behavior changes** — comments, docblocks, and Markdown/MDX docs only.

## Changes

| File | Before | After |
| --- | --- | --- |
| `compiler/crates/graphql-ir/src/ir.rs` | `Is is an error to omit the as argument` | `It is an error to omit the as argument` |
| `compiler/crates/relay-transforms/src/util.rs` | `it it uses a variable (and it the argument is available)` | `if it uses a variable (and if the argument is available)` |
| `compiler/crates/relay-transforms/src/apply_fragment_arguments.rs` | `do not need to to write normalization files` | `do not need to write normalization files` |
| `compiler/crates/relay-transforms/src/match_/split_module_import.rs` | `do not need to to write normalization files.` | `do not need to write normalization files.` |
| `compiler/crates/relay-transforms/src/match_/match_transform.rs` | `then it is is not doing anything` | `then it is not doing anything` |
| `compiler/crates/relay-compiler/src/get_programs.rs` | `not practical to to continue` | `not practical to continue` |
| `compiler/crates/docblock-shared/src/lib.rs` | `Resolver models are are JS values` | `Resolver models are JS values` |
| `compiler/crates/intern/src/atomic_arena.rs` | `Returns Ref to the the added value` | `Returns Ref to the added value` |
| `compiler/crates/relay-lsp/src/server/lsp_state_resources.rs` | `indicated the the source control update` | `indicated the source control update` |
| `packages/relay-runtime/experimental.js` | `allow the Relay compiler to to "see"` | `allow the Relay compiler to "see"` |
| `packages/relay-runtime/multi-actor-environment/MultiActorEnvironmentTypes.js` | `needs to move the the MultiActorEnvironment` | `needs to move to the MultiActorEnvironment` |
| `packages/relay-runtime/store/live-resolvers/resolverDataInjector.js` | `The the compiler generates calls` | `The compiler generates calls` |
| `packages/relay-runtime/store/RelayStoreTypes.js` | `the results of the the operation.` | `the results of the operation.` |
| `packages/relay-runtime/store/RelayStoreTypes.d.ts` | `the results of the the operation.` | `the results of the operation.` |
| `website/docs/tutorial/intro.mdx` | `GraphQL server that that front-end` | `GraphQL server that the front-end` |
| `website/docs/api-reference/types/MutationConfig.mdx` | `is the the mutation fragment` | `is the mutation fragment` |
| `website/docs/guided-tour/updating-data/graphql-mutations.mdx` | `is the the mutation fragment` | `is the mutation fragment` |
| `website/docs/guided-tour/updating-data/updating-connections.mdx` | `add it to the the connection` | `add it to the connection` |
| `website/docs/guides/relay-resolvers/introduction.mdx` | `use a a different query API` | `use a different query API` |

## Notes

- Only the canonical `website/docs/` sources were edited; frozen `website/versioned_docs/` snapshots were intentionally left untouched.
- Verified that grammatically-correct sequences (e.g. "indicates ... that that ID is stable") were *not* changed.
