### PR TITLE
Fix/mock payload generator plural double nest

### DIFF
--- a/packages/relay-test-utils/RelayMockPayloadGenerator.js
+++ b/packages/relay-test-utils/RelayMockPayloadGenerator.js
@@ -810,6 +810,14 @@ class RelayMockPayloadGenerator {
       if (fieldDefaultValue === null) {
         return null;
       }
+      // `fieldPath` above already indexes plural fields by `index`; the prior
+      // data must be indexed the same way, or the whole array is passed as each
+      // element's previous value and the list double-nests (`[[item]]`).
+      const prevFieldData = field.plural
+        ? index != null && Array.isArray(data[applicationName])
+          ? data[applicationName][index]
+          : null
+        : data[applicationName];
       return this._traverse(
         {
           selections: field.selections,
@@ -820,9 +828,9 @@ class RelayMockPayloadGenerator {
           args,
         },
         fieldPath,
-        typeof data[applicationName] === 'object'
+        typeof prevFieldData === 'object' && prevFieldData !== null
           ? // $FlowFixMe[incompatible-variance]
-            data[applicationName]
+            prevFieldData
           : null,
         // $FlowFixMe[incompatible-type]
         fieldDefaultValue,

--- a/packages/relay-test-utils/__tests__/RelayMockPayloadGenerator-test.js
+++ b/packages/relay-test-utils/__tests__/RelayMockPayloadGenerator-test.js
@@ -2214,3 +2214,63 @@ describe("Aliased linked fields without arguments don't overwrite each other", (
     );
   });
 });
+
+describe('plural linked field selected twice at the same path', () => {
+  // When the same plural linked field is selected once unconditionally and once
+  // again in a sibling selection (an `@include`/`@skip` condition or an abstract
+  // inline fragment), the generator used to pass the whole previously-generated
+  // array down as the prior value for *each* element, so `_traverse` returned
+  // the array itself and `generateMockList` wrapped it again — producing
+  // `[[item]]` instead of `[item]`. The normalizer then could not read the leaf
+  // fields and warned. `disallowWarnings()` at the top of this file turns that
+  // warning into a failure, and the snapshot pins the flat shape.
+  test('does not double-nest under an @include condition', () => {
+    testGeneratedData(
+      graphql`
+        query RelayMockPayloadGeneratorTest71Query($showDetails: Boolean!) {
+          node(id: "my-id") {
+            ... on User {
+              allPhones {
+                isVerified
+              }
+              ... @include(if: $showDetails) {
+                allPhones {
+                  phoneNumber {
+                    displayNumber
+                  }
+                }
+              }
+            }
+          }
+        }
+      `,
+      null,
+      undefined,
+      {showDetails: true},
+    );
+  });
+
+  test('does not double-nest across concrete + abstract inline fragments (#5258)', () => {
+    // Same root cause, but the second selection lives in an *abstract* inline
+    // fragment (`... on Actor`) rather than an `@include` condition — the exact
+    // shape reported in facebook/relay#5258.
+    testGeneratedData(graphql`
+      query RelayMockPayloadGeneratorTest72Query {
+        me {
+          ... on User {
+            allPhones {
+              isVerified
+            }
+          }
+          ... on Actor {
+            allPhones {
+              phoneNumber {
+                displayNumber
+              }
+            }
+          }
+        }
+      }
+    `);
+  });
+});

--- a/packages/relay-test-utils/__tests__/__generated__/RelayMockPayloadGeneratorTest71Query.graphql.js
+++ b/packages/relay-test-utils/__tests__/__generated__/RelayMockPayloadGeneratorTest71Query.graphql.js
@@ -1,0 +1,190 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<9d0bfa5e03434970a3d21b1fa9913a6c>>
+ * @flow
+ * @lightSyntaxTransform
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+export type RelayMockPayloadGeneratorTest71Query$variables = {
+  showDetails: boolean,
+};
+export type RelayMockPayloadGeneratorTest71Query$data = {
+  readonly node: ?{
+    readonly allPhones?: ?ReadonlyArray<?{
+      readonly isVerified: ?boolean,
+      readonly phoneNumber?: ?{
+        readonly displayNumber: ?string,
+      },
+    }>,
+  },
+};
+export type RelayMockPayloadGeneratorTest71Query = {
+  response: RelayMockPayloadGeneratorTest71Query$data,
+  variables: RelayMockPayloadGeneratorTest71Query$variables,
+};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "showDetails"
+  }
+],
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "my-id"
+  }
+],
+v2 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Phone",
+      "kind": "LinkedField",
+      "name": "allPhones",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "isVerified",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "condition": "showDetails",
+      "kind": "Condition",
+      "passingValue": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Phone",
+          "kind": "LinkedField",
+          "name": "allPhones",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "PhoneNumber",
+              "kind": "LinkedField",
+              "name": "phoneNumber",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "displayNumber",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ]
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RelayMockPayloadGeneratorTest71Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*:: as any*/)
+        ],
+        "storageKey": "node(id:\"my-id\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Operation",
+    "name": "RelayMockPayloadGeneratorTest71Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*:: as any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "node(id:\"my-id\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "885dbe8d46bc5c892926325509426b87",
+    "id": null,
+    "metadata": {},
+    "name": "RelayMockPayloadGeneratorTest71Query",
+    "operationKind": "query",
+    "text": "query RelayMockPayloadGeneratorTest71Query(\n  $showDetails: Boolean!\n) {\n  node(id: \"my-id\") {\n    __typename\n    ... on User {\n      allPhones {\n        isVerified\n      }\n      allPhones @include(if: $showDetails) {\n        phoneNumber {\n          displayNumber\n        }\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*:: as any*/).hash = "9dc9e9e4f89aa6ba1bbc90bfff3e4043";
+}
+
+module.exports = ((node/*:: as any*/)/*:: as Query<
+  RelayMockPayloadGeneratorTest71Query$variables,
+  RelayMockPayloadGeneratorTest71Query$data,
+>*/);

--- a/packages/relay-test-utils/__tests__/__generated__/RelayMockPayloadGeneratorTest72Query.graphql.js
+++ b/packages/relay-test-utils/__tests__/__generated__/RelayMockPayloadGeneratorTest72Query.graphql.js
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<d943ff9137a81ba129dd40e16b0b2809>>
+ * @flow
+ * @lightSyntaxTransform
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+export type RelayMockPayloadGeneratorTest72Query$variables = {};
+export type RelayMockPayloadGeneratorTest72Query$data = {
+  readonly me: ?{
+    readonly allPhones: ?ReadonlyArray<?{
+      readonly isVerified: ?boolean,
+      readonly phoneNumber?: ?{
+        readonly displayNumber: ?string,
+      },
+    }>,
+  },
+};
+export type RelayMockPayloadGeneratorTest72Query = {
+  response: RelayMockPayloadGeneratorTest72Query$data,
+  variables: RelayMockPayloadGeneratorTest72Query$variables,
+};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Phone",
+  "kind": "LinkedField",
+  "name": "allPhones",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "isVerified",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v1 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Phone",
+      "kind": "LinkedField",
+      "name": "allPhones",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PhoneNumber",
+          "kind": "LinkedField",
+          "name": "phoneNumber",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "displayNumber",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Actor",
+  "abstractKey": "__isActor"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RelayMockPayloadGeneratorTest72Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          (v0/*:: as any*/),
+          (v1/*:: as any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "RelayMockPayloadGeneratorTest72Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "User",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          (v0/*:: as any*/),
+          (v1/*:: as any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "a1632f5c8f64ae2bf03821882dcd4c13",
+    "id": null,
+    "metadata": {},
+    "name": "RelayMockPayloadGeneratorTest72Query",
+    "operationKind": "query",
+    "text": "query RelayMockPayloadGeneratorTest72Query {\n  me {\n    allPhones {\n      isVerified\n    }\n    ... on Actor {\n      __isActor: __typename\n      allPhones {\n        phoneNumber {\n          displayNumber\n        }\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*:: as any*/).hash = "10885288fd723c757635eb66b86e4b07";
+}
+
+module.exports = ((node/*:: as any*/)/*:: as Query<
+  RelayMockPayloadGeneratorTest72Query$variables,
+  RelayMockPayloadGeneratorTest72Query$data,
+>*/);

--- a/packages/relay-test-utils/__tests__/__snapshots__/RelayMockPayloadGenerator-test.js.snap
+++ b/packages/relay-test-utils/__tests__/__snapshots__/RelayMockPayloadGenerator-test.js.snap
@@ -1697,6 +1697,84 @@ fragment RelayMockPayloadGeneratorTest13Fragment on Viewer {
 }
 `;
 
+exports[`plural linked field selected twice at the same path does not double-nest across concrete + abstract inline fragments (#5258) 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+query RelayMockPayloadGeneratorTest72Query {
+  me {
+    allPhones {
+      isVerified
+    }
+    ... on Actor {
+      __isActor: __typename
+      allPhones {
+        phoneNumber {
+          displayNumber
+        }
+      }
+    }
+    id
+  }
+}
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+{
+  "data": {
+    "me": {
+      "allPhones": [
+        {
+          "isVerified": "<mock-value-for-field-\\"isVerified\\">",
+          "phoneNumber": {
+            "displayNumber": "<mock-value-for-field-\\"displayNumber\\">"
+          }
+        }
+      ],
+      "__isActor": true,
+      "id": "<User-mock-id-1>"
+    }
+  }
+}
+`;
+
+exports[`plural linked field selected twice at the same path does not double-nest under an @include condition 1`] = `
+~~~~~~~~~~ INPUT ~~~~~~~~~~
+query RelayMockPayloadGeneratorTest71Query(
+  $showDetails: Boolean!
+) {
+  node(id: "my-id") {
+    __typename
+    ... on User {
+      allPhones {
+        isVerified
+      }
+      allPhones @include(if: $showDetails) {
+        phoneNumber {
+          displayNumber
+        }
+      }
+    }
+    id
+  }
+}
+
+~~~~~~~~~~ OUTPUT ~~~~~~~~~~
+{
+  "data": {
+    "node": {
+      "__typename": "User",
+      "allPhones": [
+        {
+          "isVerified": "<mock-value-for-field-\\"isVerified\\">",
+          "phoneNumber": {
+            "displayNumber": "<mock-value-for-field-\\"displayNumber\\">"
+          }
+        }
+      ],
+      "id": "<mock-id-1>"
+    }
+  }
+}
+`;
+
 exports[`should generate data for @match with PlainUserNameRenderer_name and use defaults from mock resolvers 1`] = `
 ~~~~~~~~~~ INPUT ~~~~~~~~~~
 query RelayMockPayloadGeneratorTest67Query {


### PR DESCRIPTION
## Summary

`MockPayloadGenerator` produced a double-nested list (`[[item]]` instead of
`[item]`) when the same plural linked field is selected twice at one path —
once unconditionally and once in a sibling `@include`/`@skip` condition or
abstract inline fragment. The normalizer then couldn't read the leaf fields
(`Payload did not contain a value for field ...`).

Cause: in `_mockLink`'s `generateDataForField`, the whole prior array was
passed as each element's previous value, so it got wrapped again. Fix: index
the prior array by `index` for plural fields (as `fieldPath` already is).

Fixes #5258.

## Test plan

Added regression tests for the `@include` and concrete+abstract-fragment shapes
(via `testGeneratedData`, so the normalizer runs under `disallowWarnings()`).

- `yarn jest` — 243 suites / 3739 tests pass (fail without the fix)
- `flow`, `prettier --check`, `eslint` — clean