### PR TITLE
Export PreloadableConcreteRequest from relay-runtime's Flow types

### DIFF
--- a/packages/react-relay/relay-hooks/EntryPointTypes.flow.js
+++ b/packages/react-relay/relay-hooks/EntryPointTypes.flow.js
@@ -22,9 +22,12 @@ import type {
   IEnvironment,
   Observable,
   OperationType,
+  PreloadableConcreteRequest,
   RequestParameters,
   VariablesOf as _VariablesOf,
 } from 'relay-runtime';
+
+export type {PreloadableConcreteRequest};
 
 export type VariablesOf<T> = _VariablesOf<T>;
 
@@ -44,17 +47,6 @@ export type LoadQueryOptions = {
   readonly fetchPolicy?: ?FetchPolicy,
   readonly networkCacheConfig?: ?CacheConfig,
   readonly __nameForWarning?: ?string,
-};
-
-export type PreloadableConcreteRequest<out TQuery extends OperationType> = {
-  kind: 'PreloadableConcreteRequest',
-  params: RequestParameters,
-  // Note: the phantom type parameter here helps ensures that the
-  // $Parameters.js value matches the type param provided to preloadQuery.
-  // We also need to add usage of this generic here,
-  // becuase not using the generic in the definition makes it
-  // unconstrained in the call to a function that accepts PreloadableConcreteRequest<T>
-  readonly __phantom__?: ?TQuery,
 };
 
 export type EnvironmentProviderOptions = {readonly [string]: unknown, ...};

--- a/packages/relay-runtime/index.js
+++ b/packages/relay-runtime/index.js
@@ -223,6 +223,7 @@ export type {
   ClientRequest,
   ConcreteUpdatableQuery,
   GeneratedNode,
+  PreloadableConcreteRequest,
   RequestParameters,
 } from './util/RelayConcreteNode';
 export type {

--- a/packages/relay-runtime/util/RelayConcreteNode.js
+++ b/packages/relay-runtime/util/RelayConcreteNode.js
@@ -16,6 +16,7 @@ import type {
   NormalizationSplitOperation,
 } from './NormalizationNode';
 import type {ReaderFragment, ReaderInlineDataFragment} from './ReaderNode';
+import type {OperationType} from './RelayRuntimeTypes';
 
 /**
  * Represents a common GraphQL request that can be executed, an `operation`
@@ -33,6 +34,29 @@ export type ConcreteRequest = {
 export type ConcreteUpdatableQuery = {
   readonly kind: 'UpdatableQuery',
   readonly fragment: ReaderFragment,
+};
+
+/**
+ * A lightweight stand-in for a `ConcreteRequest` emitted by the compiler for
+ * `@preloadable` queries: a `$Parameters.js` artifact containing only the
+ * `RequestParameters` (e.g. the persisted query `id`), so that the full
+ * normalization/reader AST can be code-split away from eager query loaders.
+ *
+ * This mirrors the type already published in the TypeScript declarations
+ * (`RelayConcreteNode.d.ts`) and re-exported from `relay-runtime`'s
+ * `index.d.ts`; the Flow definition previously only lived in `react-relay`
+ * (`EntryPointTypes.flow.js`), so Flow consumers could not import it from
+ * `relay-runtime` the way TypeScript consumers can.
+ */
+export type PreloadableConcreteRequest<out TQuery extends OperationType> = {
+  kind: 'PreloadableConcreteRequest',
+  params: RequestParameters,
+  // Note: the phantom type parameter here helps ensures that the
+  // $Parameters.js value matches the type param provided to preloadQuery.
+  // We also need to add usage of this generic here,
+  // becuase not using the generic in the definition makes it
+  // unconstrained in the call to a function that accepts PreloadableConcreteRequest<T>
+  readonly __phantom__?: ?TQuery,
 };
 
 export type NormalizationRootNode =


### PR DESCRIPTION
## Summary

`relay-runtime`'s **TypeScript** declarations expose `PreloadableConcreteRequest` — it is defined in [`util/RelayConcreteNode.d.ts`](https://github.com/facebook/relay/blob/main/packages/relay-runtime/util/RelayConcreteNode.d.ts) and re-exported from [`index.d.ts`](https://github.com/facebook/relay/blob/main/packages/relay-runtime/index.d.ts). The **Flow** types do not: the Flow definition only lives in `react-relay` ([`relay-hooks/EntryPointTypes.flow.js`](https://github.com/facebook/relay/blob/main/packages/react-relay/relay-hooks/EntryPointTypes.flow.js)).

So this works for a TypeScript consumer but not the Flow equivalent:

```ts
import type {PreloadableConcreteRequest} from 'relay-runtime'; // ✅ TS  /  ❌ Flow
```

The compiler emits `@preloadable` `$Parameters.js` artifacts whose type is `PreloadableConcreteRequest`, so it's natural for eager query-loader code to want the type from `relay-runtime` alongside `RequestParameters`, `ConcreteRequest`, etc.

## What this does (types-only)

- Moves the canonical Flow definition of `PreloadableConcreteRequest` down into `relay-runtime/util/RelayConcreteNode.js` — the same file/location the `.d.ts` uses — and exports it from `relay-runtime`'s `index.js`, matching `index.d.ts`.
- `react-relay`'s `EntryPointTypes.flow.js` now imports and re-exports it from `relay-runtime` instead of defining an identical local copy, so there's a single source of truth. Every existing `import ... from 'EntryPointTypes'` keeps working via the re-export.

The Flow definition is unchanged — it's relay's own existing one (`out TQuery extends OperationType`, phantom `__phantom__?: ?TQuery`). No runtime code changes.

## Notes

- `OperationType` is imported into `RelayConcreteNode.js` from the sibling `./RelayRuntimeTypes` (same import the `.d.ts` already uses); `RelayRuntimeTypes` does not import `RelayConcreteNode`, so no cycle is introduced.
- This aligns the Flow public surface with the already-published TypeScript surface; it does not change the TS declarations.
