### PR TITLE
Fix partial fragment reads from GC and harden missing-data owner refetch

### DIFF
--- a/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentMissingDataOwnerRefetchTestKeepAliveQuery.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentMissingDataOwnerRefetchTestKeepAliveQuery.graphql.js
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<9a129e363a4240cd6c038fb2501c160a>>
+ * @flow
+ * @lightSyntaxTransform
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+export type useFragmentMissingDataOwnerRefetchTestKeepAliveQuery$variables = {
+  id: string,
+};
+export type useFragmentMissingDataOwnerRefetchTestKeepAliveQuery$data = {
+  readonly node: ?{
+    readonly id: string,
+  },
+};
+export type useFragmentMissingDataOwnerRefetchTestKeepAliveQuery = {
+  response: useFragmentMissingDataOwnerRefetchTestKeepAliveQuery$data,
+  variables: useFragmentMissingDataOwnerRefetchTestKeepAliveQuery$variables,
+};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useFragmentMissingDataOwnerRefetchTestKeepAliveQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*:: as any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Operation",
+    "name": "useFragmentMissingDataOwnerRefetchTestKeepAliveQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*:: as any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "12a7f4fcd84cf1b3003b3f7392499515",
+    "id": null,
+    "metadata": {},
+    "name": "useFragmentMissingDataOwnerRefetchTestKeepAliveQuery",
+    "operationKind": "query",
+    "text": "query useFragmentMissingDataOwnerRefetchTestKeepAliveQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    id\n  }\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*:: as any*/).hash = "1a1f85e95c8c0ed8143b68b1ffb39df3";
+}
+
+module.exports = ((node/*:: as any*/)/*:: as Query<
+  useFragmentMissingDataOwnerRefetchTestKeepAliveQuery$variables,
+  useFragmentMissingDataOwnerRefetchTestKeepAliveQuery$data,
+>*/);

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentMissingDataOwnerRefetchTestOwnerQuery.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentMissingDataOwnerRefetchTestOwnerQuery.graphql.js
@@ -1,0 +1,153 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<f7247e1eb14e7d28fa7307343aef4785>>
+ * @flow
+ * @lightSyntaxTransform
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { useFragmentMissingDataOwnerRefetchTestUserFragment$fragmentType } from "./useFragmentMissingDataOwnerRefetchTestUserFragment.graphql";
+export type useFragmentMissingDataOwnerRefetchTestOwnerQuery$variables = {
+  id: string,
+};
+export type useFragmentMissingDataOwnerRefetchTestOwnerQuery$data = {
+  readonly node: ?{
+    readonly $fragmentSpreads: useFragmentMissingDataOwnerRefetchTestUserFragment$fragmentType,
+  },
+};
+export type useFragmentMissingDataOwnerRefetchTestOwnerQuery = {
+  response: useFragmentMissingDataOwnerRefetchTestOwnerQuery$data,
+  variables: useFragmentMissingDataOwnerRefetchTestOwnerQuery$variables,
+};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useFragmentMissingDataOwnerRefetchTestOwnerQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "useFragmentMissingDataOwnerRefetchTestUserFragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Operation",
+    "name": "useFragmentMissingDataOwnerRefetchTestOwnerQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Date",
+                "kind": "LinkedField",
+                "name": "birthdate",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "day",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "ab37d7e0988d76c27d43ebe128c344f4",
+    "id": null,
+    "metadata": {},
+    "name": "useFragmentMissingDataOwnerRefetchTestOwnerQuery",
+    "operationKind": "query",
+    "text": "query useFragmentMissingDataOwnerRefetchTestOwnerQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...useFragmentMissingDataOwnerRefetchTestUserFragment\n    id\n  }\n}\n\nfragment useFragmentMissingDataOwnerRefetchTestUserFragment on User {\n  birthdate {\n    day\n  }\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*:: as any*/).hash = "8338f0fba26c637a3afff95c70b07479";
+}
+
+module.exports = ((node/*:: as any*/)/*:: as Query<
+  useFragmentMissingDataOwnerRefetchTestOwnerQuery$variables,
+  useFragmentMissingDataOwnerRefetchTestOwnerQuery$data,
+>*/);

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentMissingDataOwnerRefetchTestUserFragment.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentMissingDataOwnerRefetchTestUserFragment.graphql.js
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<94259f8788980f0b57387b59a098cbc9>>
+ * @flow
+ * @lightSyntaxTransform
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type useFragmentMissingDataOwnerRefetchTestUserFragment$fragmentType: FragmentType;
+export type useFragmentMissingDataOwnerRefetchTestUserFragment$data = {
+  readonly birthdate: ?{
+    readonly day: ?number,
+  },
+  readonly $fragmentType: useFragmentMissingDataOwnerRefetchTestUserFragment$fragmentType,
+};
+export type useFragmentMissingDataOwnerRefetchTestUserFragment$key = {
+  readonly $data?: useFragmentMissingDataOwnerRefetchTestUserFragment$data,
+  readonly $fragmentSpreads: useFragmentMissingDataOwnerRefetchTestUserFragment$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "useFragmentMissingDataOwnerRefetchTestUserFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Date",
+      "kind": "LinkedField",
+      "name": "birthdate",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "day",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*:: as any*/).hash = "55efb5537c658de35c05222a4d876973";
+}
+
+module.exports = ((node/*:: as any*/)/*:: as Fragment<
+  useFragmentMissingDataOwnerRefetchTestUserFragment$fragmentType,
+  useFragmentMissingDataOwnerRefetchTestUserFragment$data,
+>*/);

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentMissingDataRecoveryAttemptTestKeepAliveQuery.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentMissingDataRecoveryAttemptTestKeepAliveQuery.graphql.js
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<6305b6658ec86909b41a1ede950a6cf7>>
+ * @flow
+ * @lightSyntaxTransform
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+export type useFragmentMissingDataRecoveryAttemptTestKeepAliveQuery$variables = {
+  id: string,
+};
+export type useFragmentMissingDataRecoveryAttemptTestKeepAliveQuery$data = {
+  readonly node: ?{
+    readonly id: string,
+  },
+};
+export type useFragmentMissingDataRecoveryAttemptTestKeepAliveQuery = {
+  response: useFragmentMissingDataRecoveryAttemptTestKeepAliveQuery$data,
+  variables: useFragmentMissingDataRecoveryAttemptTestKeepAliveQuery$variables,
+};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useFragmentMissingDataRecoveryAttemptTestKeepAliveQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*:: as any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Operation",
+    "name": "useFragmentMissingDataRecoveryAttemptTestKeepAliveQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*:: as any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "e0fe7523fdbc70e43f5b7aab8cae848d",
+    "id": null,
+    "metadata": {},
+    "name": "useFragmentMissingDataRecoveryAttemptTestKeepAliveQuery",
+    "operationKind": "query",
+    "text": "query useFragmentMissingDataRecoveryAttemptTestKeepAliveQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    id\n  }\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*:: as any*/).hash = "745c42765a8f7c710cde7c08e9544845";
+}
+
+module.exports = ((node/*:: as any*/)/*:: as Query<
+  useFragmentMissingDataRecoveryAttemptTestKeepAliveQuery$variables,
+  useFragmentMissingDataRecoveryAttemptTestKeepAliveQuery$data,
+>*/);

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentMissingDataRecoveryAttemptTestOwnerQuery.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentMissingDataRecoveryAttemptTestOwnerQuery.graphql.js
@@ -6,7 +6,7 @@
  *
  * @oncall relay
  *
- * @generated SignedSource<<df076dba5c2e820165a983523b0d3237>>
+ * @generated SignedSource<<ab6b9bf33672605ec27e386d384a6568>>
  * @flow
  * @lightSyntaxTransform
  */
@@ -17,18 +17,19 @@
 
 /*::
 import type { ConcreteRequest, Query } from 'relay-runtime';
-import type { useFragmentMissingDataOwnerRefetchTestUserFragment$fragmentType } from "./useFragmentMissingDataOwnerRefetchTestUserFragment.graphql";
-export type useFragmentMissingDataOwnerRefetchTestOwnerQuery$variables = {
+import type { useFragmentMissingDataRecoveryAttemptTestSiblingFragment$fragmentType } from "./useFragmentMissingDataRecoveryAttemptTestSiblingFragment.graphql";
+import type { useFragmentMissingDataRecoveryAttemptTestUserFragment$fragmentType } from "./useFragmentMissingDataRecoveryAttemptTestUserFragment.graphql";
+export type useFragmentMissingDataRecoveryAttemptTestOwnerQuery$variables = {
   id: string,
 };
-export type useFragmentMissingDataOwnerRefetchTestOwnerQuery$data = {
+export type useFragmentMissingDataRecoveryAttemptTestOwnerQuery$data = {
   readonly node: ?{
-    readonly $fragmentSpreads: useFragmentMissingDataOwnerRefetchTestUserFragment$fragmentType,
+    readonly $fragmentSpreads: useFragmentMissingDataRecoveryAttemptTestSiblingFragment$fragmentType & useFragmentMissingDataRecoveryAttemptTestUserFragment$fragmentType,
   },
 };
-export type useFragmentMissingDataOwnerRefetchTestOwnerQuery = {
-  response: useFragmentMissingDataOwnerRefetchTestOwnerQuery$data,
-  variables: useFragmentMissingDataOwnerRefetchTestOwnerQuery$variables,
+export type useFragmentMissingDataRecoveryAttemptTestOwnerQuery = {
+  response: useFragmentMissingDataRecoveryAttemptTestOwnerQuery$data,
+  variables: useFragmentMissingDataRecoveryAttemptTestOwnerQuery$variables,
 };
 */
 
@@ -52,7 +53,7 @@ return {
     "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "useFragmentMissingDataOwnerRefetchTestOwnerQuery",
+    "name": "useFragmentMissingDataRecoveryAttemptTestOwnerQuery",
     "selections": [
       {
         "alias": null,
@@ -65,7 +66,12 @@ return {
           {
             "args": null,
             "kind": "FragmentSpread",
-            "name": "useFragmentMissingDataOwnerRefetchTestUserFragment"
+            "name": "useFragmentMissingDataRecoveryAttemptTestUserFragment"
+          },
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "useFragmentMissingDataRecoveryAttemptTestSiblingFragment"
           }
         ],
         "storageKey": null
@@ -78,7 +84,7 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Operation",
-    "name": "useFragmentMissingDataOwnerRefetchTestOwnerQuery",
+    "name": "useFragmentMissingDataRecoveryAttemptTestOwnerQuery",
     "selections": [
       {
         "alias": null,
@@ -140,21 +146,21 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5941e2ee515c83c10833a11580193c26",
+    "cacheID": "c3ede778067fa11d72bd4b58785f9b29",
     "id": null,
     "metadata": {},
-    "name": "useFragmentMissingDataOwnerRefetchTestOwnerQuery",
+    "name": "useFragmentMissingDataRecoveryAttemptTestOwnerQuery",
     "operationKind": "query",
-    "text": "query useFragmentMissingDataOwnerRefetchTestOwnerQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...useFragmentMissingDataOwnerRefetchTestUserFragment\n    id\n  }\n}\n\nfragment useFragmentMissingDataOwnerRefetchTestUserFragment on User {\n  name\n  birthdate {\n    day\n  }\n}\n"
+    "text": "query useFragmentMissingDataRecoveryAttemptTestOwnerQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...useFragmentMissingDataRecoveryAttemptTestUserFragment\n    ...useFragmentMissingDataRecoveryAttemptTestSiblingFragment\n    id\n  }\n}\n\nfragment useFragmentMissingDataRecoveryAttemptTestSiblingFragment on User {\n  name\n}\n\nfragment useFragmentMissingDataRecoveryAttemptTestUserFragment on User {\n  name\n  birthdate {\n    day\n  }\n}\n"
   }
 };
 })();
 
 if (__DEV__) {
-  (node/*:: as any*/).hash = "8338f0fba26c637a3afff95c70b07479";
+  (node/*:: as any*/).hash = "e92843ce6c00f8297f6e6b1d88c75ba6";
 }
 
 module.exports = ((node/*:: as any*/)/*:: as Query<
-  useFragmentMissingDataOwnerRefetchTestOwnerQuery$variables,
-  useFragmentMissingDataOwnerRefetchTestOwnerQuery$data,
+  useFragmentMissingDataRecoveryAttemptTestOwnerQuery$variables,
+  useFragmentMissingDataRecoveryAttemptTestOwnerQuery$data,
 >*/);

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentMissingDataRecoveryAttemptTestPluralFragment.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentMissingDataRecoveryAttemptTestPluralFragment.graphql.js
@@ -6,7 +6,7 @@
  *
  * @oncall relay
  *
- * @generated SignedSource<<7abeac178e003fe0e9eeca03ef3ee51e>>
+ * @generated SignedSource<<2aae866be442f0949e6faeead2514dab>>
  * @flow
  * @lightSyntaxTransform
  */
@@ -18,26 +18,28 @@
 /*::
 import type { Fragment, ReaderFragment } from 'relay-runtime';
 import type { FragmentType } from "relay-runtime";
-declare export opaque type useFragmentMissingDataOwnerRefetchTestUserFragment$fragmentType: FragmentType;
-export type useFragmentMissingDataOwnerRefetchTestUserFragment$data = {
+declare export opaque type useFragmentMissingDataRecoveryAttemptTestPluralFragment$fragmentType: FragmentType;
+export type useFragmentMissingDataRecoveryAttemptTestPluralFragment$data = ReadonlyArray<{
   readonly birthdate: ?{
     readonly day: ?number,
   },
   readonly name: ?string,
-  readonly $fragmentType: useFragmentMissingDataOwnerRefetchTestUserFragment$fragmentType,
-};
-export type useFragmentMissingDataOwnerRefetchTestUserFragment$key = {
-  readonly $data?: useFragmentMissingDataOwnerRefetchTestUserFragment$data,
-  readonly $fragmentSpreads: useFragmentMissingDataOwnerRefetchTestUserFragment$fragmentType,
+  readonly $fragmentType: useFragmentMissingDataRecoveryAttemptTestPluralFragment$fragmentType,
+}>;
+export type useFragmentMissingDataRecoveryAttemptTestPluralFragment$key = ReadonlyArray<{
+  readonly $data?: useFragmentMissingDataRecoveryAttemptTestPluralFragment$data,
+  readonly $fragmentSpreads: useFragmentMissingDataRecoveryAttemptTestPluralFragment$fragmentType,
   ...
-};
+}>;
 */
 
 var node/*: ReaderFragment*/ = {
   "argumentDefinitions": [],
   "kind": "Fragment",
-  "metadata": null,
-  "name": "useFragmentMissingDataOwnerRefetchTestUserFragment",
+  "metadata": {
+    "plural": true
+  },
+  "name": "useFragmentMissingDataRecoveryAttemptTestPluralFragment",
   "selections": [
     {
       "alias": null,
@@ -70,10 +72,10 @@ var node/*: ReaderFragment*/ = {
 };
 
 if (__DEV__) {
-  (node/*:: as any*/).hash = "6fcbdb9733e7fc4c21d97717f3348f98";
+  (node/*:: as any*/).hash = "9e3f5fffb9cf171e9f52ef78a60a6f7d";
 }
 
 module.exports = ((node/*:: as any*/)/*:: as Fragment<
-  useFragmentMissingDataOwnerRefetchTestUserFragment$fragmentType,
-  useFragmentMissingDataOwnerRefetchTestUserFragment$data,
+  useFragmentMissingDataRecoveryAttemptTestPluralFragment$fragmentType,
+  useFragmentMissingDataRecoveryAttemptTestPluralFragment$data,
 >*/);

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentMissingDataRecoveryAttemptTestPluralQuery.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentMissingDataRecoveryAttemptTestPluralQuery.graphql.js
@@ -6,7 +6,7 @@
  *
  * @oncall relay
  *
- * @generated SignedSource<<df076dba5c2e820165a983523b0d3237>>
+ * @generated SignedSource<<43e97202f458ae5b45416ed04c23671d>>
  * @flow
  * @lightSyntaxTransform
  */
@@ -17,18 +17,18 @@
 
 /*::
 import type { ConcreteRequest, Query } from 'relay-runtime';
-import type { useFragmentMissingDataOwnerRefetchTestUserFragment$fragmentType } from "./useFragmentMissingDataOwnerRefetchTestUserFragment.graphql";
-export type useFragmentMissingDataOwnerRefetchTestOwnerQuery$variables = {
-  id: string,
+import type { useFragmentMissingDataRecoveryAttemptTestPluralFragment$fragmentType } from "./useFragmentMissingDataRecoveryAttemptTestPluralFragment.graphql";
+export type useFragmentMissingDataRecoveryAttemptTestPluralQuery$variables = {
+  ids?: ?ReadonlyArray<string>,
 };
-export type useFragmentMissingDataOwnerRefetchTestOwnerQuery$data = {
-  readonly node: ?{
-    readonly $fragmentSpreads: useFragmentMissingDataOwnerRefetchTestUserFragment$fragmentType,
-  },
+export type useFragmentMissingDataRecoveryAttemptTestPluralQuery$data = {
+  readonly nodes: ?ReadonlyArray<?{
+    readonly $fragmentSpreads: useFragmentMissingDataRecoveryAttemptTestPluralFragment$fragmentType,
+  }>,
 };
-export type useFragmentMissingDataOwnerRefetchTestOwnerQuery = {
-  response: useFragmentMissingDataOwnerRefetchTestOwnerQuery$data,
-  variables: useFragmentMissingDataOwnerRefetchTestOwnerQuery$variables,
+export type useFragmentMissingDataRecoveryAttemptTestPluralQuery = {
+  response: useFragmentMissingDataRecoveryAttemptTestPluralQuery$data,
+  variables: useFragmentMissingDataRecoveryAttemptTestPluralQuery$variables,
 };
 */
 
@@ -37,14 +37,14 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
-    "name": "id"
+    "name": "ids"
   }
 ],
 v1 = [
   {
     "kind": "Variable",
-    "name": "id",
-    "variableName": "id"
+    "name": "ids",
+    "variableName": "ids"
   }
 ];
 return {
@@ -52,20 +52,20 @@ return {
     "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "useFragmentMissingDataOwnerRefetchTestOwnerQuery",
+    "name": "useFragmentMissingDataRecoveryAttemptTestPluralQuery",
     "selections": [
       {
         "alias": null,
         "args": (v1/*:: as any*/),
         "concreteType": null,
         "kind": "LinkedField",
-        "name": "node",
-        "plural": false,
+        "name": "nodes",
+        "plural": true,
         "selections": [
           {
             "args": null,
             "kind": "FragmentSpread",
-            "name": "useFragmentMissingDataOwnerRefetchTestUserFragment"
+            "name": "useFragmentMissingDataRecoveryAttemptTestPluralFragment"
           }
         ],
         "storageKey": null
@@ -78,15 +78,15 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Operation",
-    "name": "useFragmentMissingDataOwnerRefetchTestOwnerQuery",
+    "name": "useFragmentMissingDataRecoveryAttemptTestPluralQuery",
     "selections": [
       {
         "alias": null,
         "args": (v1/*:: as any*/),
         "concreteType": null,
         "kind": "LinkedField",
-        "name": "node",
-        "plural": false,
+        "name": "nodes",
+        "plural": true,
         "selections": [
           {
             "alias": null,
@@ -140,21 +140,21 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5941e2ee515c83c10833a11580193c26",
+    "cacheID": "d39de45cc485952e266f0d36a5b344a3",
     "id": null,
     "metadata": {},
-    "name": "useFragmentMissingDataOwnerRefetchTestOwnerQuery",
+    "name": "useFragmentMissingDataRecoveryAttemptTestPluralQuery",
     "operationKind": "query",
-    "text": "query useFragmentMissingDataOwnerRefetchTestOwnerQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...useFragmentMissingDataOwnerRefetchTestUserFragment\n    id\n  }\n}\n\nfragment useFragmentMissingDataOwnerRefetchTestUserFragment on User {\n  name\n  birthdate {\n    day\n  }\n}\n"
+    "text": "query useFragmentMissingDataRecoveryAttemptTestPluralQuery(\n  $ids: [ID!]\n) {\n  nodes(ids: $ids) {\n    __typename\n    ...useFragmentMissingDataRecoveryAttemptTestPluralFragment\n    id\n  }\n}\n\nfragment useFragmentMissingDataRecoveryAttemptTestPluralFragment on User {\n  name\n  birthdate {\n    day\n  }\n}\n"
   }
 };
 })();
 
 if (__DEV__) {
-  (node/*:: as any*/).hash = "8338f0fba26c637a3afff95c70b07479";
+  (node/*:: as any*/).hash = "8f8f63b9fac3b8c44c432c61952f6940";
 }
 
 module.exports = ((node/*:: as any*/)/*:: as Query<
-  useFragmentMissingDataOwnerRefetchTestOwnerQuery$variables,
-  useFragmentMissingDataOwnerRefetchTestOwnerQuery$data,
+  useFragmentMissingDataRecoveryAttemptTestPluralQuery$variables,
+  useFragmentMissingDataRecoveryAttemptTestPluralQuery$data,
 >*/);

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentMissingDataRecoveryAttemptTestSiblingFragment.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentMissingDataRecoveryAttemptTestSiblingFragment.graphql.js
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<6f989d6ce2397dbd52157631e2574bf8>>
+ * @flow
+ * @lightSyntaxTransform
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type useFragmentMissingDataRecoveryAttemptTestSiblingFragment$fragmentType: FragmentType;
+export type useFragmentMissingDataRecoveryAttemptTestSiblingFragment$data = {
+  readonly name: ?string,
+  readonly $fragmentType: useFragmentMissingDataRecoveryAttemptTestSiblingFragment$fragmentType,
+};
+export type useFragmentMissingDataRecoveryAttemptTestSiblingFragment$key = {
+  readonly $data?: useFragmentMissingDataRecoveryAttemptTestSiblingFragment$data,
+  readonly $fragmentSpreads: useFragmentMissingDataRecoveryAttemptTestSiblingFragment$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "useFragmentMissingDataRecoveryAttemptTestSiblingFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*:: as any*/).hash = "ce708b8f37d405c45ce15a0ab81e8bd4";
+}
+
+module.exports = ((node/*:: as any*/)/*:: as Fragment<
+  useFragmentMissingDataRecoveryAttemptTestSiblingFragment$fragmentType,
+  useFragmentMissingDataRecoveryAttemptTestSiblingFragment$data,
+>*/);

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentMissingDataRecoveryAttemptTestUserFragment.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentMissingDataRecoveryAttemptTestUserFragment.graphql.js
@@ -6,7 +6,7 @@
  *
  * @oncall relay
  *
- * @generated SignedSource<<7abeac178e003fe0e9eeca03ef3ee51e>>
+ * @generated SignedSource<<8a0dccf87969d1c3bfbd922a7d6f73a7>>
  * @flow
  * @lightSyntaxTransform
  */
@@ -18,17 +18,17 @@
 /*::
 import type { Fragment, ReaderFragment } from 'relay-runtime';
 import type { FragmentType } from "relay-runtime";
-declare export opaque type useFragmentMissingDataOwnerRefetchTestUserFragment$fragmentType: FragmentType;
-export type useFragmentMissingDataOwnerRefetchTestUserFragment$data = {
+declare export opaque type useFragmentMissingDataRecoveryAttemptTestUserFragment$fragmentType: FragmentType;
+export type useFragmentMissingDataRecoveryAttemptTestUserFragment$data = {
   readonly birthdate: ?{
     readonly day: ?number,
   },
   readonly name: ?string,
-  readonly $fragmentType: useFragmentMissingDataOwnerRefetchTestUserFragment$fragmentType,
+  readonly $fragmentType: useFragmentMissingDataRecoveryAttemptTestUserFragment$fragmentType,
 };
-export type useFragmentMissingDataOwnerRefetchTestUserFragment$key = {
-  readonly $data?: useFragmentMissingDataOwnerRefetchTestUserFragment$data,
-  readonly $fragmentSpreads: useFragmentMissingDataOwnerRefetchTestUserFragment$fragmentType,
+export type useFragmentMissingDataRecoveryAttemptTestUserFragment$key = {
+  readonly $data?: useFragmentMissingDataRecoveryAttemptTestUserFragment$data,
+  readonly $fragmentSpreads: useFragmentMissingDataRecoveryAttemptTestUserFragment$fragmentType,
   ...
 };
 */
@@ -37,7 +37,7 @@ var node/*: ReaderFragment*/ = {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
-  "name": "useFragmentMissingDataOwnerRefetchTestUserFragment",
+  "name": "useFragmentMissingDataRecoveryAttemptTestUserFragment",
   "selections": [
     {
       "alias": null,
@@ -70,10 +70,10 @@ var node/*: ReaderFragment*/ = {
 };
 
 if (__DEV__) {
-  (node/*:: as any*/).hash = "6fcbdb9733e7fc4c21d97717f3348f98";
+  (node/*:: as any*/).hash = "6c4ca10756efed97636694ac3eaeda87";
 }
 
 module.exports = ((node/*:: as any*/)/*:: as Fragment<
-  useFragmentMissingDataOwnerRefetchTestUserFragment$fragmentType,
-  useFragmentMissingDataOwnerRefetchTestUserFragment$data,
+  useFragmentMissingDataRecoveryAttemptTestUserFragment$fragmentType,
+  useFragmentMissingDataRecoveryAttemptTestUserFragment$data,
 >*/);

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentMissingDataRecoveryStaleReadTestQuery.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentMissingDataRecoveryStaleReadTestQuery.graphql.js
@@ -6,7 +6,7 @@
  *
  * @oncall relay
  *
- * @generated SignedSource<<df076dba5c2e820165a983523b0d3237>>
+ * @generated SignedSource<<3baf9f694bbbb9cdc35db109ae620cd4>>
  * @flow
  * @lightSyntaxTransform
  */
@@ -17,18 +17,18 @@
 
 /*::
 import type { ConcreteRequest, Query } from 'relay-runtime';
-import type { useFragmentMissingDataOwnerRefetchTestUserFragment$fragmentType } from "./useFragmentMissingDataOwnerRefetchTestUserFragment.graphql";
-export type useFragmentMissingDataOwnerRefetchTestOwnerQuery$variables = {
+import type { useFragmentMissingDataRecoveryStaleReadTestUserFragment$fragmentType } from "./useFragmentMissingDataRecoveryStaleReadTestUserFragment.graphql";
+export type useFragmentMissingDataRecoveryStaleReadTestQuery$variables = {
   id: string,
 };
-export type useFragmentMissingDataOwnerRefetchTestOwnerQuery$data = {
+export type useFragmentMissingDataRecoveryStaleReadTestQuery$data = {
   readonly node: ?{
-    readonly $fragmentSpreads: useFragmentMissingDataOwnerRefetchTestUserFragment$fragmentType,
+    readonly $fragmentSpreads: useFragmentMissingDataRecoveryStaleReadTestUserFragment$fragmentType,
   },
 };
-export type useFragmentMissingDataOwnerRefetchTestOwnerQuery = {
-  response: useFragmentMissingDataOwnerRefetchTestOwnerQuery$data,
-  variables: useFragmentMissingDataOwnerRefetchTestOwnerQuery$variables,
+export type useFragmentMissingDataRecoveryStaleReadTestQuery = {
+  response: useFragmentMissingDataRecoveryStaleReadTestQuery$data,
+  variables: useFragmentMissingDataRecoveryStaleReadTestQuery$variables,
 };
 */
 
@@ -46,13 +46,27 @@ v1 = [
     "name": "id",
     "variableName": "id"
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "useFragmentMissingDataOwnerRefetchTestOwnerQuery",
+    "name": "useFragmentMissingDataRecoveryStaleReadTestQuery",
     "selections": [
       {
         "alias": null,
@@ -65,7 +79,7 @@ return {
           {
             "args": null,
             "kind": "FragmentSpread",
-            "name": "useFragmentMissingDataOwnerRefetchTestUserFragment"
+            "name": "useFragmentMissingDataRecoveryStaleReadTestUserFragment"
           }
         ],
         "storageKey": null
@@ -78,7 +92,7 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*:: as any*/),
     "kind": "Operation",
-    "name": "useFragmentMissingDataOwnerRefetchTestOwnerQuery",
+    "name": "useFragmentMissingDataRecoveryStaleReadTestQuery",
     "selections": [
       {
         "alias": null,
@@ -98,28 +112,17 @@ return {
           {
             "kind": "InlineFragment",
             "selections": [
+              (v2/*:: as any*/),
               {
                 "alias": null,
                 "args": null,
-                "kind": "ScalarField",
-                "name": "name",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "Date",
+                "concreteType": "User",
                 "kind": "LinkedField",
-                "name": "birthdate",
+                "name": "author",
                 "plural": false,
                 "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "day",
-                    "storageKey": null
-                  }
+                  (v3/*:: as any*/),
+                  (v2/*:: as any*/)
                 ],
                 "storageKey": null
               }
@@ -127,34 +130,28 @@ return {
             "type": "User",
             "abstractKey": null
           },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "id",
-            "storageKey": null
-          }
+          (v3/*:: as any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "5941e2ee515c83c10833a11580193c26",
+    "cacheID": "0b2cc332c6f9f6ba423dedce441272ac",
     "id": null,
     "metadata": {},
-    "name": "useFragmentMissingDataOwnerRefetchTestOwnerQuery",
+    "name": "useFragmentMissingDataRecoveryStaleReadTestQuery",
     "operationKind": "query",
-    "text": "query useFragmentMissingDataOwnerRefetchTestOwnerQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...useFragmentMissingDataOwnerRefetchTestUserFragment\n    id\n  }\n}\n\nfragment useFragmentMissingDataOwnerRefetchTestUserFragment on User {\n  name\n  birthdate {\n    day\n  }\n}\n"
+    "text": "query useFragmentMissingDataRecoveryStaleReadTestQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...useFragmentMissingDataRecoveryStaleReadTestUserFragment\n    id\n  }\n}\n\nfragment useFragmentMissingDataRecoveryStaleReadTestUserFragment on User {\n  name\n  author {\n    id\n    name\n  }\n}\n"
   }
 };
 })();
 
 if (__DEV__) {
-  (node/*:: as any*/).hash = "8338f0fba26c637a3afff95c70b07479";
+  (node/*:: as any*/).hash = "b1f842e4898ff9941928392220c78424";
 }
 
 module.exports = ((node/*:: as any*/)/*:: as Query<
-  useFragmentMissingDataOwnerRefetchTestOwnerQuery$variables,
-  useFragmentMissingDataOwnerRefetchTestOwnerQuery$data,
+  useFragmentMissingDataRecoveryStaleReadTestQuery$variables,
+  useFragmentMissingDataRecoveryStaleReadTestQuery$data,
 >*/);

--- a/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentMissingDataRecoveryStaleReadTestUserFragment.graphql.js
+++ b/packages/react-relay/relay-hooks/__tests__/__generated__/useFragmentMissingDataRecoveryStaleReadTestUserFragment.graphql.js
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<71c38fc4d5df3a306c1d94fa42d4d655>>
+ * @flow
+ * @lightSyntaxTransform
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type useFragmentMissingDataRecoveryStaleReadTestUserFragment$fragmentType: FragmentType;
+export type useFragmentMissingDataRecoveryStaleReadTestUserFragment$data = {
+  readonly author: ?{
+    readonly id: string,
+    readonly name: ?string,
+  },
+  readonly name: ?string,
+  readonly $fragmentType: useFragmentMissingDataRecoveryStaleReadTestUserFragment$fragmentType,
+};
+export type useFragmentMissingDataRecoveryStaleReadTestUserFragment$key = {
+  readonly $data?: useFragmentMissingDataRecoveryStaleReadTestUserFragment$data,
+  readonly $fragmentSpreads: useFragmentMissingDataRecoveryStaleReadTestUserFragment$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "useFragmentMissingDataRecoveryStaleReadTestUserFragment",
+  "selections": [
+    (v0/*:: as any*/),
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "User",
+      "kind": "LinkedField",
+      "name": "author",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "id",
+          "storageKey": null
+        },
+        (v0/*:: as any*/)
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+})();
+
+if (__DEV__) {
+  (node/*:: as any*/).hash = "f04b73fa207c0d656ae6ea3e4391fc1b";
+}
+
+module.exports = ((node/*:: as any*/)/*:: as Fragment<
+  useFragmentMissingDataRecoveryStaleReadTestUserFragment$fragmentType,
+  useFragmentMissingDataRecoveryStaleReadTestUserFragment$data,
+>*/);

--- a/packages/react-relay/relay-hooks/__tests__/useFragment-missing-data-owner-refetch-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useFragment-missing-data-owner-refetch-test.js
@@ -42,6 +42,12 @@ let userRef;
 
 beforeEach(() => {
   RelayFeatureFlags.ENABLE_MISSING_DATA_OWNER_REFETCH = true;
+  // Recovery is what happens when prevention did not apply, so these cases
+  // need the collection to actually occur. ENABLE_SUBSCRIPTION_GC_ROOTS would
+  // keep a subscribed fragment's records alive and the recovery path would
+  // never be reached — see the both-flags case in
+  // useFragment-missing-data-recovery-attempt-test.js.
+  RelayFeatureFlags.ENABLE_SUBSCRIPTION_GC_ROOTS = false;
 
   // gcReleaseBufferSize 0 + a synchronous scheduler make GC deterministic in
   // one dispose; the default 10-slot release buffer gets there over a session.
@@ -52,8 +58,15 @@ beforeEach(() => {
     }),
   });
 
+  // `name` is read alongside the field that goes missing so that
+  // writeOverlappingParentRecord() changes this fragment's DATA. Without it a
+  // re-read yields an identical partial snapshot, recycleNodesInto returns the
+  // same object, the subscription never fires, and the component never
+  // re-renders — which would make the assertions that follow such a write
+  // vacuous rather than failing.
   gqlFragment = graphql`
     fragment useFragmentMissingDataOwnerRefetchTestUserFragment on User {
+      name
       birthdate {
         day
       }
@@ -85,6 +98,7 @@ beforeEach(() => {
     node: {
       __typename: 'User',
       id: '1',
+      name: 'Alice',
       birthdate: {day: 15, month: 7, year: 1991},
     },
   });
@@ -99,6 +113,10 @@ beforeEach(() => {
 
 afterEach(() => {
   RelayFeatureFlags.ENABLE_MISSING_DATA_OWNER_REFETCH = false;
+  // RTL auto-cleanup is disabled globally (scripts/jest/environment.js), so
+  // trees rendered here stay mounted and subscribed to a superseded
+  // environment unless each test unmounts them.
+  ReactTestingLibrary.cleanup();
 });
 
 component UserBirthday(userRef: unknown) {
@@ -162,6 +180,7 @@ async function resolveOwnerRefetch(operation: $FlowFixMe) {
         node: {
           __typename: 'User',
           id: '1',
+          name: 'Alice',
           birthdate: {day: 15, month: 7, year: 1991},
         },
       },
@@ -233,7 +252,7 @@ test('recovers a remounted fragment whose ref outlived the owner (fresh mount, m
   expect(remounted.container.textContent).toBe('15');
 });
 
-test('refetches only once: a transport error does not start a request loop', async () => {
+test('does not retry immediately: a transport error does not start a request loop', async () => {
   const renderer = ReactTestingLibrary.render(
     <TestHarness userRef={userRef} />,
   );
@@ -250,16 +269,17 @@ test('refetches only once: a transport error does not start a request loop', asy
     jest.runAllImmediates();
   });
 
-  // The read is still missing, but the once-per-owner marker holds: no new
+  // The read is still missing, but the attempt's cooldown holds: no new
   // pending operation appears (getAllOperations lists pending ones; the
   // rejected refetch is gone), and the fragment falls through to today's
-  // partial render.
+  // partial render. That the owner is re-armed once the cooldown elapses is
+  // covered in useFragment-missing-data-recovery-attempt-test.js.
   writeOverlappingParentRecord();
   expect(environment.mock.getAllOperations().length).toBe(0);
   expect(renderer.container.textContent).toBe('partial');
 });
 
-test('the marker clears once data reads back complete: a second GC episode recovers again', async () => {
+test('the attempt is released once data reads back complete: a second GC episode recovers again', async () => {
   const renderer = ReactTestingLibrary.render(
     <TestHarness userRef={userRef} />,
   );
@@ -278,7 +298,7 @@ test('the marker clears once data reads back complete: a second GC episode recov
     undefined,
   );
 
-  // The data-complete render after episode one cleared the marker, so this
+  // The data-complete render after episode one released the attempt, so this
   // episode recovers with one more request instead of staying broken.
   writeOverlappingParentRecord();
   expect(renderer.container.textContent).toBe('Fallback');
@@ -288,8 +308,8 @@ test('the marker clears once data reads back complete: a second GC episode recov
   expect(renderer.container.textContent).toBe('15');
 });
 
-test("a store-wide invalidation ('stale') clears the marker instead of permanently disarming recovery", async () => {
-  // Episode one fails at transport, so the marker is retained with the data
+test("a store-wide invalidation ('stale') releases the attempt instead of permanently disarming recovery", async () => {
+  // Episode one fails at transport, so the attempt is retained with the data
   // still missing.
   const renderer = ReactTestingLibrary.render(
     <TestHarness userRef={userRef} />,
@@ -307,7 +327,7 @@ test("a store-wide invalidation ('stale') clears the marker instead of permanent
 
   // The data heals through an unrelated write, and the whole store is then
   // invalidated (e.g. an auth boundary): the complete read now checks as
-  // 'stale', not 'available'. That must still clear the marker.
+  // 'stale', not 'available'. That must still release the attempt.
   await act(async () => {
     environment.commitPayload(ownerOperation, {
       node: {
@@ -325,7 +345,7 @@ test("a store-wide invalidation ('stale') clears the marker instead of permanent
 
   // Episode two: expire any temporary retain left by episode one's failed
   // refetch, then a retain/release cycle lets GC collect the healed birthdate
-  // again. Recovery must re-arm — a permanently retained marker would render
+  // again. Recovery must re-arm — a permanently retained attempt would render
   // 'partial' here.
   await act(async () => {
     jest.runAllTimers();

--- a/packages/react-relay/relay-hooks/__tests__/useFragment-missing-data-owner-refetch-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useFragment-missing-data-owner-refetch-test.js
@@ -1,0 +1,387 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall relay
+ * @jest-environment jsdom
+ */
+
+'use strict';
+
+const useFragment = require('../useFragment');
+const ReactTestingLibrary = require('@testing-library/react');
+const React = require('react');
+const {RelayEnvironmentProvider} = require('react-relay');
+const {
+  FRAGMENT_OWNER_KEY,
+  RecordSource,
+  Store,
+  createOperationDescriptor,
+  graphql,
+} = require('relay-runtime');
+const RelayFeatureFlags = require('relay-runtime/util/RelayFeatureFlags');
+const {createMockEnvironment} = require('relay-test-utils');
+
+const {act} = ReactTestingLibrary;
+// $FlowFixMe[missing-export] Not yet exists in the Flow types in OSS
+const Activity: $FlowFixMe = React.unstable_Activity;
+const Suspense = React.Suspense;
+
+let environment;
+let gqlFragment;
+let gqlOwnerQuery;
+let gqlKeepAliveQuery;
+let ownerOperation;
+let keepAliveOperation;
+let ownerRetention;
+let userRef;
+
+beforeEach(() => {
+  RelayFeatureFlags.ENABLE_MISSING_DATA_OWNER_REFETCH = true;
+
+  // gcReleaseBufferSize 0 + a synchronous scheduler make GC deterministic in
+  // one dispose; the default 10-slot release buffer gets there over a session.
+  environment = createMockEnvironment({
+    store: new Store(new RecordSource(), {
+      gcReleaseBufferSize: 0,
+      gcScheduler: run => run(),
+    }),
+  });
+
+  gqlFragment = graphql`
+    fragment useFragmentMissingDataOwnerRefetchTestUserFragment on User {
+      birthdate {
+        day
+      }
+    }
+  `;
+  // The fragment's owner: what a route or list rendered from.
+  gqlOwnerQuery = graphql`
+    query useFragmentMissingDataOwnerRefetchTestOwnerQuery($id: ID!) {
+      node(id: $id) {
+        ...useFragmentMissingDataOwnerRefetchTestUserFragment
+          @dangerously_unaliased_fixme
+      }
+    }
+  `;
+  // A longer-lived query that overlaps the User record but NOT the birthdate
+  // record: its retain keeps the User alive across GC, so collecting the
+  // owner query leaves a dangling `user.birthdate` link.
+  gqlKeepAliveQuery = graphql`
+    query useFragmentMissingDataOwnerRefetchTestKeepAliveQuery($id: ID!) {
+      node(id: $id) {
+        id
+      }
+    }
+  `;
+
+  ownerOperation = createOperationDescriptor(gqlOwnerQuery, {id: '1'});
+  keepAliveOperation = createOperationDescriptor(gqlKeepAliveQuery, {id: '1'});
+  environment.commitPayload(ownerOperation, {
+    node: {
+      __typename: 'User',
+      id: '1',
+      birthdate: {day: 15, month: 7, year: 1991},
+    },
+  });
+  environment.commitPayload(keepAliveOperation, {
+    node: {__typename: 'User', id: '1'},
+  });
+  environment.retain(keepAliveOperation); // held for the session
+  ownerRetention = environment.retain(ownerOperation);
+  userRef = (environment.lookup(ownerOperation.fragment).data as $FlowFixMe)
+    .node;
+});
+
+afterEach(() => {
+  RelayFeatureFlags.ENABLE_MISSING_DATA_OWNER_REFETCH = false;
+});
+
+component UserBirthday(userRef: unknown) {
+  // $FlowFixMe[incompatible-call]
+  const data = useFragment(gqlFragment, userRef as $FlowFixMe);
+  return data?.birthdate?.day ?? 'partial';
+}
+
+component TestHarness(
+  mode: 'visible' | 'hidden' = 'visible',
+  userRef: unknown,
+) {
+  return (
+    <RelayEnvironmentProvider environment={environment}>
+      <Suspense fallback="Fallback">
+        <Activity mode={mode}>
+          <UserBirthday userRef={userRef} />
+        </Activity>
+      </Suspense>
+    </RelayEnvironmentProvider>
+  );
+}
+
+// Release the owner query and let GC run for real. Root reachability works as
+// designed: the keep-alive query keeps the User; the birthdate record,
+// reachable only through the owner query, is collected — `user.birthdate`
+// now dangles.
+function collectOwnerOnlyRecords() {
+  act(() => {
+    ownerRetention.dispose();
+  });
+  const source = environment.getStore().getSource();
+  expect(source.get('1')).not.toBe(undefined);
+  expect(source.get('client:1:birthdate')).toBe(undefined);
+}
+
+// GC bumps no epoch and notifies no subscriber; the dangling link surfaces at
+// the next store write that changes the parent record (any mutation or
+// revalidation touching the User).
+let writeCounter = 0;
+function writeOverlappingParentRecord() {
+  act(() => {
+    environment.commitUpdate(store => {
+      store.get('1')?.setValue(`Alice ${++writeCounter}`, 'name');
+    });
+  });
+}
+
+function expectSingleForcedOwnerRefetch() {
+  const operations = environment.mock.getAllOperations();
+  expect(operations.length).toBe(1);
+  expect(operations[0].request.node).toBe(gqlOwnerQuery);
+  expect(operations[0].request.cacheConfig?.force).toBe(true);
+  return operations[0];
+}
+
+async function resolveOwnerRefetch(operation: $FlowFixMe) {
+  await act(async () => {
+    environment.mock.resolve(operation, {
+      data: {
+        node: {
+          __typename: 'User',
+          id: '1',
+          birthdate: {day: 15, month: 7, year: 1991},
+        },
+      },
+    });
+    jest.runAllImmediates();
+  });
+}
+
+test('refetches the owner once and suspends when a subscribed fragment re-reads missing data after GC', async () => {
+  const renderer = ReactTestingLibrary.render(
+    <TestHarness userRef={userRef} />,
+  );
+  expect(renderer.container.textContent).toBe('15');
+
+  collectOwnerOnlyRecords();
+  writeOverlappingParentRecord();
+
+  // Instead of rendering the partial snapshot, the fragment issues one forced
+  // owner refetch and suspends on it.
+  expect(renderer.container.textContent).toBe('Fallback');
+  const refetch = expectSingleForcedOwnerRefetch();
+
+  await resolveOwnerRefetch(refetch);
+  expect(renderer.container.textContent).toBe('15');
+});
+
+test('recovers a fragment restored by <Activity> (hidden → GC → visible)', async () => {
+  const renderer = ReactTestingLibrary.render(
+    <TestHarness mode="visible" userRef={userRef} />,
+  );
+  expect(renderer.container.textContent).toBe('15');
+
+  // Hiding disposes the fragment's store subscription; the write while hidden
+  // is what the restored hook discovers as missed updates.
+  renderer.rerender(<TestHarness mode="hidden" userRef={userRef} />);
+  collectOwnerOnlyRecords();
+  writeOverlappingParentRecord();
+  renderer.rerender(<TestHarness mode="visible" userRef={userRef} />);
+  act(() => {
+    jest.runAllImmediates();
+  });
+
+  expect(renderer.container.textContent).toBe('Fallback');
+  const refetch = expectSingleForcedOwnerRefetch();
+
+  await resolveOwnerRefetch(refetch);
+  expect(renderer.container.textContent).toBe('15');
+});
+
+test('recovers a remounted fragment whose ref outlived the owner (fresh mount, missing data)', async () => {
+  const renderer = ReactTestingLibrary.render(
+    <TestHarness userRef={userRef} />,
+  );
+  expect(renderer.container.textContent).toBe('15');
+
+  renderer.unmount();
+  collectOwnerOnlyRecords();
+
+  // A new component mounts with the ref that survived in app state
+  // (virtualized list row, navigation back-stack…).
+  const remounted = ReactTestingLibrary.render(
+    <TestHarness userRef={userRef} />,
+  );
+
+  expect(remounted.container.textContent).toBe('Fallback');
+  const refetch = expectSingleForcedOwnerRefetch();
+
+  await resolveOwnerRefetch(refetch);
+  expect(remounted.container.textContent).toBe('15');
+});
+
+test('refetches only once: a transport error does not start a request loop', async () => {
+  const renderer = ReactTestingLibrary.render(
+    <TestHarness userRef={userRef} />,
+  );
+  collectOwnerOnlyRecords();
+  writeOverlappingParentRecord();
+  expect(renderer.container.textContent).toBe('Fallback');
+  expect(environment.mock.getAllOperations().length).toBe(1);
+
+  await act(async () => {
+    environment.mock.reject(
+      environment.mock.getAllOperations()[0],
+      new Error('network is down'),
+    );
+    jest.runAllImmediates();
+  });
+
+  // The read is still missing, but the once-per-owner marker holds: no new
+  // pending operation appears (getAllOperations lists pending ones; the
+  // rejected refetch is gone), and the fragment falls through to today's
+  // partial render.
+  writeOverlappingParentRecord();
+  expect(environment.mock.getAllOperations().length).toBe(0);
+  expect(renderer.container.textContent).toBe('partial');
+});
+
+test('the marker clears once data reads back complete: a second GC episode recovers again', async () => {
+  const renderer = ReactTestingLibrary.render(
+    <TestHarness userRef={userRef} />,
+  );
+  collectOwnerOnlyRecords();
+  writeOverlappingParentRecord();
+  await resolveOwnerRefetch(expectSingleForcedOwnerRefetch());
+  expect(renderer.container.textContent).toBe('15');
+
+  // The recovered data is held only by the refetch's temporary retain (the
+  // owner query's own retain lapsed before episode one). Let that TTL expire —
+  // GC legitimately collects the birthdate again.
+  await act(async () => {
+    jest.runAllTimers();
+  });
+  expect(environment.getStore().getSource().get('client:1:birthdate')).toBe(
+    undefined,
+  );
+
+  // The data-complete render after episode one cleared the marker, so this
+  // episode recovers with one more request instead of staying broken.
+  writeOverlappingParentRecord();
+  expect(renderer.container.textContent).toBe('Fallback');
+  const refetch = expectSingleForcedOwnerRefetch();
+
+  await resolveOwnerRefetch(refetch);
+  expect(renderer.container.textContent).toBe('15');
+});
+
+test("a store-wide invalidation ('stale') clears the marker instead of permanently disarming recovery", async () => {
+  // Episode one fails at transport, so the marker is retained with the data
+  // still missing.
+  const renderer = ReactTestingLibrary.render(
+    <TestHarness userRef={userRef} />,
+  );
+  collectOwnerOnlyRecords();
+  writeOverlappingParentRecord();
+  await act(async () => {
+    environment.mock.reject(
+      environment.mock.getAllOperations()[0],
+      new Error('network is down'),
+    );
+    jest.runAllImmediates();
+  });
+  expect(renderer.container.textContent).toBe('partial');
+
+  // The data heals through an unrelated write, and the whole store is then
+  // invalidated (e.g. an auth boundary): the complete read now checks as
+  // 'stale', not 'available'. That must still clear the marker.
+  await act(async () => {
+    environment.commitPayload(ownerOperation, {
+      node: {
+        __typename: 'User',
+        id: '1',
+        birthdate: {day: 15, month: 7, year: 1991},
+      },
+    });
+    environment.commitUpdate(store => {
+      store.invalidateStore();
+    });
+    jest.runAllImmediates();
+  });
+  expect(renderer.container.textContent).toBe('15');
+
+  // Episode two: expire any temporary retain left by episode one's failed
+  // refetch, then a retain/release cycle lets GC collect the healed birthdate
+  // again. Recovery must re-arm — a permanently retained marker would render
+  // 'partial' here.
+  await act(async () => {
+    jest.runAllTimers();
+  });
+  act(() => {
+    environment.retain(ownerOperation).dispose();
+  });
+  expect(environment.getStore().getSource().get('client:1:birthdate')).toBe(
+    undefined,
+  );
+  writeOverlappingParentRecord();
+
+  expect(renderer.container.textContent).toBe('Fallback');
+  const refetch = expectSingleForcedOwnerRefetch();
+
+  await resolveOwnerRefetch(refetch);
+  expect(renderer.container.textContent).toBe('15');
+});
+
+test('never re-executes a non-query owner', () => {
+  const ref = userRef as $FlowFixMe;
+  const mutationOwnedRef = {
+    ...ref,
+    [FRAGMENT_OWNER_KEY]: {
+      ...ref[FRAGMENT_OWNER_KEY],
+      node: {
+        ...ref[FRAGMENT_OWNER_KEY].node,
+        params: {
+          ...ref[FRAGMENT_OWNER_KEY].node.params,
+          operationKind: 'mutation',
+        },
+      },
+    },
+  };
+  collectOwnerOnlyRecords();
+
+  const renderer = ReactTestingLibrary.render(
+    <TestHarness userRef={mutationOwnedRef} />,
+  );
+
+  // No refetch is attempted for a mutation-owned fragment; the partial render
+  // is unchanged from today's behavior.
+  expect(environment.mock.getAllOperations().length).toBe(0);
+  expect(renderer.container.textContent).toBe('partial');
+});
+
+test('does not change behavior when the flag is off', () => {
+  RelayFeatureFlags.ENABLE_MISSING_DATA_OWNER_REFETCH = false;
+
+  const renderer = ReactTestingLibrary.render(
+    <TestHarness userRef={userRef} />,
+  );
+  collectOwnerOnlyRecords();
+  writeOverlappingParentRecord();
+
+  // Today's behavior: no request, partial snapshot rendered.
+  expect(environment.mock.getAllOperations().length).toBe(0);
+  expect(renderer.container.textContent).toBe('partial');
+});

--- a/packages/react-relay/relay-hooks/__tests__/useFragment-missing-data-recovery-attempt-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useFragment-missing-data-recovery-attempt-test.js
@@ -172,7 +172,7 @@ beforeEach(() => {
   // A plural owner over records the singular fixture does not touch, so
   // releasing one owner cannot disturb the other.
   pluralOperation = createOperationDescriptor(gqlPluralQuery, {
-    ids: ['8', '9'],
+    ids: ['8', '9', '10'],
   });
   environment.commitPayload(pluralOperation, {
     nodes: [
@@ -187,6 +187,12 @@ beforeEach(() => {
         id: '9',
         name: 'Nine',
         birthdate: {day: 9, month: 9, year: 1999},
+      },
+      {
+        __typename: 'User',
+        id: '10',
+        name: 'Ten',
+        birthdate: {day: 10, month: 10, year: 2000},
       },
     ],
   });
@@ -431,6 +437,79 @@ describe('the attempt is not released by an unrelated reader', () => {
     expect(pendingRecoveryOperations().length).toBe(0);
   });
 
+  it('releases when the plural row set changed between the missing read and the complete read', async () => {
+    // A reader's identity has to survive its own row set changing — a list that
+    // paginates while a recovery is in flight is the ordinary case. Keyed by the
+    // joined dataID list, the read that goes missing and the read that comes
+    // back complete produce DIFFERENT keys, so the completion deletes a key that
+    // was never added and the attempt is never released: the next genuinely new
+    // missing episode finds a live attempt and gets no recovery at all.
+    const renderer = ReactTestingLibrary.render(
+      <Harness>
+        <PluralBirthdays userRefs={[pluralRefs[0], pluralRefs[1]]} />
+      </Harness>,
+    );
+    expect(renderer.container.textContent).toBe('8/9');
+
+    act(() => {
+      const source = environment.getStore().getSource() as $FlowFixMe;
+      source.remove('client:9:birthdate');
+      environment.commitUpdate(store => {
+        store.get('9')?.setValue('Nine!', 'name');
+      });
+    });
+    expect(renderer.container.textContent).toBe('Fallback');
+    expect(environment.mock.getAllOperations().length).toBe(1);
+
+    await act(async () => {
+      environment.mock.resolve(environment.mock.getAllOperations()[0], {
+        data: {
+          nodes: [
+            {
+              __typename: 'User',
+              id: '8',
+              name: 'Eight',
+              birthdate: {day: 8, month: 8, year: 1988},
+            },
+            {
+              __typename: 'User',
+              id: '9',
+              name: 'Nine',
+              birthdate: {day: 9, month: 9, year: 1999},
+            },
+            {
+              __typename: 'User',
+              id: '10',
+              name: 'Ten',
+              birthdate: {day: 10, month: 10, year: 2000},
+            },
+          ],
+        },
+      });
+      // The list grows in the SAME commit as the response, so the suspended
+      // reader's retry render never sees its old row set complete — the only
+      // complete read it performs covers the new one.
+      renderer.rerender(
+        <Harness>
+          <PluralBirthdays userRefs={pluralRefs} />
+        </Harness>,
+      );
+      jest.runAllImmediates();
+    });
+    expect(renderer.container.textContent).toBe('8/9/10');
+
+    // Everything the missing read covered is complete now, so a brand-new
+    // episode must be able to recover rather than finding a stale attempt.
+    act(() => {
+      const source = environment.getStore().getSource() as $FlowFixMe;
+      source.remove('client:8:birthdate');
+      environment.commitUpdate(store => {
+        store.get('8')?.setValue('Eight!', 'name');
+      });
+    });
+    expect(environment.mock.getAllOperations().length).toBe(1);
+  });
+
   it('holds when a plural reader over a DIFFERENT row set reads complete', async () => {
     // Reader identity has to survive the plural branch too: keyed only by
     // fragment name, every plural reader under one owner collapses into one
@@ -438,7 +517,7 @@ describe('the attempt is not released by an unrelated reader', () => {
     const renderer = ReactTestingLibrary.render(
       <Harness>
         <PluralBirthdays userRefs={[pluralRefs[0]]} />
-        <PluralBirthdays userRefs={pluralRefs} />
+        <PluralBirthdays userRefs={[pluralRefs[0], pluralRefs[1]]} />
       </Harness>,
     );
     expect(renderer.container.textContent).toBe('88/9');

--- a/packages/react-relay/relay-hooks/__tests__/useFragment-missing-data-recovery-attempt-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useFragment-missing-data-recovery-attempt-test.js
@@ -1,0 +1,489 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall relay
+ * @jest-environment jsdom
+ */
+
+'use strict';
+
+const useFragment = require('../useFragment');
+const ReactTestingLibrary = require('@testing-library/react');
+const React = require('react');
+const {RelayEnvironmentProvider} = require('react-relay');
+const {
+  RecordSource,
+  Store,
+  createOperationDescriptor,
+  graphql,
+} = require('relay-runtime');
+const RelayFeatureFlags = require('relay-runtime/util/RelayFeatureFlags');
+const {createMockEnvironment} = require('relay-test-utils');
+
+const {act} = ReactTestingLibrary;
+const Suspense = React.Suspense;
+
+/**
+ * Two properties of the recovery attempt that guards
+ * ENABLE_MISSING_DATA_OWNER_REFETCH, both of which a naive marker gets wrong in
+ * opposite directions:
+ *
+ * - It must EXPIRE. A marker with no clock turns one transient failure (a
+ *   dropped connection) into a permanent opt-out: the owner can never recover
+ *   again for the life of the environment, because the only release path runs
+ *   from a complete read that will never happen.
+ *
+ * - It must not be released by a reader OTHER than the ones it was taken for.
+ *   One query owner is shared by every fragment spread under it, so a healthy
+ *   reader releasing the attempt lets a still-broken reader take a fresh one on
+ *   the very next round trip — an unbounded refetch loop at network speed,
+ *   which presents as a screen that never leaves its skeleton. `check(owner)`
+ *   cannot stand in for "no reader is missing": it walks the normalization AST
+ *   from the query root asking only whether records exist, while a reader walks
+ *   one fragment from the record its pointer captured.
+ *
+ * The readers here disagree with `check` by pointing a fragment at a record
+ * that is not reachable from the query root, which is what an escaped fragment
+ * ref does. No GC is needed for that: `check(owner)` stays 'available'
+ * throughout, while the reader reads missing.
+ */
+
+let environment;
+let gqlFragment;
+let gqlSiblingFragment;
+let gqlPluralFragment;
+let gqlPluralQuery;
+let gqlOwnerQuery;
+let gqlKeepAliveQuery;
+let ownerOperation;
+let pluralOperation;
+let pluralRefs;
+let keepAliveOperation;
+let ownerRetention;
+let userRef;
+let nowSpy;
+let currentTime;
+
+const COOLDOWN_MS = 30 * 1000;
+const MAX_ATTEMPTS = 3;
+/** A fragment ref aimed at a record the owner query never reaches. */
+const ORPHAN_ID = 'not-in-this-query';
+
+beforeEach(() => {
+  RelayFeatureFlags.ENABLE_MISSING_DATA_OWNER_REFETCH = true;
+  // Recovery is what happens when prevention did not apply, so these cases
+  // need the collection to actually occur. ENABLE_SUBSCRIPTION_GC_ROOTS would
+  // keep a subscribed fragment's records alive and the recovery path would
+  // never be reached — see the both-flags case in
+  // useFragment-missing-data-recovery-attempt-test.js.
+  RelayFeatureFlags.ENABLE_SUBSCRIPTION_GC_ROOTS = false;
+
+  // Date.now is advanced by hand so the cooldown can be crossed deliberately;
+  // starting from the real clock keeps every other Relay timestamp sane.
+  currentTime = Date.now();
+  nowSpy = jest.spyOn(global.Date, 'now').mockImplementation(() => currentTime);
+
+  environment = createMockEnvironment({
+    store: new Store(new RecordSource(), {
+      gcReleaseBufferSize: 0,
+      gcScheduler: run => run(),
+    }),
+  });
+
+  // `name` is read alongside the field that goes missing so that a write to the
+  // parent changes this fragment's DATA. Without it a re-read produces an
+  // identical partial snapshot, recycleNodesInto returns the same object, the
+  // subscription never fires, and the component never re-renders — which would
+  // silently make the assertions below vacuous rather than failing them.
+  gqlFragment = graphql`
+    fragment useFragmentMissingDataRecoveryAttemptTestUserFragment on User {
+      name
+      birthdate {
+        day
+      }
+    }
+  `;
+  // A second reader under the same owner whose data survives everything the
+  // first one loses — the "healthy sibling".
+  gqlSiblingFragment = graphql`
+    fragment useFragmentMissingDataRecoveryAttemptTestSiblingFragment on User {
+      name
+    }
+  `;
+  gqlPluralFragment = graphql`
+    fragment useFragmentMissingDataRecoveryAttemptTestPluralFragment on User
+    @relay(plural: true) {
+      name
+      birthdate {
+        day
+      }
+    }
+  `;
+  gqlPluralQuery = graphql`
+    query useFragmentMissingDataRecoveryAttemptTestPluralQuery($ids: [ID!]) {
+      nodes(ids: $ids) {
+        ...useFragmentMissingDataRecoveryAttemptTestPluralFragment
+          @dangerously_unaliased_fixme
+      }
+    }
+  `;
+  gqlOwnerQuery = graphql`
+    query useFragmentMissingDataRecoveryAttemptTestOwnerQuery($id: ID!) {
+      node(id: $id) {
+        ...useFragmentMissingDataRecoveryAttemptTestUserFragment
+          @dangerously_unaliased_fixme
+        ...useFragmentMissingDataRecoveryAttemptTestSiblingFragment
+          @dangerously_unaliased_fixme
+      }
+    }
+  `;
+  // Overlaps the owner on `User:1` without selecting `birthdate`, so releasing
+  // the owner leaves a dangling `user.birthdate` link rather than removing the
+  // user outright.
+  gqlKeepAliveQuery = graphql`
+    query useFragmentMissingDataRecoveryAttemptTestKeepAliveQuery($id: ID!) {
+      node(id: $id) {
+        id
+      }
+    }
+  `;
+
+  ownerOperation = createOperationDescriptor(gqlOwnerQuery, {id: '1'});
+  keepAliveOperation = createOperationDescriptor(gqlKeepAliveQuery, {id: '1'});
+  environment.commitPayload(ownerOperation, {
+    node: {
+      __typename: 'User',
+      id: '1',
+      name: 'Alice',
+      birthdate: {day: 15, month: 7, year: 1991},
+    },
+  });
+  environment.commitPayload(keepAliveOperation, {
+    node: {__typename: 'User', id: '1'},
+  });
+  environment.retain(keepAliveOperation);
+  ownerRetention = environment.retain(ownerOperation);
+
+  // A plural owner over records the singular fixture does not touch, so
+  // releasing one owner cannot disturb the other.
+  pluralOperation = createOperationDescriptor(gqlPluralQuery, {
+    ids: ['8', '9'],
+  });
+  environment.commitPayload(pluralOperation, {
+    nodes: [
+      {
+        __typename: 'User',
+        id: '8',
+        name: 'Eight',
+        birthdate: {day: 8, month: 8, year: 1988},
+      },
+      {
+        __typename: 'User',
+        id: '9',
+        name: 'Nine',
+        birthdate: {day: 9, month: 9, year: 1999},
+      },
+    ],
+  });
+  environment.retain(pluralOperation);
+  pluralRefs = (environment.lookup(pluralOperation.fragment).data as $FlowFixMe)
+    .nodes;
+  userRef = (environment.lookup(ownerOperation.fragment).data as $FlowFixMe)
+    .node;
+});
+
+afterEach(() => {
+  RelayFeatureFlags.ENABLE_MISSING_DATA_OWNER_REFETCH = false;
+  RelayFeatureFlags.ENABLE_SUBSCRIPTION_GC_ROOTS = false;
+  nowSpy.mockRestore();
+  ReactTestingLibrary.cleanup();
+});
+
+function advanceClock(ms: number) {
+  currentTime += ms;
+}
+
+/** Same fragment, aimed at a record the owner query does not reach. */
+function orphanRef(): $FlowFixMe {
+  return {...(userRef as $FlowFixMe), __id: ORPHAN_ID};
+}
+
+component Birthday(userRef: unknown) {
+  // $FlowFixMe[incompatible-call]
+  const data = useFragment(gqlFragment, userRef as $FlowFixMe);
+  return data?.birthdate?.day ?? 'partial';
+}
+
+component PluralBirthdays(userRefs: unknown) {
+  // $FlowFixMe[incompatible-call]
+  const data = useFragment(gqlPluralFragment, userRefs as $FlowFixMe);
+  return (data ?? []).map(each => each?.birthdate?.day ?? 'partial').join('/');
+}
+
+component Sibling(userRef: unknown) {
+  // $FlowFixMe[incompatible-call]
+  const data = useFragment(gqlSiblingFragment, userRef as $FlowFixMe);
+  return data?.name ?? 'partial';
+}
+
+component Harness(children: React.Node) {
+  return (
+    <RelayEnvironmentProvider environment={environment}>
+      <Suspense fallback="Fallback">{children}</Suspense>
+    </RelayEnvironmentProvider>
+  );
+}
+
+function collectOwnerOnlyRecords() {
+  act(() => {
+    ownerRetention.dispose();
+  });
+  expect(environment.getStore().getSource().get('1')).not.toBe(undefined);
+  expect(environment.getStore().getSource().get('client:1:birthdate')).toBe(
+    undefined,
+  );
+}
+
+// GC bumps no epoch and notifies no subscriber; the dangling link surfaces at
+// the next store write that touches the parent record.
+let writeCounter = 0;
+function writeOverlappingParentRecord() {
+  act(() => {
+    environment.commitUpdate(store => {
+      store.get('1')?.setValue(`Alice ${++writeCounter}`, 'name');
+    });
+  });
+}
+
+function pendingRecoveryOperations(): $FlowFixMe {
+  const operations = environment.mock.getAllOperations();
+  operations.forEach(operation => {
+    expect(operation.request.node).toBe(gqlOwnerQuery);
+    expect(operation.request.cacheConfig?.force).toBe(true);
+  });
+  return operations;
+}
+
+async function resolveRecovery(operation: $FlowFixMe) {
+  await act(async () => {
+    environment.mock.resolve(operation, {
+      data: {
+        node: {
+          __typename: 'User',
+          id: '1',
+          name: 'Alice',
+          birthdate: {day: 15, month: 7, year: 1991},
+        },
+      },
+    });
+    jest.runAllImmediates();
+  });
+}
+
+describe('the attempt expires', () => {
+  it('re-arms recovery for a new episode once the cooldown has elapsed', async () => {
+    const renderer = ReactTestingLibrary.render(
+      <Harness>
+        <Birthday userRef={userRef} />
+      </Harness>,
+    );
+    expect(renderer.container.textContent).toBe('15');
+
+    // Episode one fails at the transport, leaving the data missing.
+    collectOwnerOnlyRecords();
+    writeOverlappingParentRecord();
+    expect(pendingRecoveryOperations().length).toBe(1);
+    await act(async () => {
+      environment.mock.reject(
+        environment.mock.getAllOperations()[0],
+        new Error('network is down'),
+      );
+      jest.runAllImmediates();
+    });
+    expect(renderer.container.textContent).toBe('partial');
+
+    // Within the cooldown, further missing reads must NOT retry — that is the
+    // loop protection, and it is why the attempt is kept at all.
+    writeOverlappingParentRecord();
+    expect(pendingRecoveryOperations().length).toBe(0);
+    advanceClock(COOLDOWN_MS - 1);
+    writeOverlappingParentRecord();
+    expect(pendingRecoveryOperations().length).toBe(0);
+
+    // Past it, a genuinely new episode gets a fresh attempt. Without expiry
+    // this owner would stay disarmed for the life of the environment.
+    advanceClock(2);
+    writeOverlappingParentRecord();
+    const retry = pendingRecoveryOperations();
+    expect(retry.length).toBe(1);
+
+    await resolveRecovery(retry[0]);
+    expect(renderer.container.textContent).toBe('15');
+  });
+
+  it('spends a bounded number of requests on a read that can never be satisfied', async () => {
+    const renderer = ReactTestingLibrary.render(
+      <Harness>
+        <Birthday userRef={userRef} />
+      </Harness>,
+    );
+    collectOwnerOnlyRecords();
+
+    // Every recovery fails at the transport, so the read never heals and the
+    // attempt is never released. Expiry alone would make this a request every
+    // cooldown for the life of the app; the per-episode budget stops it.
+    let requests = 0;
+    for (let round = 0; round < 8; round++) {
+      writeOverlappingParentRecord();
+      const pending = pendingRecoveryOperations();
+      if (pending.length > 0) {
+        requests++;
+        await act(async () => {
+          environment.mock.reject(pending[0], new Error('network is down'));
+          jest.runAllImmediates();
+        });
+      }
+      // Past any backoff the budget could still be honouring.
+      advanceClock(COOLDOWN_MS * 8);
+    }
+
+    expect(requests).toBe(MAX_ATTEMPTS);
+    expect(renderer.container.textContent).toBe('partial');
+  });
+});
+
+describe('prevention and recovery', () => {
+  it('never reaches recovery for a subscribed reader when subscription GC roots are on', () => {
+    // The two flags address the same hazard at different points: GC roots stop
+    // the collection while a fragment is observing, and the recovery path
+    // repairs the cases roots cannot reach — a hidden <Activity> route, whose
+    // subscription is torn down, or a ref that outlived its owner. Pinning them
+    // together states that relationship instead of leaving it to be inferred
+    // from each flag's tests in isolation.
+    RelayFeatureFlags.ENABLE_SUBSCRIPTION_GC_ROOTS = true;
+
+    const renderer = ReactTestingLibrary.render(
+      <Harness>
+        <Birthday userRef={userRef} />
+      </Harness>,
+    );
+    expect(renderer.container.textContent).toBe('15');
+
+    act(() => {
+      ownerRetention.dispose();
+    });
+    expect(
+      environment.getStore().getSource().get('client:1:birthdate'),
+    ).not.toBe(undefined);
+
+    writeOverlappingParentRecord();
+    expect(pendingRecoveryOperations().length).toBe(0);
+    expect(renderer.container.textContent).toBe('15');
+  });
+});
+
+describe('the attempt is not released by an unrelated reader', () => {
+  it('holds when a DIFFERENT fragment under the same owner reads complete', async () => {
+    // The healthy reader renders first, so on every retry it takes the release
+    // branch before the broken one re-reads. That ordering is what turns a
+    // premature release into a loop rather than a one-off.
+    const renderer = ReactTestingLibrary.render(
+      <Harness>
+        <Sibling userRef={userRef} />
+        <Birthday userRef={orphanRef()} />
+      </Harness>,
+    );
+
+    // `check` disagrees with the reader: every record the query selects is
+    // present, so the owner is 'available' — while the orphan-pointed reader
+    // reads missing and takes an attempt.
+    expect(environment.check(ownerOperation).status).toBe('available');
+    expect(renderer.container.textContent).toBe('Fallback');
+    expect(pendingRecoveryOperations().length).toBe(1);
+
+    // The response cannot heal a reader pointed outside the query, so this
+    // round trip is the moment a premature release would re-arm.
+    await resolveRecovery(pendingRecoveryOperations()[0]);
+    expect(pendingRecoveryOperations().length).toBe(0);
+  });
+
+  it('holds when ANOTHER ROW of the same fragment reads complete', async () => {
+    // The same fragment rendered twice against different records — an ordinary
+    // list. A guard keyed by fragment NAME cannot tell these two apart, so the
+    // healthy row releases the broken row's attempt and the loop reopens.
+    const renderer = ReactTestingLibrary.render(
+      <Harness>
+        <Birthday userRef={userRef} />
+        <Birthday userRef={orphanRef()} />
+      </Harness>,
+    );
+
+    expect(environment.check(ownerOperation).status).toBe('available');
+    expect(renderer.container.textContent).toBe('Fallback');
+    expect(pendingRecoveryOperations().length).toBe(1);
+
+    await resolveRecovery(pendingRecoveryOperations()[0]);
+    expect(pendingRecoveryOperations().length).toBe(0);
+  });
+
+  it('holds when a plural reader over a DIFFERENT row set reads complete', async () => {
+    // Reader identity has to survive the plural branch too: keyed only by
+    // fragment name, every plural reader under one owner collapses into one
+    // identity and the healthy row set releases the holed one's attempt.
+    const renderer = ReactTestingLibrary.render(
+      <Harness>
+        <PluralBirthdays userRefs={[pluralRefs[0]]} />
+        <PluralBirthdays userRefs={pluralRefs} />
+      </Harness>,
+    );
+    expect(renderer.container.textContent).toBe('88/9');
+
+    // Remove the record the way GC does. `store.delete()` is not equivalent: it
+    // writes an explicit null, which the reader resolves as a value rather than
+    // as missing data. Store.getSource() is typed read-only, hence the cast.
+    act(() => {
+      const source = environment.getStore().getSource() as $FlowFixMe;
+      source.remove('client:9:birthdate');
+      // Force a re-read of the holed row. Removing a record notifies nobody,
+      // and a plural reader re-reads only the sub-snapshots whose records the
+      // write touched — so writing to a different row would leave this one
+      // reading its pre-removal snapshot.
+      environment.commitUpdate(store => {
+        store.get('9')?.setValue('Nine!', 'name');
+      });
+    });
+
+    expect(renderer.container.textContent).toBe('Fallback');
+    const pending = environment.mock.getAllOperations();
+    expect(pending.length).toBe(1);
+    expect(pending[0].request.node).toBe(gqlPluralQuery);
+
+    // The response leaves `User:9` untouched, so the holed reader is still
+    // missing when the healthy one takes the release branch. `User:8`'s name
+    // does change, which is what makes the healthy reader re-render and reach
+    // that branch at all.
+    await act(async () => {
+      environment.mock.resolve(pending[0], {
+        data: {
+          nodes: [
+            {
+              __typename: 'User',
+              id: '8',
+              name: 'Eight (refetched)',
+              birthdate: {day: 8, month: 8, year: 1988},
+            },
+            null,
+          ],
+        },
+      });
+      jest.runAllImmediates();
+    });
+
+    expect(environment.mock.getAllOperations().length).toBe(0);
+  });
+});

--- a/packages/react-relay/relay-hooks/__tests__/useFragment-missing-data-recovery-stale-read-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/useFragment-missing-data-recovery-stale-read-test.js
@@ -1,0 +1,238 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ * @oncall relay
+ * @jest-environment jsdom
+ */
+
+'use strict';
+
+const useFragment = require('../useFragment');
+const useLazyLoadQuery = require('../useLazyLoadQuery');
+const ReactTestingLibrary = require('@testing-library/react');
+const React = require('react');
+const {RelayEnvironmentProvider} = require('react-relay');
+const {Record, createOperationDescriptor, graphql} = require('relay-runtime');
+const RelayFeatureFlags = require('relay-runtime/util/RelayFeatureFlags');
+const {createMockEnvironment} = require('relay-test-utils');
+
+const {act} = ReactTestingLibrary;
+// $FlowFixMe[missing-export] Not yet exists in the Flow types in OSS
+const Activity: $FlowFixMe = React.unstable_Activity;
+const Suspense = React.Suspense;
+
+/**
+ * The recovery path added for ENABLE_MISSING_DATA_OWNER_REFETCH decides whether
+ * data is missing from `state` — a snapshot taken at an earlier store epoch.
+ * Nothing in the render path refreshes it: `getFragmentState` re-reads only
+ * when the selector or environment changed, and `handleMissedUpdates`, the only
+ * epoch-refreshing read, runs exclusively from effects. Because the recovery
+ * branch suspends by throwing during render, those effects never run for that
+ * render.
+ *
+ * So when a recovery refetch lands while the tree is suspended — which is what
+ * a hidden React <Activity> guarantees, since hiding tears the effects down —
+ * the restore render re-reads nothing. The records are back in the store and
+ * `environment.check(owner)` reports 'available', yet the reader still sees the
+ * pre-recovery snapshot, judges the data missing, finds the once-per-owner
+ * marker already spent, and hands its consumers the partial snapshot that
+ * recovery had just repaired — a field the schema declares non-nullable arrives
+ * as `undefined`, which is the crash this feature exists to prevent. A later
+ * commit does heal the reader, so asserting only the FINAL rendered output
+ * cannot see this: the assertions below are on the sequence of renders.
+ *
+ * This needs no GC: any partial record reachable from the fragment produces the
+ * same missing read. The store here is left complete and a mutation links in a
+ * record that carries only `id`, which is what an unmount updater writing a
+ * freshly created object does in a real app.
+ */
+
+/** Every value the fragment consumer rendered, in order. */
+let renderLog: Array<string>;
+let environment;
+let gqlFragment;
+let gqlQuery;
+let operation;
+
+const VARIABLES = {id: '1'};
+
+beforeEach(() => {
+  RelayFeatureFlags.ENABLE_MISSING_DATA_OWNER_REFETCH = true;
+  RelayFeatureFlags.ENABLE_ACTIVITY_COMPATIBILITY = true;
+  renderLog = [];
+
+  environment = createMockEnvironment();
+
+  gqlFragment = graphql`
+    fragment useFragmentMissingDataRecoveryStaleReadTestUserFragment on User {
+      name
+      author {
+        id
+        name
+      }
+    }
+  `;
+  gqlQuery = graphql`
+    query useFragmentMissingDataRecoveryStaleReadTestQuery($id: ID!) {
+      node(id: $id) {
+        ...useFragmentMissingDataRecoveryStaleReadTestUserFragment
+          @dangerously_unaliased_fixme
+      }
+    }
+  `;
+
+  operation = createOperationDescriptor(gqlQuery, VARIABLES);
+  // The store starts complete, so mounting serves from the store and issues no
+  // request — the "navigate back to a page you already loaded" read.
+  environment.commitPayload(operation, {
+    node: {
+      __typename: 'User',
+      id: '1',
+      name: 'Alice',
+      author: {__typename: 'User', id: '2', name: 'Bob'},
+    },
+  });
+});
+
+afterEach(() => {
+  RelayFeatureFlags.ENABLE_MISSING_DATA_OWNER_REFETCH = false;
+  ReactTestingLibrary.cleanup();
+});
+
+// `author.name` is non-nullable in the schema, so PARTIAL standing in for it is
+// a value product code would never see — real code dereferences it and throws.
+// Reading defensively keeps that observable as data instead of an incidental
+// TypeError, and every render is recorded so an intermediate partial cannot
+// hide behind a later healed one.
+const PARTIAL = 'partial';
+
+component Author(userRef: unknown) {
+  // $FlowFixMe[incompatible-call]
+  const data = useFragment(gqlFragment, userRef as $FlowFixMe);
+  const authorName = data?.author?.name ?? PARTIAL;
+  renderLog.push(authorName);
+  return authorName;
+}
+
+component Page() {
+  const data = useLazyLoadQuery(gqlQuery, VARIABLES) as $FlowFixMe;
+  return <Author userRef={data.node} />;
+}
+
+component Harness(hidden: boolean) {
+  return (
+    <RelayEnvironmentProvider environment={environment}>
+      <Suspense fallback="Fallback">
+        <Activity mode={hidden ? 'hidden' : 'visible'}>
+          <Page />
+        </Activity>
+      </Suspense>
+    </RelayEnvironmentProvider>
+  );
+}
+
+/**
+ * Link a record that carries only `id` into the relationship the fragment
+ * reads, so `author.name` reads missing. This is the shape an unmount updater
+ * leaves behind when it writes a just-created object it only has the id for.
+ */
+function linkPartialAuthorRecord() {
+  act(() => {
+    environment.commitUpdate(store => {
+      const partial = store.create('3', 'User');
+      partial.setValue('3', 'id');
+      const user = store.get('1');
+      if (user == null) {
+        throw new Error('expected User:1 in the store');
+      }
+      user.setLinkedRecord(partial, 'author');
+    });
+  });
+}
+
+function expectSingleRecoveryRefetch() {
+  const operations = environment.mock.getAllOperations();
+  expect(operations.length).toBe(1);
+  expect(operations[0].request.node).toBe(gqlQuery);
+  expect(operations[0].request.cacheConfig?.force).toBe(true);
+  return operations[0];
+}
+
+async function resolveRecovery(pendingOperation: $FlowFixMe) {
+  await act(async () => {
+    environment.mock.resolve(pendingOperation, {
+      data: {
+        node: {
+          __typename: 'User',
+          id: '1',
+          name: 'Alice',
+          author: {__typename: 'User', id: '3', name: 'Carol'},
+        },
+      },
+    });
+    jest.runAllImmediates();
+  });
+}
+
+test('recovers when the refetch resolves while the fragment is visible', async () => {
+  const renderer = ReactTestingLibrary.render(<Harness hidden={false} />);
+  expect(renderer.container.textContent).toBe('Bob');
+
+  linkPartialAuthorRecord();
+
+  // The partial read suspends on a forced refetch of the owner rather than
+  // rendering the partial snapshot.
+  expect(renderer.container.textContent).toBe('Fallback');
+  await resolveRecovery(expectSingleRecoveryRefetch());
+
+  expect(renderer.container.textContent).toBe('Carol');
+});
+
+test('recovers when the refetch resolves while the fragment is hidden inside <Activity>', async () => {
+  const renderer = ReactTestingLibrary.render(<Harness hidden={false} />);
+  expect(renderer.container.textContent).toBe('Bob');
+
+  linkPartialAuthorRecord();
+  expect(renderer.container.textContent).toBe('Fallback');
+  const refetch = expectSingleRecoveryRefetch();
+
+  // The user navigates away. The route is not unmounted — it is hidden, so
+  // only its effects are destroyed and the hook keeps its (now stale) state.
+  await act(async () => {
+    renderer.rerender(<Harness hidden={true} />);
+  });
+
+  // The recovery response lands while the tree is hidden. This is the whole
+  // reproduction: no effect can refresh the reader's snapshot in this window.
+  await resolveRecovery(refetch);
+
+  // The store is genuinely repaired before the restore read happens.
+  expect(environment.check(operation).status).toBe('available');
+  const restoredAuthor = environment.getStore().getSource().get('3');
+  expect(restoredAuthor).not.toBe(undefined);
+  expect(Record.getValue(restoredAuthor as $FlowFixMe, 'name')).toBe('Carol');
+
+  const rendersBeforeRestore = renderLog.length;
+  await act(async () => {
+    renderer.rerender(<Harness hidden={false} />);
+    jest.runAllImmediates();
+  });
+
+  // Restoring must re-read the current store. Without that re-read the reader
+  // judges the repaired data missing and emits one partial render before a
+  // later commit heals it — so assert on every render the restore produced,
+  // not just the last one.
+  const restoreRenders = renderLog.slice(rendersBeforeRestore);
+  // not.toContain passes trivially on an empty array, so pin that the restore
+  // actually rendered something before trusting it.
+  expect(restoreRenders.length).toBeGreaterThan(0);
+  expect(restoreRenders).not.toContain(PARTIAL);
+  expect(renderer.container.textContent).toBe('Carol');
+  // And it recovers by re-reading rather than by spending another refetch.
+  expect(environment.mock.getAllOperations().length).toBe(0);
+});

--- a/packages/react-relay/relay-hooks/useFragmentInternal_EXPERIMENTAL.js
+++ b/packages/react-relay/relay-hooks/useFragmentInternal_EXPERIMENTAL.js
@@ -129,8 +129,8 @@ function getMissingDataRefetches(
 }
 
 /**
- * Identity of one reader within its owner: the fragment, the record(s) it was
- * pointed at, and the @arguments it was spread with.
+ * Identity of what one reader read, as one key per constituent selector: the
+ * fragment, the record it was pointed at, and the @arguments it was spread with.
  *
  * The fragment NAME alone is not enough. A list renders the same fragment once
  * per row against different records, so one row reading missing while another
@@ -138,24 +138,28 @@ function getMissingDataRefetches(
  * broken row's attempt and re-arms it on the next round trip. Variables matter
  * for the same reason at a single record: two spreads of one fragment with
  * different @arguments read different fields and can disagree about missingness.
+ *
+ * Per selector rather than one key over the whole row set, because a plural
+ * reader's row set is not stable: a list that paginates while a recovery is in
+ * flight reads back complete over a different set than the one that went
+ * missing. A single combined key would then be deleted under a name that was
+ * never added, leaving the attempt permanently unreleasable — the next genuinely
+ * new missing episode would find a live attempt and get no recovery at all.
  */
-function getReaderKey(
+function getReaderKeys(
   fragmentName: string,
   fragmentSelector: ReaderSelector,
-): string {
+): Array<string> {
   const selectors =
     fragmentSelector.kind === 'PluralReaderSelector'
       ? fragmentSelector.selectors
       : [fragmentSelector];
-  return (
-    fragmentName +
-    '\u0000' +
-    selectors
-      .map(
-        selector =>
-          selector.dataID + JSON.stringify(stableCopy(selector.variables)),
-      )
-      .join(',')
+  return selectors.map(
+    selector =>
+      fragmentName +
+      '\u0000' +
+      selector.dataID +
+      JSON.stringify(stableCopy(selector.variables)),
   );
 }
 
@@ -166,7 +170,7 @@ function getReaderKey(
 function markMissingDataRefetch(
   environment: IEnvironment,
   identifier: string,
-  readerKey: string,
+  readerKeys: Array<string>,
 ): boolean {
   const refetches = getMissingDataRefetches(environment);
   const lastAttempt = refetches.get(identifier);
@@ -181,7 +185,9 @@ function markMissingDataRefetch(
       // Still broken for this reader. Record it even though we are not
       // refetching: otherwise the attempt forgets that this reader is broken
       // and a healthy sibling can release it (see the complete branch below).
-      lastAttempt.missingReaders.add(readerKey);
+      readerKeys.forEach(readerKey => {
+        lastAttempt.missingReaders.add(readerKey);
+      });
       return false;
     }
   }
@@ -203,7 +209,7 @@ function markMissingDataRefetch(
   refetches.set(identifier, {
     at: now,
     count: lastAttempt == null ? 1 : lastAttempt.count + 1,
-    missingReaders: new Set([readerKey]),
+    missingReaders: new Set(readerKeys),
   });
   return true;
 }
@@ -845,7 +851,7 @@ hook useFragmentInternal_EXPERIMENTAL(
           markMissingDataRefetch(
             environment,
             fragmentOwner.identifier,
-            getReaderKey(fragmentNode.name, fragmentSelector),
+            getReaderKeys(fragmentNode.name, fragmentSelector),
           )
         ) {
           const QueryResource = getQueryResourceForEnvironment(environment);
@@ -910,9 +916,9 @@ hook useFragmentInternal_EXPERIMENTAL(
       // present but 'stale', and consecutive episodes must each be able to
       // recover. Over-conservatism is survivable now that an attempt also
       // expires on its own after MISSING_DATA_REFETCH_COOLDOWN_MS.
-      attempt.missingReaders.delete(
-        getReaderKey(fragmentNode.name, fragmentSelector),
-      );
+      getReaderKeys(fragmentNode.name, fragmentSelector).forEach(readerKey => {
+        attempt.missingReaders.delete(readerKey);
+      });
       if (attempt.missingReaders.size === 0) {
         const ownerOperation = createOperationDescriptor(
           fragmentOwner.node,

--- a/packages/react-relay/relay-hooks/useFragmentInternal_EXPERIMENTAL.js
+++ b/packages/react-relay/relay-hooks/useFragmentInternal_EXPERIMENTAL.js
@@ -77,6 +77,47 @@ function isMissingData(state: FragmentState): boolean {
   }
 }
 
+// Owners already refetched (once) because a fragment read missing data with no
+// pending operation — see ENABLE_MISSING_DATA_OWNER_REFETCH below. Keeping a
+// marker after a failed recovery (partial response, transport error) is what
+// prevents refetch loops; the marker is cleared when the owner query reads
+// back without missing data.
+const WEAKMAP_SUPPORTED = typeof WeakMap === 'function';
+interface IMap<K, V> {
+  get(key: K): V | void;
+  set(key: K, value: V): IMap<K, V>;
+}
+const missingDataRefetchesByEnvironment: IMap<
+  IEnvironment,
+  Set<string>,
+> = WEAKMAP_SUPPORTED ? new WeakMap() : new Map();
+const MAX_MISSING_DATA_REFETCHES = 1000;
+let nextMissingDataRefetchID = 0;
+
+function markMissingDataRefetch(
+  environment: IEnvironment,
+  identifier: string,
+): boolean {
+  let refetches = missingDataRefetchesByEnvironment.get(environment);
+  if (refetches == null) {
+    refetches = new Set<string>();
+    missingDataRefetchesByEnvironment.set(environment, refetches);
+  }
+  if (refetches.has(identifier)) {
+    return false;
+  }
+  if (refetches.size >= MAX_MISSING_DATA_REFETCHES) {
+    // Bound memory; evicting the oldest marker only re-arms a single refetch
+    // for that owner.
+    const oldest = refetches.values().next().value;
+    if (oldest != null) {
+      refetches.delete(oldest);
+    }
+  }
+  refetches.add(identifier);
+  return true;
+}
+
 function getMissingClientEdges(
   state: FragmentState,
 ): ReadonlyArray<MissingClientEdgeRequestInfo> | null {
@@ -618,6 +659,121 @@ hook useFragmentInternal_EXPERIMENTAL(
           pendingOperations: pendingOperationsResult.pendingOperations,
         });
         throw pendingOperationsResult.promise;
+      }
+    }
+    // A fragment can read missing data with NO pending operation when its
+    // records were garbage-collected while unobserved: a React <Activity>
+    // route was hidden (its store subscription disposed), the owner query's
+    // retain lapsed, GC correctly collected records only that owner reached,
+    // and the fragment ref survived in React state. On restore — or on a
+    // fresh mount with a surviving ref (Activity may either preserve or
+    // remount the hook, so recovery cannot be limited to committed
+    // fragments) — the read is partial, and the component would render
+    // `undefined` for fields the fragment explicitly fetched, crashing
+    // consumers that trust the schema types.
+    //
+    // When enabled, recover by refetching the fragment's owner query once and
+    // suspending on the request instead of rendering the partial snapshot.
+    // `force: true` plus a unique QueryResource cache breaker ensure a real
+    // network request even when a completed QueryResource entry or a
+    // response-cache layer would otherwise short-circuit it. Only query
+    // owners are refetched — a mutation or subscription must never
+    // re-execute. The once-per-owner marker (per environment) prevents
+    // request loops when the refetch itself cannot fill the data; in that
+    // case execution falls through to today's partial-render behavior.
+    //
+    // Retention of the refetched payload: when the owner query is still
+    // mounted (the <Activity> route case) its own retain keeps the data
+    // durably; when only the fragment ref survived, the data is held by the
+    // prepare() call's temporary retain (a TEMPORARY_RETAIN_DURATION_MS TTL)
+    // and is GC-eligible again after it lapses. That is by design — the
+    // marker clears once the data reads back complete (see the else branch
+    // below), so a later GC episode simply recovers again with one more
+    // request rather than staying broken.
+    //
+    // For a plural fragment only selectors[0].owner is refetched, matching
+    // how the rest of this function attributes a plural read to its first
+    // owner.
+    if (
+      RelayFeatureFlags.ENABLE_MISSING_DATA_OWNER_REFETCH &&
+      fragmentSelector != null
+    ) {
+      const fragmentOwner =
+        fragmentSelector.kind === 'PluralReaderSelector'
+          ? fragmentSelector.selectors[0].owner
+          : fragmentSelector.owner;
+      if (fragmentOwner.node.params.operationKind === 'query') {
+        const refetchOperation = createOperationDescriptor(
+          fragmentOwner.node,
+          fragmentOwner.variables,
+          {...fragmentOwner.cacheConfig, force: true},
+        );
+        const activeRequestPromise = getPromiseForActiveRequest(
+          environment,
+          refetchOperation.request,
+        );
+        if (activeRequestPromise != null) {
+          throw activeRequestPromise;
+        }
+        // Marking + fetching during render is the same tradeoff QueryResource
+        // itself makes (it writes its cache during render): a discarded
+        // concurrent render leaves the marker set with its fetch already in
+        // flight, which at worst suppresses one later refetch until a
+        // data-complete render clears the marker.
+        if (markMissingDataRefetch(environment, fragmentOwner.identifier)) {
+          const QueryResource = getQueryResourceForEnvironment(environment);
+          const cacheBreaker = `missing-data-${nextMissingDataRefetchID++}`;
+          QueryResource.prepare(
+            refetchOperation,
+            fetchQueryInternal(environment, refetchOperation),
+            'network-only',
+            undefined,
+            undefined,
+            cacheBreaker,
+            undefined,
+          );
+          // Defensive parity with the activeRequestPromise check above: with
+          // an async network, prepare() already throws the pending promise
+          // itself, so this only fires if prepare() returned synchronously
+          // (e.g. a synchronous network resolved the payload).
+          const refetchPromise = getPromiseForActiveRequest(
+            environment,
+            refetchOperation.request,
+          );
+          if (refetchPromise != null) {
+            throw refetchPromise;
+          }
+        }
+      }
+    }
+  } else if (
+    RelayFeatureFlags.ENABLE_MISSING_DATA_OWNER_REFETCH &&
+    fragmentSelector != null
+  ) {
+    const fragmentOwner =
+      fragmentSelector.kind === 'PluralReaderSelector'
+        ? fragmentSelector.selectors[0].owner
+        : fragmentSelector.owner;
+    const refetches = missingDataRefetchesByEnvironment.get(environment);
+    if (
+      refetches != null &&
+      refetches.has(fragmentOwner.identifier) &&
+      fragmentOwner.node.params.operationKind === 'query'
+    ) {
+      // Clear the marker only once the whole owner query reads back without
+      // missing data: a sibling fragment of a partially-failed recovery must
+      // not re-arm the refetch (clearing while 'missing' would loop forever
+      // against a server that keeps returning partial data). 'stale' — data
+      // fully present but invalidated, e.g. invalidateStore() at an auth
+      // boundary — is loop-safe and must clear, or the owner would stay
+      // permanently exempt from recovery in later GC episodes.
+      const ownerOperation = createOperationDescriptor(
+        fragmentOwner.node,
+        fragmentOwner.variables,
+        fragmentOwner.cacheConfig,
+      );
+      if (environment.check(ownerOperation).status !== 'missing') {
+        refetches.delete(fragmentOwner.identifier);
       }
     }
   }

--- a/packages/react-relay/relay-hooks/useFragmentInternal_EXPERIMENTAL.js
+++ b/packages/react-relay/relay-hooks/useFragmentInternal_EXPERIMENTAL.js
@@ -39,6 +39,7 @@ const {
   getVariablesFromFragment,
   handlePotentialSnapshotErrors,
   recycleNodesInto,
+  stableCopy,
 } = require('relay-runtime');
 const warning = require('warning');
 
@@ -77,44 +78,133 @@ function isMissingData(state: FragmentState): boolean {
   }
 }
 
-// Owners already refetched (once) because a fragment read missing data with no
-// pending operation — see ENABLE_MISSING_DATA_OWNER_REFETCH below. Keeping a
-// marker after a failed recovery (partial response, transport error) is what
-// prevents refetch loops; the marker is cleared when the owner query reads
-// back without missing data.
+// Owners already refetched because a fragment read missing data with no pending
+// operation — see ENABLE_MISSING_DATA_OWNER_REFETCH below. An attempt records
+// WHEN it was made and WHICH readers were missing under it; both are needed to
+// keep recovery from turning into a request loop without also disarming it
+// forever.
 const WEAKMAP_SUPPORTED = typeof WeakMap === 'function';
 interface IMap<K, V> {
   get(key: K): V | void;
   set(key: K, value: V): IMap<K, V>;
 }
+type MissingDataRefetchAttempt = {
+  at: number,
+  // How many recovery requests this episode has already spent.
+  count: number,
+  // The readers that were missing under this attempt, keyed by reader identity
+  // (see getReaderKey). The attempt may only be released once every one of
+  // them has read back complete.
+  missingReaders: Set<string>,
+};
 const missingDataRefetchesByEnvironment: IMap<
   IEnvironment,
-  Set<string>,
+  Map<string, MissingDataRefetchAttempt>,
 > = WEAKMAP_SUPPORTED ? new WeakMap() : new Map();
 const MAX_MISSING_DATA_REFETCHES = 1000;
+// A failed recovery must not disable recovery for the rest of the session, and
+// it must not turn into a heartbeat either. An episode may spend
+// MAX_MISSING_DATA_REFETCH_ATTEMPTS requests, spaced by a doubling backoff from
+// this base, and then stops: a read the server can never satisfy costs a
+// bounded number of requests rather than one every cooldown forever, while a
+// recovery that failed once — a dropped connection — still gets another chance
+// instead of disarming the owner for the environment's lifetime.
+//
+// The budget is per EPISODE, not per session: releasing the attempt (every
+// reader that was missing has read back complete) drops the record entirely, so
+// a later episode on the same owner starts again from a full budget.
+const MISSING_DATA_REFETCH_COOLDOWN_MS = 30 * 1000;
+const MAX_MISSING_DATA_REFETCH_ATTEMPTS = 3;
 let nextMissingDataRefetchID = 0;
 
+function getMissingDataRefetches(
+  environment: IEnvironment,
+): Map<string, MissingDataRefetchAttempt> {
+  let refetches = missingDataRefetchesByEnvironment.get(environment);
+  if (refetches == null) {
+    refetches = new Map<string, MissingDataRefetchAttempt>();
+    missingDataRefetchesByEnvironment.set(environment, refetches);
+  }
+  return refetches;
+}
+
+/**
+ * Identity of one reader within its owner: the fragment, the record(s) it was
+ * pointed at, and the @arguments it was spread with.
+ *
+ * The fragment NAME alone is not enough. A list renders the same fragment once
+ * per row against different records, so one row reading missing while another
+ * reads fine is routine — and if both share a key, the healthy row cancels the
+ * broken row's attempt and re-arms it on the next round trip. Variables matter
+ * for the same reason at a single record: two spreads of one fragment with
+ * different @arguments read different fields and can disagree about missingness.
+ */
+function getReaderKey(
+  fragmentName: string,
+  fragmentSelector: ReaderSelector,
+): string {
+  const selectors =
+    fragmentSelector.kind === 'PluralReaderSelector'
+      ? fragmentSelector.selectors
+      : [fragmentSelector];
+  return (
+    fragmentName +
+    '\u0000' +
+    selectors
+      .map(
+        selector =>
+          selector.dataID + JSON.stringify(stableCopy(selector.variables)),
+      )
+      .join(',')
+  );
+}
+
+/**
+ * Record that `readerKey` read missing data under `identifier`'s owner, and
+ * report whether this read should issue a recovery refetch.
+ */
 function markMissingDataRefetch(
   environment: IEnvironment,
   identifier: string,
+  readerKey: string,
 ): boolean {
-  let refetches = missingDataRefetchesByEnvironment.get(environment);
-  if (refetches == null) {
-    refetches = new Set<string>();
-    missingDataRefetchesByEnvironment.set(environment, refetches);
+  const refetches = getMissingDataRefetches(environment);
+  const lastAttempt = refetches.get(identifier);
+  const now = Date.now();
+  if (lastAttempt != null) {
+    const backoff =
+      MISSING_DATA_REFETCH_COOLDOWN_MS * Math.pow(2, lastAttempt.count - 1);
+    if (
+      lastAttempt.count >= MAX_MISSING_DATA_REFETCH_ATTEMPTS ||
+      now - lastAttempt.at < backoff
+    ) {
+      // Still broken for this reader. Record it even though we are not
+      // refetching: otherwise the attempt forgets that this reader is broken
+      // and a healthy sibling can release it (see the complete branch below).
+      lastAttempt.missingReaders.add(readerKey);
+      return false;
+    }
   }
-  if (refetches.has(identifier)) {
-    return false;
-  }
-  if (refetches.size >= MAX_MISSING_DATA_REFETCHES) {
-    // Bound memory; evicting the oldest marker only re-arms a single refetch
+  if (
+    !refetches.has(identifier) &&
+    refetches.size >= MAX_MISSING_DATA_REFETCHES
+  ) {
+    // Bound memory; evicting the oldest attempt only re-arms a single refetch
     // for that owner.
-    const oldest = refetches.values().next().value;
+    const oldest = refetches.keys().next().value;
     if (oldest != null) {
       refetches.delete(oldest);
     }
   }
-  refetches.add(identifier);
+  // Replacing the record rather than mutating it is what keeps `missingReaders`
+  // from accumulating keys for readers that have since changed identity (a
+  // plural reader whose row set grew, a singular one re-pointed at another
+  // record): each attempt tracks only the readers that were missing under it.
+  refetches.set(identifier, {
+    at: now,
+    count: lastAttempt == null ? 1 : lastAttempt.count + 1,
+    missingReaders: new Set([readerKey]),
+  });
   return true;
 }
 
@@ -513,6 +603,36 @@ hook useFragmentInternal_EXPERIMENTAL(
     state = newState;
   }
 
+  if (
+    RelayFeatureFlags.ENABLE_MISSING_DATA_OWNER_REFETCH &&
+    isMissingData(state)
+  ) {
+    // `state` is a snapshot taken at an earlier store epoch, and the render
+    // path has no other way to refresh it: `getFragmentState` above re-reads
+    // only when the selector or environment changed, and `handleMissedUpdates`
+    // — the only epoch-refreshing read — is reachable only from effects. The
+    // recovery branch below suspends by throwing during render, so those
+    // effects never run for that render. A recovery refetch that lands while
+    // this tree is suspended (or hidden inside a React <Activity>) therefore
+    // restores the records without the reader ever seeing them: the retry
+    // render still reads `isMissingData`, the once-per-owner marker is already
+    // spent, and the fragment renders the partial snapshot that recovery had
+    // just repaired.
+    //
+    // Re-read against the current store before deciding. This converges:
+    // `handleMissedUpdates` returns null when the epoch has not advanced, and
+    // the state adopted here carries the current epoch, so the next render
+    // re-reads nothing. Adopting a state that is still missing is intentional
+    // — `handlePotentialSnapshotErrorsForState` below reports
+    // `snapshot.fieldErrors`, and those have to describe the read that
+    // actually failed rather than a stale one.
+    const recoveryReread = handleMissedUpdates(environment, state);
+    if (recoveryReread != null) {
+      setState(recoveryReread[1]);
+      state = recoveryReread[1];
+    }
+  }
+
   // The purpose of this is to detect whether we have ever committed, because we
   // don't suspend on store updates, only when the component either is first trying
   // to mount or when the our selector changes. The selector change in particular is
@@ -678,17 +798,18 @@ hook useFragmentInternal_EXPERIMENTAL(
     // network request even when a completed QueryResource entry or a
     // response-cache layer would otherwise short-circuit it. Only query
     // owners are refetched — a mutation or subscription must never
-    // re-execute. The once-per-owner marker (per environment) prevents
+    // re-execute. A per-owner attempt record (per environment) prevents
     // request loops when the refetch itself cannot fill the data; in that
-    // case execution falls through to today's partial-render behavior.
+    // case execution falls through to today's partial-render behavior until
+    // the attempt's cooldown elapses.
     //
     // Retention of the refetched payload: when the owner query is still
     // mounted (the <Activity> route case) its own retain keeps the data
     // durably; when only the fragment ref survived, the data is held by the
     // prepare() call's temporary retain (a TEMPORARY_RETAIN_DURATION_MS TTL)
     // and is GC-eligible again after it lapses. That is by design — the
-    // marker clears once the data reads back complete (see the else branch
-    // below), so a later GC episode simply recovers again with one more
+    // attempt is released once the data reads back complete (see the else
+    // branch below), so a later GC episode simply recovers again with one more
     // request rather than staying broken.
     //
     // For a plural fragment only selectors[0].owner is refetched, matching
@@ -717,10 +838,16 @@ hook useFragmentInternal_EXPERIMENTAL(
         }
         // Marking + fetching during render is the same tradeoff QueryResource
         // itself makes (it writes its cache during render): a discarded
-        // concurrent render leaves the marker set with its fetch already in
-        // flight, which at worst suppresses one later refetch until a
-        // data-complete render clears the marker.
-        if (markMissingDataRefetch(environment, fragmentOwner.identifier)) {
+        // concurrent render leaves the attempt recorded with its fetch already
+        // in flight, which at worst suppresses one later refetch until the
+        // cooldown elapses or a data-complete render releases the attempt.
+        if (
+          markMissingDataRefetch(
+            environment,
+            fragmentOwner.identifier,
+            getReaderKey(fragmentNode.name, fragmentSelector),
+          )
+        ) {
           const QueryResource = getQueryResourceForEnvironment(environment);
           const cacheBreaker = `missing-data-${nextMissingDataRefetchID++}`;
           QueryResource.prepare(
@@ -755,25 +882,46 @@ hook useFragmentInternal_EXPERIMENTAL(
         ? fragmentSelector.selectors[0].owner
         : fragmentSelector.owner;
     const refetches = missingDataRefetchesByEnvironment.get(environment);
+    const attempt = refetches?.get(fragmentOwner.identifier);
     if (
       refetches != null &&
-      refetches.has(fragmentOwner.identifier) &&
+      attempt != null &&
       fragmentOwner.node.params.operationKind === 'query'
     ) {
-      // Clear the marker only once the whole owner query reads back without
-      // missing data: a sibling fragment of a partially-failed recovery must
-      // not re-arm the refetch (clearing while 'missing' would loop forever
-      // against a server that keeps returning partial data). 'stale' — data
-      // fully present but invalidated, e.g. invalidateStore() at an auth
-      // boundary — is loop-safe and must clear, or the owner would stay
-      // permanently exempt from recovery in later GC episodes.
-      const ownerOperation = createOperationDescriptor(
-        fragmentOwner.node,
-        fragmentOwner.variables,
-        fragmentOwner.cacheConfig,
+      // This branch runs for a fragment whose OWN read is complete, and one
+      // query owner is shared by every fragment spread under it. Releasing the
+      // attempt on `check(owner)` alone therefore lets a healthy reader disarm
+      // a broken one: reader A reads missing and takes an attempt, the
+      // response lands, sibling B reads fine and releases it, A re-reads
+      // missing and takes a *fresh* attempt — an unbounded refetch loop at
+      // network speed.
+      //
+      // `environment.check()` is not a proxy for "no reader is missing". It
+      // walks the normalization AST from the query root and only asks whether
+      // records exist, while a reader walks one fragment's AST from the record
+      // its pointer captured and additionally applies @required, client
+      // resolvers, and missing_expected_data. A query can report 'available'
+      // while a fragment under it reads missing — and 'stale' can even be
+      // returned for an unretained owner whose data is genuinely absent. So
+      // the still-missing readers are tracked explicitly rather than inferred,
+      // and `check` is kept only as a secondary, conservative gate.
+      //
+      // Releasing at all still matters: a store-wide invalidation leaves data
+      // present but 'stale', and consecutive episodes must each be able to
+      // recover. Over-conservatism is survivable now that an attempt also
+      // expires on its own after MISSING_DATA_REFETCH_COOLDOWN_MS.
+      attempt.missingReaders.delete(
+        getReaderKey(fragmentNode.name, fragmentSelector),
       );
-      if (environment.check(ownerOperation).status !== 'missing') {
-        refetches.delete(fragmentOwner.identifier);
+      if (attempt.missingReaders.size === 0) {
+        const ownerOperation = createOperationDescriptor(
+          fragmentOwner.node,
+          fragmentOwner.variables,
+          fragmentOwner.cacheConfig,
+        );
+        if (environment.check(ownerOperation).status !== 'missing') {
+          refetches.delete(fragmentOwner.identifier);
+        }
       }
     }
   }

--- a/packages/relay-runtime/store/RelayModernStore.js
+++ b/packages/relay-runtime/store/RelayModernStore.js
@@ -651,7 +651,23 @@ class RelayModernStore implements Store {
     snapshot: Snapshot,
     callback: (snapshot: Snapshot) => void,
   ): Disposable {
-    return this._storeSubscriptions.subscribe(snapshot, callback);
+    const disposable = this._storeSubscriptions.subscribe(snapshot, callback);
+    if (!RelayFeatureFlags.ENABLE_SUBSCRIPTION_GC_ROOTS) {
+      return disposable;
+    }
+    // While subscriptions are GC roots, losing one can make records
+    // unreachable — and unlike releasing a retain, disposing a subscription
+    // reaches no path that would notice. This is not a rare corner: React tears
+    // an <Activity> route down in effect declaration order, so the query's
+    // retain is released (scheduling a GC) while the fragment below it is still
+    // subscribed, and that pass marks exactly the records the route was hiding
+    // to release. The pass scheduled here is the one that collects them.
+    return {
+      dispose: () => {
+        disposable.dispose();
+        this.scheduleGC();
+      },
+    };
   }
 
   holdGC(): Disposable {
@@ -905,6 +921,19 @@ class RelayModernStore implements Store {
           }
           continue top;
         }
+      }
+
+      if (RelayFeatureFlags.ENABLE_SUBSCRIPTION_GC_ROOTS) {
+        // Retained operations are not the only reachability roots. A mounted
+        // fragment observes the store through a subscription, and the records
+        // it reads may be selected by no retained operation at all — e.g. its
+        // owner query's retain lapsed while a React <Activity> route was
+        // hidden, and a different retained operation keeps the parent record
+        // alive without selecting the subtree the fragment reads. Collecting
+        // there would leave the fragment reading a record that is gone: a
+        // partial read, where a field the schema declares non-nullable comes
+        // back undefined.
+        this._storeSubscriptions.markReferences(references);
       }
 
       // NOTE: It may be tempting to use `this._recordSource.clear()`

--- a/packages/relay-runtime/store/RelayStoreSubscriptions.js
+++ b/packages/relay-runtime/store/RelayStoreSubscriptions.js
@@ -263,6 +263,23 @@ class RelayStoreSubscriptions implements StoreSubscriptions {
   size(): number {
     return this._subscriptions.size;
   }
+
+  /**
+   * Add every record read by an active subscription to `references`.
+   *
+   * `snapshot.seenRecords` is exactly the set of records backing a
+   * subscription's currently rendered data, so treating them as GC roots
+   * restores the invariant that anything actively observed survives
+   * collection. Records already absent from the source are harmless here: the
+   * collection pass only deletes IDs that are missing from `references`.
+   */
+  markReferences(references: DataIDSet): void {
+    this._subscriptions.forEach(subscription => {
+      subscription.snapshot.seenRecords.forEach(dataID => {
+        references.add(dataID);
+      });
+    });
+  }
 }
 
 module.exports = RelayStoreSubscriptions;

--- a/packages/relay-runtime/store/RelayStoreTypes.js
+++ b/packages/relay-runtime/store/RelayStoreTypes.js
@@ -432,6 +432,14 @@ export interface StoreSubscriptions {
    * returns the number of subscriptions
    */
   size(): number;
+
+  /**
+   * Adds every record read by an active subscription to `references`, so that
+   * the store's GC can treat observed data as reachable even when no retained
+   * operation selects it. Only consulted when
+   * RelayFeatureFlags.ENABLE_SUBSCRIPTION_GC_ROOTS is enabled.
+   */
+  markReferences(references: DataIDSet): void;
 }
 
 /**

--- a/packages/relay-runtime/store/__tests__/RelayModernStore-SubscriptionGC-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernStore-SubscriptionGC-test.js
@@ -1,0 +1,289 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+import type {Snapshot} from '../RelayStoreTypes';
+
+const RelayNetwork = require('../../network/RelayNetwork');
+const RelayFeatureFlags = require('../../util/RelayFeatureFlags');
+const RelayModernEnvironment = require('../RelayModernEnvironment');
+const {
+  createOperationDescriptor,
+} = require('../RelayModernOperationDescriptor');
+const {createReaderSelector} = require('../RelayModernSelector');
+const RelayModernStore = require('../RelayModernStore');
+const RelayRecordSource = require('../RelayRecordSource');
+const {graphql} = require('relay-runtime');
+const {
+  disallowWarnings,
+  injectPromisePolyfill__DEPRECATED,
+} = require('relay-test-utils-internal');
+
+injectPromisePolyfill__DEPRECATED();
+disallowWarnings();
+
+/**
+ * GC reachability is computed from retained operations only
+ * (`RelayModernStore._collect()` walks `this._roots`). An active store
+ * subscription — the thing a mounted fragment observes the store through — is
+ * not a root. So a record that a rendered fragment is reading gets collected
+ * as soon as no *retained* operation happens to select it.
+ *
+ * The topology below is the one that occurs in a real app. Two operations
+ * overlap on the same parent record but select different subtrees:
+ *
+ *   KeepAliveQuery  node(id:"1") { id }            — retained for the session
+ *   OwnerQuery      node(id:"1") { ...fragment }   — retained by a route
+ *
+ * The keep-alive query holds `User:1`, so the parent survives; the subtrees
+ * only the owner query reaches (`birthdate`, `friends`) do not. When the
+ * owner's retain lapses — a React <Activity> route is hidden, so the effect
+ * holding it is torn down — GC collects those subtrees while a fragment is
+ * still subscribed to them. The next read of that fragment returns `undefined`
+ * for fields the schema declares non-nullable.
+ *
+ * Both flag states are pinned here on purpose: the `false` cases document the
+ * behavior these tests exist to change, so a future refactor cannot quietly
+ * restore it while the `true` cases keep passing.
+ */
+
+let OwnerQuery;
+let KeepAliveQuery;
+let UserFragment;
+let FriendsFragment;
+let environment;
+let store;
+let ownerOperation;
+let keepAliveOperation;
+
+const BIRTHDATE_ID = 'client:1:birthdate';
+const FRIENDS_ID = 'client:1:friends(first:1)';
+
+beforeEach(() => {
+  UserFragment = graphql`
+    fragment RelayModernStoreSubscriptionGCTestUserFragment on User {
+      name
+      birthdate {
+        day
+      }
+    }
+  `;
+  FriendsFragment = graphql`
+    fragment RelayModernStoreSubscriptionGCTestFriendsFragment on User {
+      friends(first: 1) {
+        edges {
+          node {
+            id
+            name
+          }
+        }
+      }
+    }
+  `;
+  OwnerQuery = graphql`
+    query RelayModernStoreSubscriptionGCTestOwnerQuery($id: ID!) {
+      node(id: $id) {
+        ...RelayModernStoreSubscriptionGCTestUserFragment
+          @dangerously_unaliased_fixme
+        ...RelayModernStoreSubscriptionGCTestFriendsFragment
+          @dangerously_unaliased_fixme
+      }
+    }
+  `;
+  // Overlaps the owner query on `User:1` but selects neither subtree, so its
+  // retain keeps the parent alive while leaving the children collectable.
+  KeepAliveQuery = graphql`
+    query RelayModernStoreSubscriptionGCTestKeepAliveQuery($id: ID!) {
+      node(id: $id) {
+        id
+      }
+    }
+  `;
+
+  // gcReleaseBufferSize 0 makes a released operation immediately eligible;
+  // with the default buffer the same thing happens a few navigations later.
+  store = new RelayModernStore(RelayRecordSource.create(), {
+    gcReleaseBufferSize: 0,
+  });
+  environment = new RelayModernEnvironment({
+    network: RelayNetwork.create(jest.fn()),
+    store,
+  });
+
+  ownerOperation = createOperationDescriptor(OwnerQuery, {id: '1'});
+  keepAliveOperation = createOperationDescriptor(KeepAliveQuery, {id: '1'});
+
+  environment.commitPayload(ownerOperation, {
+    node: {
+      __typename: 'User',
+      id: '1',
+      name: 'Alice',
+      birthdate: {day: 15, month: 7, year: 1991},
+      friends: {
+        edges: [{node: {__typename: 'User', id: '2', name: 'Bob'}}],
+      },
+    },
+  });
+  environment.commitPayload(keepAliveOperation, {
+    node: {__typename: 'User', id: '1'},
+  });
+  environment.retain(keepAliveOperation);
+});
+
+afterEach(() => {
+  RelayFeatureFlags.ENABLE_SUBSCRIPTION_GC_ROOTS = false;
+});
+
+function lookupUser(): Snapshot {
+  return environment.lookup(
+    createReaderSelector(UserFragment, '1', {}, ownerOperation.request),
+  );
+}
+
+function lookupFriends(): Snapshot {
+  return environment.lookup(
+    createReaderSelector(FriendsFragment, '1', {}, ownerOperation.request),
+  );
+}
+
+/**
+ * Release the route's retain and let GC run for real — no store internals are
+ * stubbed, so the test fails if the fix stops being reachable from a real
+ * collection pass.
+ */
+function releaseOwnerAndCollect() {
+  environment.retain(ownerOperation).dispose();
+  jest.runAllTimers();
+}
+
+describe('GC and active subscriptions', () => {
+  it('collects a record an active subscription is reading (flag off)', () => {
+    // Set explicitly rather than relying on the module default: this case
+    // documents the behavior the flag exists to change, so it has to keep
+    // asserting that even after the default flips.
+    RelayFeatureFlags.ENABLE_SUBSCRIPTION_GC_ROOTS = false;
+
+    const snapshot = lookupUser();
+    expect(snapshot.isMissingData).toBe(false);
+    expect(snapshot.seenRecords.has(BIRTHDATE_ID)).toBe(true);
+    environment.subscribe(snapshot, jest.fn());
+
+    releaseOwnerAndCollect();
+
+    // The parent survives on the keep-alive query's retain, so the fragment
+    // still resolves `User:1` — and then dereferences a link to a record that
+    // is gone.
+    expect(store.getSource().get('1')).not.toBe(undefined);
+    expect(store.getSource().get(BIRTHDATE_ID)).toBe(undefined);
+    expect(lookupUser().isMissingData).toBe(true);
+  });
+
+  it('retains a record an active subscription is reading (flag on)', () => {
+    RelayFeatureFlags.ENABLE_SUBSCRIPTION_GC_ROOTS = true;
+
+    const snapshot = lookupUser();
+    expect(snapshot.isMissingData).toBe(false);
+    environment.subscribe(snapshot, jest.fn());
+
+    releaseOwnerAndCollect();
+
+    expect(store.getSource().get(BIRTHDATE_ID)).not.toBe(undefined);
+    const reread = lookupUser();
+    expect(reread.isMissingData).toBe(false);
+    expect(reread.data).toEqual({name: 'Alice', birthdate: {day: 15}});
+  });
+
+  it('retains a whole connection subtree an active subscription is reading (flag on)', () => {
+    RelayFeatureFlags.ENABLE_SUBSCRIPTION_GC_ROOTS = true;
+
+    const snapshot = lookupFriends();
+    expect(snapshot.isMissingData).toBe(false);
+    // The connection record, its edge, and the edge's node are all read, so
+    // all three have to survive: collecting any one of them makes the next
+    // read partial.
+    expect(snapshot.seenRecords.has(FRIENDS_ID)).toBe(true);
+    expect(snapshot.seenRecords.has('2')).toBe(true);
+    environment.subscribe(snapshot, jest.fn());
+
+    releaseOwnerAndCollect();
+
+    expect(store.getSource().get(FRIENDS_ID)).not.toBe(undefined);
+    expect(store.getSource().get('2')).not.toBe(undefined);
+    const reread = lookupFriends();
+    expect(reread.isMissingData).toBe(false);
+    expect(reread.data).toEqual({
+      friends: {edges: [{node: {id: '2', name: 'Bob'}}]},
+    });
+  });
+
+  it('still collects records nothing is observing (flag on)', () => {
+    RelayFeatureFlags.ENABLE_SUBSCRIPTION_GC_ROOTS = true;
+
+    // Read without subscribing: a lookup alone is not a commitment.
+    lookupUser();
+
+    releaseOwnerAndCollect();
+
+    expect(store.getSource().get(BIRTHDATE_ID)).toBe(undefined);
+    expect(store.getSource().get(FRIENDS_ID)).toBe(undefined);
+    // The retained keep-alive query's records are untouched.
+    expect(store.getSource().get('1')).not.toBe(undefined);
+  });
+
+  it('collects once the subscription is disposed (flag on)', () => {
+    RelayFeatureFlags.ENABLE_SUBSCRIPTION_GC_ROOTS = true;
+
+    const subscription = environment.subscribe(lookupUser(), jest.fn());
+    releaseOwnerAndCollect();
+    expect(store.getSource().get(BIRTHDATE_ID)).not.toBe(undefined);
+
+    // Unmounting ends the commitment, and losing the last root that reached
+    // these records has to schedule a collection by itself: no retain is being
+    // released here, so nothing else in the store would ever notice. Without
+    // that, data a subscription was pinning stays for the rest of the session.
+    subscription.dispose();
+    jest.runAllTimers();
+    expect(store.getSource().get(BIRTHDATE_ID)).toBe(undefined);
+  });
+
+  it('collects when a release-triggered pass is preempted by a subscription that then goes away (flag on)', () => {
+    RelayFeatureFlags.ENABLE_SUBSCRIPTION_GC_ROOTS = true;
+
+    // React tears an <Activity> route down in effect declaration order, and
+    // useLazyLoadQueryNode declares its retain effect above the fragment hook
+    // that subscribes. So the release runs first and the GC it schedules still
+    // sees the subscription, which marks exactly the records the route was
+    // being hidden to release. Only the pass triggered by the subscription
+    // going away can collect them.
+    const subscription = environment.subscribe(lookupUser(), jest.fn());
+    releaseOwnerAndCollect();
+    expect(store.getSource().get(BIRTHDATE_ID)).not.toBe(undefined);
+
+    subscription.dispose();
+    jest.runAllTimers();
+    expect(store.getSource().get(BIRTHDATE_ID)).toBe(undefined);
+    expect(store.getSource().get(FRIENDS_ID)).toBe(undefined);
+  });
+
+  it('marks only what a subscription actually read (flag on)', () => {
+    RelayFeatureFlags.ENABLE_SUBSCRIPTION_GC_ROOTS = true;
+
+    // Observing one subtree must not resurrect the other: `seenRecords` is
+    // the reader's traversal, not the owner operation's selection.
+    environment.subscribe(lookupUser(), jest.fn());
+
+    releaseOwnerAndCollect();
+
+    expect(store.getSource().get(BIRTHDATE_ID)).not.toBe(undefined);
+    expect(store.getSource().get(FRIENDS_ID)).toBe(undefined);
+  });
+});

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayModernStoreSubscriptionGCTestFriendsFragment.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayModernStoreSubscriptionGCTestFriendsFragment.graphql.js
@@ -1,0 +1,111 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<865231d771d16398e6d0f55b348f2dc0>>
+ * @flow
+ * @lightSyntaxTransform
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type RelayModernStoreSubscriptionGCTestFriendsFragment$fragmentType: FragmentType;
+export type RelayModernStoreSubscriptionGCTestFriendsFragment$data = {
+  readonly friends: ?{
+    readonly edges: ?ReadonlyArray<?{
+      readonly node: ?{
+        readonly id: string,
+        readonly name: ?string,
+      },
+    }>,
+  },
+  readonly $fragmentType: RelayModernStoreSubscriptionGCTestFriendsFragment$fragmentType,
+};
+export type RelayModernStoreSubscriptionGCTestFriendsFragment$key = {
+  readonly $data?: RelayModernStoreSubscriptionGCTestFriendsFragment$data,
+  readonly $fragmentSpreads: RelayModernStoreSubscriptionGCTestFriendsFragment$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "RelayModernStoreSubscriptionGCTestFriendsFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 1
+        }
+      ],
+      "concreteType": "FriendsConnection",
+      "kind": "LinkedField",
+      "name": "friends",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "FriendsEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "User",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "id",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "name",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "friends(first:1)"
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*:: as any*/).hash = "bfc7b1f8c851ae7b10adaa5c8372fe0f";
+}
+
+module.exports = ((node/*:: as any*/)/*:: as Fragment<
+  RelayModernStoreSubscriptionGCTestFriendsFragment$fragmentType,
+  RelayModernStoreSubscriptionGCTestFriendsFragment$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayModernStoreSubscriptionGCTestKeepAliveQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayModernStoreSubscriptionGCTestKeepAliveQuery.graphql.js
@@ -1,0 +1,124 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<681eb82c9706918b67de65a8ffb3f153>>
+ * @flow
+ * @lightSyntaxTransform
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+export type RelayModernStoreSubscriptionGCTestKeepAliveQuery$variables = {
+  id: string,
+};
+export type RelayModernStoreSubscriptionGCTestKeepAliveQuery$data = {
+  readonly node: ?{
+    readonly id: string,
+  },
+};
+export type RelayModernStoreSubscriptionGCTestKeepAliveQuery = {
+  response: RelayModernStoreSubscriptionGCTestKeepAliveQuery$data,
+  variables: RelayModernStoreSubscriptionGCTestKeepAliveQuery$variables,
+};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RelayModernStoreSubscriptionGCTestKeepAliveQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          (v2/*:: as any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Operation",
+    "name": "RelayModernStoreSubscriptionGCTestKeepAliveQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          (v2/*:: as any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "931555824c09db48e0b075d00056d86f",
+    "id": null,
+    "metadata": {},
+    "name": "RelayModernStoreSubscriptionGCTestKeepAliveQuery",
+    "operationKind": "query",
+    "text": "query RelayModernStoreSubscriptionGCTestKeepAliveQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    id\n  }\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*:: as any*/).hash = "17ed5996d1799d45061e438b796c256a";
+}
+
+module.exports = ((node/*:: as any*/)/*:: as Query<
+  RelayModernStoreSubscriptionGCTestKeepAliveQuery$variables,
+  RelayModernStoreSubscriptionGCTestKeepAliveQuery$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayModernStoreSubscriptionGCTestOwnerQuery.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayModernStoreSubscriptionGCTestOwnerQuery.graphql.js
@@ -1,0 +1,209 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<5140b561c9c87921fda999cad6fe25b3>>
+ * @flow
+ * @lightSyntaxTransform
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { ConcreteRequest, Query } from 'relay-runtime';
+import type { RelayModernStoreSubscriptionGCTestFriendsFragment$fragmentType } from "./RelayModernStoreSubscriptionGCTestFriendsFragment.graphql";
+import type { RelayModernStoreSubscriptionGCTestUserFragment$fragmentType } from "./RelayModernStoreSubscriptionGCTestUserFragment.graphql";
+export type RelayModernStoreSubscriptionGCTestOwnerQuery$variables = {
+  id: string,
+};
+export type RelayModernStoreSubscriptionGCTestOwnerQuery$data = {
+  readonly node: ?{
+    readonly $fragmentSpreads: RelayModernStoreSubscriptionGCTestFriendsFragment$fragmentType & RelayModernStoreSubscriptionGCTestUserFragment$fragmentType,
+  },
+};
+export type RelayModernStoreSubscriptionGCTestOwnerQuery = {
+  response: RelayModernStoreSubscriptionGCTestOwnerQuery$data,
+  variables: RelayModernStoreSubscriptionGCTestOwnerQuery$variables,
+};
+*/
+
+var node/*: ConcreteRequest*/ = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "RelayModernStoreSubscriptionGCTestOwnerQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "RelayModernStoreSubscriptionGCTestUserFragment"
+          },
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "RelayModernStoreSubscriptionGCTestFriendsFragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*:: as any*/),
+    "kind": "Operation",
+    "name": "RelayModernStoreSubscriptionGCTestOwnerQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*:: as any*/),
+        "concreteType": null,
+        "kind": "LinkedField",
+        "name": "node",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "__typename",
+            "storageKey": null
+          },
+          {
+            "kind": "InlineFragment",
+            "selections": [
+              (v2/*:: as any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Date",
+                "kind": "LinkedField",
+                "name": "birthdate",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "day",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 1
+                  }
+                ],
+                "concreteType": "FriendsConnection",
+                "kind": "LinkedField",
+                "name": "friends",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "FriendsEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "User",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v3/*:: as any*/),
+                          (v2/*:: as any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "friends(first:1)"
+              }
+            ],
+            "type": "User",
+            "abstractKey": null
+          },
+          (v3/*:: as any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "ab20c35f9b32bd660340c3e612dcc8e9",
+    "id": null,
+    "metadata": {},
+    "name": "RelayModernStoreSubscriptionGCTestOwnerQuery",
+    "operationKind": "query",
+    "text": "query RelayModernStoreSubscriptionGCTestOwnerQuery(\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...RelayModernStoreSubscriptionGCTestUserFragment\n    ...RelayModernStoreSubscriptionGCTestFriendsFragment\n    id\n  }\n}\n\nfragment RelayModernStoreSubscriptionGCTestFriendsFragment on User {\n  friends(first: 1) {\n    edges {\n      node {\n        id\n        name\n      }\n    }\n  }\n}\n\nfragment RelayModernStoreSubscriptionGCTestUserFragment on User {\n  name\n  birthdate {\n    day\n  }\n}\n"
+  }
+};
+})();
+
+if (__DEV__) {
+  (node/*:: as any*/).hash = "1b30ec2f4928d0968851e0532059df43";
+}
+
+module.exports = ((node/*:: as any*/)/*:: as Query<
+  RelayModernStoreSubscriptionGCTestOwnerQuery$variables,
+  RelayModernStoreSubscriptionGCTestOwnerQuery$data,
+>*/);

--- a/packages/relay-runtime/store/__tests__/__generated__/RelayModernStoreSubscriptionGCTestUserFragment.graphql.js
+++ b/packages/relay-runtime/store/__tests__/__generated__/RelayModernStoreSubscriptionGCTestUserFragment.graphql.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @oncall relay
+ *
+ * @generated SignedSource<<d5c49a534d3a950a02ceb21baf2cc0cb>>
+ * @flow
+ * @lightSyntaxTransform
+ */
+
+/* eslint-disable */
+
+'use strict';
+
+/*::
+import type { Fragment, ReaderFragment } from 'relay-runtime';
+import type { FragmentType } from "relay-runtime";
+declare export opaque type RelayModernStoreSubscriptionGCTestUserFragment$fragmentType: FragmentType;
+export type RelayModernStoreSubscriptionGCTestUserFragment$data = {
+  readonly birthdate: ?{
+    readonly day: ?number,
+  },
+  readonly name: ?string,
+  readonly $fragmentType: RelayModernStoreSubscriptionGCTestUserFragment$fragmentType,
+};
+export type RelayModernStoreSubscriptionGCTestUserFragment$key = {
+  readonly $data?: RelayModernStoreSubscriptionGCTestUserFragment$data,
+  readonly $fragmentSpreads: RelayModernStoreSubscriptionGCTestUserFragment$fragmentType,
+  ...
+};
+*/
+
+var node/*: ReaderFragment*/ = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "RelayModernStoreSubscriptionGCTestUserFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Date",
+      "kind": "LinkedField",
+      "name": "birthdate",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "day",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "User",
+  "abstractKey": null
+};
+
+if (__DEV__) {
+  (node/*:: as any*/).hash = "e7e01b5a3eba056ab3680a2cef28cc82";
+}
+
+module.exports = ((node/*:: as any*/)/*:: as Fragment<
+  RelayModernStoreSubscriptionGCTestUserFragment$fragmentType,
+  RelayModernStoreSubscriptionGCTestUserFragment$data,
+>*/);

--- a/packages/relay-runtime/util/RelayFeatureFlags.js
+++ b/packages/relay-runtime/util/RelayFeatureFlags.js
@@ -56,6 +56,12 @@ export type FeatureFlags = {
   // Temporary flag to experiment to enable compatibility with React's unstable <Activity> API
   ENABLE_ACTIVITY_COMPATIBILITY: boolean,
 
+  // When a fragment reads missing data and no operation affecting its owner is
+  // pending (e.g. its records were GC'd while a React <Activity> was hidden
+  // and the fragment ref outlived the owner query's retain), refetch the owner
+  // query once and suspend, instead of rendering a partial snapshot.
+  ENABLE_MISSING_DATA_OWNER_REFETCH: boolean,
+
   // Adds a prefix to the storage key of read time resolvers. This is used to
   // disambiguate the same resolver being used at both read time and exec time.
   ENABLE_READ_TIME_RESOLVER_STORAGE_KEY_PREFIX: boolean,
@@ -136,6 +142,7 @@ const RelayFeatureFlags: FeatureFlags = {
   MARK_RESOLVER_VALUES_AS_CLEAN_AFTER_FRAGMENT_REREAD: false,
   ENABLE_CYLE_DETECTION_IN_VARIABLES: false,
   ENABLE_ACTIVITY_COMPATIBILITY: true,
+  ENABLE_MISSING_DATA_OWNER_REFETCH: false,
   ENABLE_READ_TIME_RESOLVER_STORAGE_KEY_PREFIX: true,
   ENABLE_USE_PAGINATION_IS_LOADING_FIX: false,
   DISALLOW_NESTED_UPDATES: false,

--- a/packages/relay-runtime/util/RelayFeatureFlags.js
+++ b/packages/relay-runtime/util/RelayFeatureFlags.js
@@ -56,6 +56,13 @@ export type FeatureFlags = {
   // Temporary flag to experiment to enable compatibility with React's unstable <Activity> API
   ENABLE_ACTIVITY_COMPATIBILITY: boolean,
 
+  // Treat the records read by every active store subscription as GC roots.
+  // Without this, RelayModernStore's GC computes reachability only from
+  // retained operations, so a record that a currently-observed fragment is
+  // reading is collected as soon as no retained operation selects it — e.g.
+  // when a React <Activity> route is hidden and its query's retain lapses.
+  ENABLE_SUBSCRIPTION_GC_ROOTS: boolean,
+
   // When a fragment reads missing data and no operation affecting its owner is
   // pending (e.g. its records were GC'd while a React <Activity> was hidden
   // and the fragment ref outlived the owner query's retain), refetch the owner
@@ -142,6 +149,7 @@ const RelayFeatureFlags: FeatureFlags = {
   MARK_RESOLVER_VALUES_AS_CLEAN_AFTER_FRAGMENT_REREAD: false,
   ENABLE_CYLE_DETECTION_IN_VARIABLES: false,
   ENABLE_ACTIVITY_COMPATIBILITY: true,
+  ENABLE_SUBSCRIPTION_GC_ROOTS: false,
   ENABLE_MISSING_DATA_OWNER_REFETCH: false,
   ENABLE_READ_TIME_RESOLVER_STORAGE_KEY_PREFIX: true,
   ENABLE_USE_PAGINATION_IS_LOADING_FIX: false,


### PR DESCRIPTION
Fragments can read `undefined` for fields the schema declares non-nullable, crashing consumers that trust the generated types. This PR addresses one cause in the store and three defects in the recovery path, all behind flags that default to off.

It supersedes #5367 (closed), which contained only the first version of the recovery path. Two of the three defects below are in that code.

## 1. GC collects records that a mounted fragment is reading

`RelayModernStore._collect()` seeds its `references` set from `this._roots` and never consults `this._storeSubscriptions`. A record an actively subscribed fragment is reading is therefore collected as soon as no *retained* operation happens to select it. That is routine when two operations overlap on a parent record but select different subtrees — a session-long query keeps `User:1` alive while the route query that selected `user.birthdate` is released, and the link dangles.

The damage is latent: GC neither bumps the epoch nor populates `_updatedRecordIDs`, so no subscriber is notified. The component keeps rendering its last complete snapshot until an unrelated overlapping write forces a re-read. This is also the easiest way to write a test that passes for the wrong reason, so the tests here assert on the record source directly rather than on rendered output.

Behind `ENABLE_SUBSCRIPTION_GC_ROOTS`, every active subscription's `snapshot.seenRecords` is marked reachable.

Disposing a subscription then has to schedule a collection of its own. Unlike releasing a retain, it reaches no path that would notice the root set changed — and the gap is not a corner case. React tears an `<Activity>` route down in effect declaration order, and `useLazyLoadQueryNode` declares its retain effect above the fragment hook that subscribes, so the release runs first and the GC it schedules **still sees the subscription**, marking exactly the records the route was hidden in order to release. Without the pass scheduled on dispose, that data stays for the rest of the session. `useLazyLoadQueryNode-activity-test.js › disposes and GCs the query when hiding past query TTL in the store` is what surfaced this.

## 2. The recovery path decides from a stale snapshot

`state` is a snapshot taken at an earlier store epoch, and the render path has no way to refresh it: `getFragmentState` re-reads only when the selector or environment changed, and `handleMissedUpdates` — the only epoch-refreshing read — runs exclusively from effects, which never run for a render that suspends by throwing.

So a recovery response that lands while the tree is suspended, as a hidden `<Activity>` route guarantees, is invisible to the reader. On restore the records are present and `environment.check(owner)` reports `'available'`, yet the fragment still reads missing, finds its attempt already spent, and hands consumers the partial snapshot recovery had just repaired.

A later commit heals the reader, so asserting on final rendered output cannot see this. The test asserts on the sequence of renders; without the fix it is `["partial", "Carol"]`.

## 3. One transient failure disarms recovery permanently — and expiry alone inverts that

The marker was a `Set<string>` with no expiry, and its only release path runs from a complete read that will never happen while the data is missing. A single dropped connection therefore opted that owner out of recovery for the environment's lifetime.

Expiry alone inverts the problem: a read the server can never satisfy then costs a real request and a visible Suspense fallback every cooldown, forever. An attempt now carries a count and spends at most `MAX_MISSING_DATA_REFETCH_ATTEMPTS` requests on one episode, spaced by a doubling backoff. The budget is per *episode*, so releasing the attempt restores it in full.

## 4. A healthy reader disarms a broken one, producing an unbounded refetch loop

The release branch runs for a fragment whose *own* read is complete, and one query owner is shared by every fragment spread under it. So: reader A reads missing and takes an attempt, the response lands, sibling B reads fine and releases it, A re-reads missing and takes a **fresh** attempt — a refetch loop at network speed, which presents as a screen that never leaves its skeleton and never reaches an error boundary.

`environment.check()` cannot stand in for "no reader is missing". It walks the normalization AST from the query root asking only whether records exist, while a reader walks one fragment from the record its pointer captured and additionally applies `@required`, client resolvers, and `missing_expected_data`. A query can report `'available'` while a fragment under it reads missing.

An attempt now tracks which readers were missing under it and releases only once all of them read back complete, with `check()` kept as a conservative secondary gate. Reader identity is the fragment plus the record(s) and variables it was pointed at, per constituent selector for a plural fragment — fragment name alone collapses every row of a list into one identity, which is exactly the collision this gate exists to prevent.

## Evidence

Every property is pinned by a test that fails when that property alone is removed. Run against `packages/react-relay/relay-hooks/__tests__/useFragment-missing-data*` and `packages/relay-runtime/store/__tests__/RelayModernStore-SubscriptionGC-test.js` (23 tests):

| mutation applied to the fix | tests failing |
| --- | --- |
| `markReferences` call removed | 6 |
| GC-on-unsubscribe removed | 2 |
| render-path re-read removed | 1 |
| per-episode attempt cap removed | 1 |
| still-missing-reader gate removed | 3 |
| reader key reduced to fragment name | 2 |
| *(none — as submitted)* | **0 / 23 pass** |

The two negative controls (an unobserved record is still collected; an observed record becomes collectable once its subscription is disposed) pass in every configuration, so the GC change is not simply over-retaining.

All GC tests trigger real collection via `retain().dispose()` with `gcReleaseBufferSize: 0` — no store internals are stubbed.

## Verification

- `npx jest` — 249 suites / 3772 tests pass
- `npx flow check` — no errors
- `eslint --max-warnings 0` and `prettier --check` on every changed file — clean

With `ENABLE_SUBSCRIPTION_GC_ROOTS` **forced on** across the whole suite, 2 tests in `useLazyLoadQueryNode-activity-test.js` fail, both solely on `expect(store.scheduleGC).toHaveBeenCalledTimes(1)` receiving 2. That is the extra pass scheduled on unsubscribe, which is the point of the change; the store-emptied assertions in those tests hold. Flagging it explicitly rather than leaving it for CI to find.

## Known limitations

- The eviction path at `MAX_MISSING_DATA_REFETCHES` (1000 owners per environment) is not covered by a test — exercising it needs 1001 distinct owners.
- Records read during a concurrent render but not yet subscribed are not protected by `ENABLE_SUBSCRIPTION_GC_ROOTS`, since they are not yet in the subscription set. At present that window is covered by `QueryResource.prepare`'s temporary retain; it is worth stating that the flag does not close it in general.
- Mutation and subscription owners are still never refetched, and still render the partial snapshot.
- Rendering `undefined` for missing data remains the documented contract (`@throwOnFieldError` is the opt-in to turn it into an error); nothing here changes that. When recovery is unavailable, execution falls through to today's behavior rather than throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
