### PR TITLE
Fix CI: Prettier formatting in flow-typed jest stub

### DIFF
--- a/flow-typed/npm/jest_v29.x.x.js
+++ b/flow-typed/npm/jest_v29.x.x.js
@@ -214,7 +214,10 @@ type FakeTimersConfig = {
  */
 
 type JestStyledComponentsMatcherValue =
-  string | JestAsymmetricEqualityType | RegExp | typeof undefined;
+  | string
+  | JestAsymmetricEqualityType
+  | RegExp
+  | typeof undefined;
 
 type JestStyledComponentsMatcherOptions = {
   media?: string,


### PR DESCRIPTION
## Which job was failing

`main` CI is red on the **JS Lint → Prettier** step (e.g. run for `Update Cargo.lock (#5351)`, commit b4b5db6):

```
Checking formatting...
[warn] flow-typed/npm/jest_v29.x.x.js
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
error Command failed with exit code 123.
```

## What the error was

The recent "Bump to latest prettier" change upgraded Prettier to 3.6.2, which reformats multiline union types to use a leading pipe (`|`). The vendored `flow-typed/npm/jest_v29.x.x.js` stub was never reformatted, so `yarn run prettier-check` fails.

## How it was fixed

Ran `prettier --write` on the single offending file. The only change is the `JestStyledComponentsMatcherValue` union:

```diff
 type JestStyledComponentsMatcherValue =
-  string | JestAsymmetricEqualityType | RegExp | typeof undefined;
+  | string
+  | JestAsymmetricEqualityType
+  | RegExp
+  | typeof undefined;
```

## Verification

Reproduced the failure locally on `main`, then confirmed the fix:

```
$ node_modules/.bin/prettier --check flow-typed/npm/jest_v29.x.x.js
Checking formatting...
All matched files use Prettier code style!
```

🤖 Generated with the Fix CI Skill