### PR TITLE
fix: forward networkCacheConfig from pagination/refetchable fragment refetch

### DIFF
--- a/packages/react-relay/ReactRelayTypes.d.ts
+++ b/packages/react-relay/ReactRelayTypes.d.ts
@@ -337,6 +337,7 @@ export interface ReturnTypeNode<
 
 export interface RefetchableOptions {
     fetchPolicy?: FetchPolicy | undefined;
+    networkCacheConfig?: CacheConfig | null | undefined;
     onComplete?: ((arg: Error | null) => void) | undefined;
     UNSTABLE_renderPolicy?: RenderPolicy | undefined;
 }

--- a/packages/react-relay/relay-hooks/__tests__/usePaginationFragment-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/usePaginationFragment-test.js
@@ -3714,6 +3714,40 @@ describe.each([
         );
       }
 
+      it('forwards networkCacheConfig metadata to the network layer on refetch', () => {
+        renderFragment();
+        expectFragmentResults([
+          {
+            data: initialUser,
+            hasNext: true,
+            hasPrevious: false,
+            isLoadingNext: false,
+            isLoadingPrevious: false,
+          },
+        ]);
+
+        const networkCacheConfig = {
+          force: true,
+          metadata: {latestWinsKey: 'capacity-planning:work-table:1'},
+        };
+
+        TestRenderer.act(() => {
+          refetch(
+            {id: '1'},
+            {
+              fetchPolicy: 'network-only',
+              networkCacheConfig,
+            },
+          );
+        });
+
+        expect(fetch).toBeCalledTimes(1);
+        expect(fetch.mock.calls[0][2]).toEqual({
+          force: true,
+          metadata: {latestWinsKey: 'capacity-planning:work-table:1'},
+        });
+      });
+
       it('refetches new variables correctly when refetching new id', () => {
         const renderer = renderFragment();
         expectFragmentResults([

--- a/packages/react-relay/relay-hooks/useRefetchableFragmentInternal.js
+++ b/packages/react-relay/relay-hooks/useRefetchableFragmentInternal.js
@@ -13,6 +13,7 @@
 
 import type {LoaderFn} from './useQueryLoader';
 import type {
+  CacheConfig,
   ConcreteRequest,
   Disposable,
   FetchPolicy,
@@ -75,6 +76,7 @@ export type ReturnType<
 
 export type Options = {
   fetchPolicy?: FetchPolicy,
+  networkCacheConfig?: CacheConfig,
   onComplete?: (Error | null) => void,
   UNSTABLE_renderPolicy?: RenderPolicy,
 };
@@ -427,6 +429,10 @@ hook useRefetchFunction<TQuery extends OperationType>(
       const fetchPolicy = options?.fetchPolicy;
       const renderPolicy = options?.UNSTABLE_renderPolicy;
       const onComplete = options?.onComplete;
+      const networkCacheConfig = {
+        ...options?.networkCacheConfig,
+        force: true,
+      };
       const fragmentSelector = getSelector(fragmentNode, parentFragmentRef);
       let parentVariables: Variables;
       let fragmentVariables: Variables;
@@ -479,9 +485,7 @@ hook useRefetchFunction<TQuery extends OperationType>(
       const refetchQuery = createOperationDescriptor(
         refetchableRequest,
         refetchVariables,
-        {
-          force: true,
-        },
+        networkCacheConfig,
       );
 
       // We call loadQuery which will start a network request if necessary
@@ -495,6 +499,7 @@ hook useRefetchFunction<TQuery extends OperationType>(
         __environment: refetchEnvironment,
         __nameForWarning: 'refetch',
         fetchPolicy,
+        networkCacheConfig,
       });
 
       dispatch({


### PR DESCRIPTION
fixes #5398

usePaginationFragment / useRefetchableFragment drop networkCacheConfig because the helper hardcodes force true.

We still force, but we forward the rest of the config to loadQuery so metadata like latest-wins actually reaches the network.

there is a regression test on pagination fragment refetch.