### PR TITLE
Allow optional cacheID on the persisted-id RequestParameters variant

### DIFF
--- a/packages/relay-runtime/util/RelayConcreteNode.js
+++ b/packages/relay-runtime/util/RelayConcreteNode.js
@@ -52,6 +52,10 @@ export type RequestParameters =
   | {
       readonly id: string,
       readonly text: string | null,
+      // Optional when the compiler is configured with `include_query_text: true`
+      // for persisted queries — artifacts then carry both `id` and `text`, and a
+      // `cacheID` (hash of the text) for local caching. See the doc comment above.
+      readonly cacheID?: string,
       // common fields
       readonly name: string,
       readonly operationKind: 'mutation' | 'query' | 'subscription',


### PR DESCRIPTION
## Summary

When the relay-compiler is configured with `include_query_text: true` for persisted queries, generated artifacts carry a persisted `id`, the query `text`, **and** a `cacheID` (a hash of the text, used for local caching) all at once.

The current `RequestParameters` union only permits `cacheID` on the text-only variant (the one with `id: null`):

```js
export type RequestParameters =
  | {
      readonly id: string,
      readonly text: string | null,
      // ...no cacheID
    }
  | {
      readonly cacheID: string,
      readonly id: null,
      readonly text: string | null,
      // ...
    };
```

So an artifact with a non-null `id` plus a `cacheID` does not type-check against either variant. This PR adds an optional `readonly cacheID?: string` to the persisted-`id` variant, which makes that compiler configuration representable without altering the existing text-only variant.

This is a purely additive, optional field — no runtime behaviour changes, and existing artifacts that omit `cacheID` are unaffected.

## Motivation

We run relay-compiler with `persistConfig` + `include_query_text: true` so that artifacts carry both a persisted `id` (for id-first / trusted-documents requests) and the `text` (for a safe deploy transition), together with the `cacheID` the compiler emits for local caching. The type currently doesn't describe artifacts that have all three, which we've been carrying as a local patch.

## Test plan

Type-only change to a Flow definition; adding an optional field to one member of the union is backwards compatible. `RequestParameters` continues to type-check for all existing shapes, and now also accepts `{ id, text, cacheID }`.
