### PR TITLE
Fix relay compiler path issues for Windows

### DIFF
--- a/compiler/crates/relay-lsp/src/utils.rs
+++ b/compiler/crates/relay-lsp/src/utils.rs
@@ -6,6 +6,7 @@
  */
 
 use std::path::Path;
+use std::path::PathBuf;
 
 use common::Location;
 use common::SourceLocationKey;
@@ -23,6 +24,7 @@ use log::debug;
 use lsp_types::Position;
 use lsp_types::TextDocumentPositionParams;
 use lsp_types::Uri;
+use percent_encoding::percent_decode_str;
 use relay_compiler::FileCategorizer;
 use relay_compiler::FileGroup;
 use relay_compiler::ProjectConfig;
@@ -36,10 +38,7 @@ use crate::lsp_runtime_error::LSPRuntimeError;
 use crate::lsp_runtime_error::LSPRuntimeResult;
 
 pub fn is_file_uri_in_dir(root_dir: &Path, file_uri: &Uri) -> bool {
-    file_uri
-        .scheme()
-        .is_some_and(|scheme| scheme.eq_lowercase("file"))
-        && Path::new(file_uri.path().as_str()).starts_with(root_dir)
+    uri_to_file_path(file_uri).is_some_and(|file_path| file_path.starts_with(root_dir))
 }
 
 pub fn extract_executable_definitions_from_text_document(
@@ -83,12 +82,11 @@ pub fn get_file_group_from_uri(
     root_dir: &Path,
     config: &Config,
 ) -> LSPRuntimeResult<FileGroup> {
-    let absolute_file_path = Path::new(uri.path().as_str());
-    if !absolute_file_path.is_absolute() {
-        return Err(LSPRuntimeError::UnexpectedError(format!(
-            "Unable to convert URI to file path: {uri:?}",
-        )));
-    }
+    let absolute_file_path = uri_to_file_path(uri)
+        .filter(|path| path.is_absolute())
+        .ok_or_else(|| {
+            LSPRuntimeError::UnexpectedError(format!("Unable to convert URI to file path: {uri:?}"))
+        })?;
 
     let file_path = absolute_file_path.strip_prefix(root_dir).map_err(|_e| {
         LSPRuntimeError::UnexpectedError(format!(
@@ -296,6 +294,57 @@ pub fn position_to_offset(
     None
 }
 
+/// Converts a `file://` URI into a filesystem path, handling both Unix and
+/// Windows paths.
+///
+/// This restores the behavior that was lost when relay-lsp migrated from
+/// `lsp_types::Url` (backed by the `url` crate) to `lsp_types::Uri` (backed by
+/// `fluent-uri`). `Url::to_file_path()` used to percent-decode the path and
+/// normalize Windows drive letters, whereas `Uri::path()` exposes only the
+/// raw, still-percent-encoded path. Without this, Windows editors that send
+/// URIs such as `file:///c%3A/dir/file.graphql` produce the path
+/// `/c%3A/dir/file.graphql`, which is neither absolute nor a real file (see
+/// https://github.com/facebook/relay/issues/5347).
+///
+/// Returns `None` for non-`file` URIs.
+pub fn uri_to_file_path(uri: &Uri) -> Option<PathBuf> {
+    if !uri
+        .scheme()
+        .is_some_and(|scheme| scheme.eq_lowercase("file"))
+    {
+        return None;
+    }
+
+    // Percent-decode the path, e.g. `%3A` -> `:` for Windows drive letters and
+    // `%20` -> ` ` for paths containing spaces.
+    let decoded = percent_decode_str(uri.path().as_str()).decode_utf8_lossy();
+    Some(decoded_uri_path_to_file_path(&decoded))
+}
+
+/// Maps the (already percent-decoded) path component of a `file://` URI to a
+/// filesystem path.
+fn decoded_uri_path_to_file_path(decoded_path: &str) -> PathBuf {
+    // A `file://` URI always begins its path with `/`. On Windows the path is
+    // of the form `/C:/dir/file`, and the leading slash must be removed so it
+    // maps to the absolute path `C:/dir/file`. Unix paths (`/home/user`) are
+    // used verbatim.
+    let path = decoded_path
+        .strip_prefix('/')
+        .filter(|rest| is_windows_drive_prefix(rest))
+        .unwrap_or(decoded_path);
+    PathBuf::from(path)
+}
+
+/// Returns `true` if `path` begins with a Windows drive-letter component such
+/// as `C:`, `C:/`, or `C:\`.
+fn is_windows_drive_prefix(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    bytes.len() >= 2
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':'
+        && (bytes.len() == 2 || bytes[2] == b'/' || bytes[2] == b'\\')
+}
+
 /// Converts a filesystem path to a `file://` URI, handling both Unix and Windows paths.
 pub fn path_to_file_uri(path: &Path) -> Option<Uri> {
     let path_str = path.to_str()?;
@@ -317,4 +366,87 @@ fn str_path_to_file_uri(path: &str) -> Option<Uri> {
         format!("file:///{normalized}")
     };
     uri_str.parse::<Uri>().ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use lsp_types::Uri;
+
+    use super::is_windows_drive_prefix;
+    use super::path_to_file_uri;
+    use super::uri_to_file_path;
+
+    fn uri(s: &str) -> Uri {
+        s.parse::<Uri>().unwrap()
+    }
+
+    #[test]
+    fn uri_to_file_path_unix() {
+        assert_eq!(
+            uri_to_file_path(&uri("file:///Users/alice/project/src/foo.graphql")),
+            Some(PathBuf::from("/Users/alice/project/src/foo.graphql"))
+        );
+    }
+
+    #[test]
+    fn uri_to_file_path_windows_percent_encoded_drive_letter() {
+        // Editors such as VSCode encode the drive-letter colon as `%3A`. This
+        // is the exact shape reported in facebook/relay#5347.
+        assert_eq!(
+            uri_to_file_path(&uri(
+                "file:///c%3A/Development/repo-relay-compiler-bug/src/something.graphql"
+            )),
+            Some(PathBuf::from(
+                "c:/Development/repo-relay-compiler-bug/src/something.graphql"
+            ))
+        );
+    }
+
+    #[test]
+    fn uri_to_file_path_windows_unencoded_drive_letter() {
+        assert_eq!(
+            uri_to_file_path(&uri("file:///C:/Development/foo.graphql")),
+            Some(PathBuf::from("C:/Development/foo.graphql"))
+        );
+    }
+
+    #[test]
+    fn uri_to_file_path_decodes_spaces() {
+        assert_eq!(
+            uri_to_file_path(&uri("file:///Users/alice/my%20project/foo.graphql")),
+            Some(PathBuf::from("/Users/alice/my project/foo.graphql"))
+        );
+    }
+
+    #[test]
+    fn uri_to_file_path_rejects_non_file_scheme() {
+        assert_eq!(
+            uri_to_file_path(&uri("https://example.com/foo.graphql")),
+            None
+        );
+    }
+
+    #[test]
+    fn uri_to_file_path_roundtrips_windows_path() {
+        // `path_to_file_uri` (the reverse direction) followed by
+        // `uri_to_file_path` should recover a usable absolute Windows path.
+        let file_uri = path_to_file_uri(&PathBuf::from("C:\\Development\\foo.graphql")).unwrap();
+        assert_eq!(
+            uri_to_file_path(&file_uri),
+            Some(PathBuf::from("C:/Development/foo.graphql"))
+        );
+    }
+
+    #[test]
+    fn windows_drive_prefix_detection() {
+        assert!(is_windows_drive_prefix("C:"));
+        assert!(is_windows_drive_prefix("c:/dir"));
+        assert!(is_windows_drive_prefix("Z:\\dir"));
+        assert!(!is_windows_drive_prefix("Users/alice"));
+        assert!(!is_windows_drive_prefix("/c:/dir"));
+        assert!(!is_windows_drive_prefix("cc:/dir"));
+        assert!(!is_windows_drive_prefix("1:/dir"));
+    }
 }


### PR DESCRIPTION
Fixes #5347

## The bug

On Windows, the Relay LSP breaks for every graphql tagged literal starting with `relay-compiler` 21.0.0 (20.0.0 works). The schema can't be resolved and IDE features (hover, autocomplete, diagnostics) silently stop working. The LSP log shows:

```
Unable to convert URI to file path: Uri { scheme: Some("file"), … path: "/c%3A/Development/repo-relay-compiler-bug/src/something.graphql" }
```

The give-away is `%3A` (a URL-encoded `:`) and the leading slash before the drive letter: the compiler is treating the raw URI path as a filesystem path instead of decoding it into `c:\Development\…`.

macOS/Linux are unaffected because their URI paths (`/Users/…`) need no decoding and have no drive letter.

## Root cause

This is a regression from `6098dee` ("Update from lsp-types 0.94 to 0.97"), which migrated relay-lsp from `lsp_types::Url` (backed by the `url` crate) to `lsp_types::Uri` (backed by `fluent-uri`).

`Url::to_file_path()` used to do two Windows-critical things that the new API does not:

1. **Percent-decode** the path (`%3A` → `:`).
2. **Normalize the Windows drive letter** by stripping the leading `/` (`/C:/…` → `C:\…`).

The migration replaced those calls with a naïve `Path::new(uri.path().as_str())`, and `Uri::path()` returns the raw, still-percent-encoded path. So on Windows the path stays `/c%3A/…`, which is:

- not absolute → `get_file_group_from_uri` returns the *"Unable to convert URI to file path"* error above (schema resolution fails), and
- not `starts_with(root_dir)` → `is_file_uri_in_dir` returns `false`, so the LSP treats the file as outside the project and ignores its `didOpen`/`didChange` entirely (hover/autocomplete break).

The reverse direction (path → URI) was already re-fixed in #5285 (`path_to_file_uri`), but the mirror URI → path conversion was never restored — that's the remaining gap.

## The fix

Added a `uri_to_file_path()` helper in `relay-lsp/src/utils.rs` that restores the old `Url::to_file_path()` behavior:

- rejects non-`file` URIs (returns `None`),
- percent-decodes the path via the `percent-encoding` crate (already a dependency), and
- strips the leading `/` only when a Windows drive-letter component (`C:`, `C:/`, `C:\`) follows — Unix paths pass through verbatim.

Both broken call sites now route through it:

- `is_file_uri_in_dir` → `uri_to_file_path(uri).is_some_and(|p| p.starts_with(root_dir))`
- `get_file_group_from_uri` → converts via `uri_to_file_path`, keeping the existing `is_absolute()` guard.

This is behaviorally equivalent to what `Url::to_file_path()` produced in 20.0.0 (same case-preserving output; Rust already compares Windows drive prefixes case-insensitively, and the `starts_with` comparison itself is unchanged from before the regression).

## Tests

Added a `#[cfg(test)] mod tests` in `utils.rs` (matching the existing inline-unit-test convention used across the compiler, e.g. `file_categorizer.rs`) covering:

- Unix path passthrough,
- the **percent-encoded Windows drive letter** — the exact `file:///c%3A/…` URI from the issue → `c:/…`,
- an unencoded `file:///C:/…` drive letter,
- percent-decoding of spaces (`%20`),
- non-`file` schemes → `None`,
- a round-trip through `path_to_file_uri` (the reverse direction), and
- the drive-letter detection predicate.

## Testing

- We're verified this fix on multiple windows machines, including the original reporter's environment, and confirmed that the LSP now works correctly.
- `cargo test -p relay-lsp` — all new tests pass, existing tests green.
- `cargo fmt` / `cargo check` clean per `CONTRIBUTING.md`.
- The change is confined to `relay-lsp/src/utils.rs`; no API, schema, or compiler-CLI changes.
