### PR TITLE
RelayResponseNormalizer: don't write false __isInterface under deferDeduplicatedFields

### DIFF
--- a/packages/relay-runtime/store/RelayResponseNormalizer.js
+++ b/packages/relay-runtime/store/RelayResponseNormalizer.js
@@ -283,18 +283,24 @@ class RelayResponseNormalizer {
             data,
             abstractKey,
           );
-          const typeName = RelayModernRecord.getType(record);
-          const typeID = generateTypeID(typeName);
-          let typeRecord = this._recordSource.get(typeID);
-          if (typeRecord == null) {
-            typeRecord = RelayModernRecord.create(typeID, TYPE_SCHEMA_TYPE);
-            this._recordSource.set(typeID, typeRecord);
+          // Under `deferDeduplicatedFields` a missing abstract typename means
+          // the server omitted it as already-delivered, not that the concrete
+          // type fails the type refinement. Skip the write; DataChecker then
+          // treats the entry as unknown and refetches on the next check.
+          if (implementsInterface || !this._deferDeduplicatedFields) {
+            const typeName = RelayModernRecord.getType(record);
+            const typeID = generateTypeID(typeName);
+            let typeRecord = this._recordSource.get(typeID);
+            if (typeRecord == null) {
+              typeRecord = RelayModernRecord.create(typeID, TYPE_SCHEMA_TYPE);
+              this._recordSource.set(typeID, typeRecord);
+            }
+            RelayModernRecord.setValue(
+              typeRecord,
+              abstractKey,
+              implementsInterface,
+            );
           }
-          RelayModernRecord.setValue(
-            typeRecord,
-            abstractKey,
-            implementsInterface,
-          );
           break;
         }
         case 'LinkedHandle':
@@ -402,14 +408,21 @@ class RelayResponseNormalizer {
         data,
         abstractKey,
       );
-      const typeName = RelayModernRecord.getType(record);
-      const typeID = generateTypeID(typeName);
-      let typeRecord = this._recordSource.get(typeID);
-      if (typeRecord == null) {
-        typeRecord = RelayModernRecord.create(typeID, TYPE_SCHEMA_TYPE);
-        this._recordSource.set(typeID, typeRecord);
+      // See the `TypeDiscriminator` case above for the reasoning.
+      if (implementsInterface || !this._deferDeduplicatedFields) {
+        const typeName = RelayModernRecord.getType(record);
+        const typeID = generateTypeID(typeName);
+        let typeRecord = this._recordSource.get(typeID);
+        if (typeRecord == null) {
+          typeRecord = RelayModernRecord.create(typeID, TYPE_SCHEMA_TYPE);
+          this._recordSource.set(typeID, typeRecord);
+        }
+        RelayModernRecord.setValue(
+          typeRecord,
+          abstractKey,
+          implementsInterface,
+        );
       }
-      RelayModernRecord.setValue(typeRecord, abstractKey, implementsInterface);
       if (implementsInterface) {
         this._traverseSelections(selection, record, data);
       }

--- a/packages/relay-runtime/store/__tests__/RelayResponseNormalizer-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayResponseNormalizer-test.js
@@ -4390,4 +4390,139 @@ describe('RelayResponseNormalizer', () => {
       });
     });
   });
+
+  describe('deferDeduplicatedFields', () => {
+    it('does not write `__is<Interface>: false` when the abstract typename is missing from the payload', () => {
+      const query = graphql`
+        query RelayResponseNormalizerTest44Query($id: ID!) {
+          node(id: $id) {
+            ...RelayResponseNormalizerTest44Fragment
+          }
+        }
+      `;
+
+      graphql`
+        fragment RelayResponseNormalizerTest44Fragment on Node {
+          id
+          ... on User {
+            name
+          }
+        }
+      `;
+
+      // Payload omits `__isNode`: under deferDeduplicatedFields this signals
+      // that the server dedup'd an already-delivered field, not that the
+      // concrete type fails the type refinement.
+      const payload = {
+        node: {
+          __typename: 'User',
+          id: '1',
+          name: 'Alice',
+        },
+      };
+
+      const recordSource = new RelayRecordSource();
+      recordSource.set(ROOT_ID, RelayModernRecord.create(ROOT_ID, ROOT_TYPE));
+
+      normalize(
+        recordSource,
+        createNormalizationSelector(query.operation, ROOT_ID, {id: '1'}),
+        payload,
+        {...defaultOptions, deferDeduplicatedFields: true},
+      );
+
+      // No `client:__type:User` record — the write is skipped so
+      // DataChecker treats the entry as unknown and refetches on next
+      // check.
+      expect(recordSource.get('client:__type:User')).toBe(undefined);
+    });
+
+    it('still writes `__is<Interface>: true` when the abstract typename is present in the payload', () => {
+      const query = graphql`
+        query RelayResponseNormalizerTest45Query($id: ID!) {
+          node(id: $id) {
+            ...RelayResponseNormalizerTest45Fragment
+          }
+        }
+      `;
+
+      graphql`
+        fragment RelayResponseNormalizerTest45Fragment on Node {
+          id
+          ... on User {
+            name
+          }
+        }
+      `;
+
+      const payload = {
+        node: {
+          __typename: 'User',
+          __isNode: 'User',
+          id: '1',
+          name: 'Alice',
+        },
+      };
+
+      const recordSource = new RelayRecordSource();
+      recordSource.set(ROOT_ID, RelayModernRecord.create(ROOT_ID, ROOT_TYPE));
+
+      normalize(
+        recordSource,
+        createNormalizationSelector(query.operation, ROOT_ID, {id: '1'}),
+        payload,
+        {...defaultOptions, deferDeduplicatedFields: true},
+      );
+
+      expect(recordSource.get('client:__type:User')).toEqual({
+        __id: 'client:__type:User',
+        __typename: '__TypeSchema',
+        __isNode: true,
+      });
+    });
+
+    it('still writes `__is<Interface>: false` when deferDeduplicatedFields is off (default behaviour preserved)', () => {
+      const query = graphql`
+        query RelayResponseNormalizerTest46Query($id: ID!) {
+          node(id: $id) {
+            ...RelayResponseNormalizerTest46Fragment
+          }
+        }
+      `;
+
+      graphql`
+        fragment RelayResponseNormalizerTest46Fragment on Node {
+          id
+          ... on User {
+            name
+          }
+        }
+      `;
+
+      const payload = {
+        node: {
+          __typename: 'Page',
+          id: '1',
+        },
+      };
+
+      const recordSource = new RelayRecordSource();
+      recordSource.set(ROOT_ID, RelayModernRecord.create(ROOT_ID, ROOT_TYPE));
+
+      normalize(
+        recordSource,
+        createNormalizationSelector(query.operation, ROOT_ID, {id: '1'}),
+        payload,
+        defaultOptions,
+      );
+
+      // Without deferDeduplicatedFields the missing `__isNode` is still a
+      // real "type does not implement" signal — behaviour unchanged.
+      expect(recordSource.get('client:__type:Page')).toEqual({
+        __id: 'client:__type:Page',
+        __typename: '__TypeSchema',
+        __isNode: false,
+      });
+    });
+  });
 });


### PR DESCRIPTION
Fixes #5389.

## Summary

`RelayResponseNormalizer._normalizeTypeDiscriminator` and `._normalizeInlineFragment` write `client:__type:<ConcreteType>.__is<Interface>` unconditionally, using `Object.prototype.hasOwnProperty.call(data, abstractKey)` as the value. Under `Environment({ deferDeduplicatedFields: true })`, that misinterprets a legitimately-omitted abstract typename in an incremental `@defer` payload as "type does not implement" — it writes `false` into the type registry, `DataChecker` reads it and takes the "skip fragment" branch, and every subsequent `... on <Interface>` selection on that concrete type is silently dropped without a missing-data signal. Downstream `useLazyLoadQuery` / `usePreloadedQuery` report `available`, never fetch, and reads inside the fragment collapse to `null` under `$isWithinUnmatchedTypeRefinement`.

Full reproduction and evidence-based trace in #5389.

## Change

Only skip the type-registry write when `implementsInterface === false && this._deferDeduplicatedFields`. When the write is skipped, `DataChecker` treats the registry entry as unknown (`_implementsInterface == null`) → `_handleMissing()` → fetches on next check → response arrives with the tag → `true` is written normally.

Environments that don't opt into `deferDeduplicatedFields` are byte-identical to before: the missing tag is still an authoritative "type doesn't implement" signal there, and `false` is still written.

Both write sites (`TypeDiscriminator` in `_traverseSelections` and the `abstractKey != null` branch of `_normalizeInlineFragment`) get the same guard.

## Test plan

- Manual repro on our app (branded `@defer` + `deferDeduplicatedFields`) — the corrupted `__type:X.__is<Interface>: false` writes are gone, downstream queries fetch correctly. Confirmed by instrumenting `store.publish` and dumping the registry.
- Running the existing relay-runtime test suite locally against this branch — happy to add a targeted test if you'd like one for the `deferDeduplicatedFields + missing tag` interaction.

## Notes

Filed as a targeted, minimal patch — the wider question of whether writing `false` on a missing abstract typename is ever the *right* thing (even without `deferDeduplicatedFields`) can be answered separately. The narrower guard here keeps the blast radius as small as possible.