### PR TITLE
Fix Windows CI: allow backslash path separator in disallowed-chars check

### DIFF
--- a/compiler/crates/relay-config/src/project_config.rs
+++ b/compiler/crates/relay-config/src/project_config.rs
@@ -605,7 +605,11 @@ fn path_has_disallowed_filename_chars(path: &Path) -> bool {
     !path
         .to_string_lossy()
         .chars()
-        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-' | '_' | '@' | '+' | '/' | '$'))
+        .all(|c| {
+            c.is_ascii_alphanumeric()
+                || std::path::is_separator(c)
+                || matches!(c, '.' | '-' | '_' | '@' | '+' | '$')
+        })
 }
 
 // Stringify a path such that it is stable across operating systems.


### PR DESCRIPTION
## Summary

- The `path_has_disallowed_filename_chars` function hardcoded `'/'` as the only allowed path separator, but on Windows `PathBuf` operations produce `\` separators
- This caused `\` to be flagged as a disallowed character, making all sharded extra-artifact paths fall back to the flat layout on Windows
- Replace the literal `'/'` with `std::path::is_separator(c)` which handles both `/` (all platforms) and `\` (Windows)

Fixes the `Rust Tests (windows-latest)` CI failures:
- `extra_artifact_path_sharded_with_regex_mirrors_normal_artifact_layout`
- `extra_artifact_path_sharded_without_regex_uses_full_source_dir`

## Test plan
- [x] All 6 `extra_artifact_path_*` tests pass locally on macOS
- [ ] Windows CI should now pass (the two previously failing tests should produce correct sharded paths instead of falling back to flat layout)