### PR TITLE
fix: change PreloadedQuery back to interface to allow type inference based on PreloadedQuery generic type (#5361)

### DIFF
--- a/packages/react-relay/ReactRelayTypes.d.ts
+++ b/packages/react-relay/ReactRelayTypes.d.ts
@@ -136,6 +136,7 @@ export type PreloadedQuery<
     TQuery extends OperationType,
     TEnvironmentProviderOptions = EnvironmentProviderOptions,
 > = Readonly<{
+    ' $queryShape': TQuery;
     kind: 'PreloadedQuery';
     environment: IEnvironment;
     environmentProviderOptions?: TEnvironmentProviderOptions | null | undefined;


### PR DESCRIPTION
Fix #5361