### PR TITLE
[relay-runtime] Add gcReleaseBufferTTL to age out the GC release buffer

### DIFF
--- a/packages/relay-runtime/store/RelayModernStore.js
+++ b/packages/relay-runtime/store/RelayModernStore.js
@@ -109,6 +109,8 @@ class RelayModernStore implements Store {
   _recordSource: MutableRecordSource;
   _resolverCache: LiveResolverCache;
   _releaseBuffer: Array<string>;
+  _releaseBufferTTL: number;
+  _releaseTimes: Map<string, number>;
   _roots: Map<
     string,
     {
@@ -137,6 +139,7 @@ class RelayModernStore implements Store {
       operationLoader?: ?OperationLoader,
       getDataID?: ?GetDataID,
       gcReleaseBufferSize?: ?number,
+      gcReleaseBufferTTL?: ?number,
       queryCacheExpirationTime?: ?number,
       shouldProcessClientComponents?: ?boolean,
       resolverContext?: ResolverContext,
@@ -179,6 +182,8 @@ class RelayModernStore implements Store {
     this._optimisticSource = null;
     this._recordSource = source;
     this._releaseBuffer = [];
+    this._releaseBufferTTL = options?.gcReleaseBufferTTL ?? 0;
+    this._releaseTimes = new Map();
     this._roots = new Map();
     this._shouldScheduleGC = false;
     this._resolverCache = new LiveResolverCache(
@@ -404,18 +409,8 @@ class RelayModernStore implements Store {
           this.scheduleGC();
         } else {
           this._releaseBuffer.push(id);
-
-          // If the release buffer is now over-full, remove the least-recently
-          // added entry and schedule a GC. Note that all items in the release
-          // buffer have a refCount of 0.
-          if (this._releaseBuffer.length > this._gcReleaseBufferSize) {
-            const _id = this._releaseBuffer.shift();
-            if (!this._shouldRetainWithinTTL_EXPERIMENTAL) {
-              // $FlowFixMe[incompatible-type]
-              this._roots.delete(_id);
-            }
-            this.scheduleGC();
-          }
+          this._releaseTimes.set(id, Date.now());
+          this._trimReleaseBuffer();
         }
       }
     };
@@ -427,6 +422,7 @@ class RelayModernStore implements Store {
         // there since it's retained. Remove it to maintain the invariant that
         // all release buffer entries have a refCount of 0.
         this._releaseBuffer = this._releaseBuffer.filter(_id => _id !== id);
+        this._releaseTimes.delete(id);
       }
       // If we've previously retained this operation, increment the refCount
       rootEntry.refCount += 1;
@@ -441,6 +437,52 @@ class RelayModernStore implements Store {
     }
 
     return {dispose};
+  }
+
+  /**
+   * Evict released roots from the release buffer, least-recently-released
+   * first. Entries in the buffer have a refCount of 0.
+   *
+   * The buffer exists to keep a query's data around between "this screen was
+   * released" and "the user came back to it". Sizing that window by *count*
+   * mis-serves React `<Activity>`: a hidden subtree's effects are destroyed, so
+   * its query is released while the subtree is still mounted and will read
+   * again on reveal. A handful of navigations then pushes it out of the buffer,
+   * GC collects records the mounted tree still points at, and the reveal reads
+   * missing data.
+   *
+   * `gcReleaseBufferTTL` sizes the same window by *age* instead: an entry stays
+   * while it is younger than the TTL no matter how many releases followed, and
+   * `gcReleaseBufferSize` remains the floor. Zero (the default) preserves the
+   * count-only behaviour.
+   *
+   * The buffer is ordered by release time, so the first entry still within the
+   * TTL ends the scan. Eviction is lazy — it happens on the next release rather
+   * than on a timer, so an idle store keeps whatever it last held.
+   */
+  _trimReleaseBuffer(): void {
+    const ttl = this._releaseBufferTTL;
+    const now = Date.now();
+    let evicted = false;
+    while (this._releaseBuffer.length > this._gcReleaseBufferSize) {
+      const oldest = this._releaseBuffer[0];
+      if (ttl > 0) {
+        const releasedAt = this._releaseTimes.get(oldest);
+        if (releasedAt != null && now - releasedAt < ttl) {
+          break;
+        }
+      }
+      this._releaseBuffer.shift();
+      this._releaseTimes.delete(oldest);
+      if (!this._shouldRetainWithinTTL_EXPERIMENTAL) {
+        // $FlowFixMe[incompatible-type]
+        this._roots.delete(oldest);
+      }
+      evicted = true;
+    }
+    if (evicted) {
+      this.scheduleGC();
+    }
   }
 
   lookup(selector: SingularReaderSelector): Snapshot {

--- a/packages/relay-runtime/store/__tests__/RelayModernStore-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernStore-test.js
@@ -2420,6 +2420,70 @@ function cloneEventWithSets(event: LogEvent) {
           });
         });
 
+        it('keeps an over-capacity entry that is younger than gcReleaseBufferTTL', () => {
+          const ttlSource = getRecordSourceImplementation(simpleClone(data));
+          const ttlStore = new RelayModernStore(ttlSource, {
+            gcReleaseBufferSize: 1,
+            gcReleaseBufferTTL: 60 * 1000,
+          });
+
+          ttlStore
+            .retain(createOperationDescriptor(UserQuery, {id: '4', size: 32}))
+            .dispose();
+          ttlStore
+            .retain(createOperationDescriptor(UserQuery, {id: '5', size: 32}))
+            .dispose();
+          jest.runAllTimers();
+
+          // The buffer is over its size floor, but both entries were released
+          // moments ago, so neither is evicted and no data is collected.
+          expect(ttlSource.toJSON()).toEqual(initialData);
+        });
+
+        it('collects an over-capacity entry once it is older than gcReleaseBufferTTL', () => {
+          let now = Date.now();
+          jest.spyOn(global.Date, 'now').mockImplementation(() => now);
+
+          const ttlSource = getRecordSourceImplementation(simpleClone(data));
+          const ttlStore = new RelayModernStore(ttlSource, {
+            gcReleaseBufferSize: 1,
+            gcReleaseBufferTTL: 60 * 1000,
+          });
+
+          ttlStore
+            .retain(createOperationDescriptor(UserQuery, {id: '4', size: 32}))
+            .dispose();
+
+          now += 60 * 1000 + 1;
+
+          // Releasing a second operation puts the buffer over its floor. The
+          // oldest entry is now past the TTL, so it is evicted and collected.
+          ttlStore
+            .retain(createOperationDescriptor(UserQuery, {id: '5', size: 32}))
+            .dispose();
+          jest.runAllTimers();
+
+          expect(ttlSource.toJSON()).toEqual({
+            '5': {
+              __id: '5',
+              __typename: 'User',
+              id: '5',
+              name: 'Other',
+              'profilePicture(size:32)': {[REF_KEY]: 'client:2'},
+            },
+            'client:2': {
+              __id: 'client:2',
+              uri: 'https://photo2.jpg',
+            },
+            'client:root': {
+              __id: 'client:root',
+              __typename: '__Root',
+              'node(id:\"4\")': {__ref: '4'},
+              'node(id:\"5\")': {__ref: '5'},
+            },
+          });
+        });
+
         it('does not free data if previously disposed query is retained again', () => {
           // Disposing and re-retaining an operation should cause that query to *not* count
           // toward the release buffer capacity.


### PR DESCRIPTION
## Problem

The GC release buffer keeps a query's data around between "this screen was released" and "the user came back to it". It is sized by **count** (`gcReleaseBufferSize`, default 10).

React `<Activity mode="hidden">` breaks that sizing. Hiding a subtree destroys its effects, so `useLazyLoadQueryNode`'s retain effect cleans up on hide exactly as it does on unmount — while the subtree stays mounted and *will read again on reveal*. The store is then left with no reachability root for a screen the user is one tap away from returning to, and a handful of navigations drains the buffer. GC collects records the mounted tree still points at, and the reveal reads missing data.

The count is the wrong axis here: what makes a hidden route likely to come back is **how recently it was used**, not how many other routes were released after it.

`shouldRetainWithinTTL_EXPERIMENTAL` + `queryCacheExpirationTime` do not cover this — that TTL is keyed on `fetchTime` and is not refreshed by retain or read, so a screen served from the store (`fetchTime == null`) is treated as immediately expired.

## Change

`gcReleaseBufferTTL` sizes the same window by **age**: an entry stays while it is younger than the TTL no matter how many releases followed, and `gcReleaseBufferSize` remains the floor.

- **Opt-in and backwards compatible.** Zero — the default — preserves today's count-only behaviour exactly.
- **Lazy eviction.** Trimming happens on the next release rather than on a timer, so an idle store keeps whatever it last held and no new timers are introduced.
- **Cheap scan.** The buffer is ordered by release time, so the first entry still within the TTL ends the loop.

## Measurement

Measured on a Next.js app (`cacheComponents: true`, so every route tree is wrapped in `<Activity>`), on a production build. The flow: home → 12 searches → back to home via the tab bar, roughly 45 seconds.

| | stock | `gcReleaseBufferTTL` set |
|---|---|---|
| home root retained at return | evicted | retained |
| release buffer at return | 10 (the floor) | 14 |
| fragment reads with missing data | 42 | **0** |
| GC runs | 1 | **0** |
| home render | did not complete in 30s | **~110ms, no network** |

Without the TTL the buffer sits exactly at its count limit with the home query already pushed out; with it, the buffer grows past the floor and the query survives.

## Testing

- `yarn jest` — 245 suites, 3757 passed, 0 failed.
- `yarn flow check` — no errors.
- `yarn prettier` — no changes.
- Two new tests in the existing `GC with a release buffer` describe: an over-capacity entry younger than the TTL is kept, and the same entry is collected once it is older than the TTL. The seven existing release-buffer tests are unchanged and still pass, which is what pins the default-off behaviour.

I have completed the CLA.
