### PR TITLE
Demo: the zombie QueryResource fix, as a snapshot diff (stacked on #5405)

### DIFF
--- a/packages/react-relay/relay-hooks/QueryResource.js
+++ b/packages/react-relay/relay-hooks/QueryResource.js
@@ -437,6 +437,15 @@ class QueryResourceImpl {
       }
     }
 
+    // Tracks whether this call has ever populated a cache entry for
+    // `cacheIdentifier`. Used by the `next`/`error` callbacks below to
+    // distinguish "entry not yet created" (synchronous observable that
+    // fires during `.subscribe()`, before the post-subscribe creation
+    // path at the bottom runs) from "entry was created and has since
+    // been disposed" (StrictMode / navigation / suspended-and-discarded
+    // — in which case we must NOT resurrect it).
+    let entryHasBeenCreated = false;
+
     // NOTE: If this value is false, we will cache a promise for this
     // query, which means we will suspend here at this query root.
     // If it's true, we will cache the query resource and allow rendering to
@@ -452,6 +461,7 @@ class QueryResourceImpl {
         this._clearCacheEntry,
       );
       this._cache.set(cacheIdentifier, cacheEntry);
+      entryHasBeenCreated = true;
     }
 
     if (shouldFetch) {
@@ -479,13 +489,45 @@ class QueryResourceImpl {
           }
         },
         next: () => {
-          const cacheEntry = this._getOrCreateCacheEntry(
-            cacheIdentifier,
-            operation,
-            queryAvailability,
-            queryResult,
-            networkSubscription,
-          );
+          // Do not resurrect a cache entry that has already been
+          // disposed. This can happen when a fetch is in flight during
+          // React Strict Mode's mount/unmount/mount cycle (or Offscreen
+          // / fast refresh): `prepareWithIdentifier` creates the entry,
+          // the strict-mode effect cleanup in `useLazyLoadQueryNode`
+          // disposes it, and `forceUpdate` produces a *new* entry with
+          // a different cacheBreaker. If we resurrected the original
+          // entry here, it would re-enter the LRU with no permanent
+          // retain (no useEffect ever attached to it), survive the
+          // component's eventual unmount, and be reused by a later
+          // mount that computes the same cacheIdentifier — pointing at
+          // records the GC has since reclaimed.
+          //
+          // The store still receives the data via normalization; any
+          // *live* cache entry sharing this fetch (deduped through
+          // `fetchQuery`) receives its own `next` and updates its value
+          // correctly. Dropping the update on a disposed entry is the
+          // right behavior.
+          //
+          // We must still create the entry on the *first* `next` if
+          // the observable fires synchronously inside `.subscribe()`
+          // (e.g. cached/mocked transports): in that case the
+          // post-subscribe creation path below hasn't run yet, and no
+          // entry has ever existed for this fetch — there is nothing
+          // to resurrect.
+          let cacheEntry = this._cache.get(cacheIdentifier);
+          if (cacheEntry == null) {
+            if (entryHasBeenCreated) {
+              return;
+            }
+            cacheEntry = this._getOrCreateCacheEntry(
+              cacheIdentifier,
+              operation,
+              queryAvailability,
+              queryResult,
+              networkSubscription,
+            );
+            entryHasBeenCreated = true;
+          }
           cacheEntry.processedPayloadsCount += 1;
           cacheEntry.setValue(queryResult);
           resolveNetworkPromise();
@@ -497,13 +539,23 @@ class QueryResourceImpl {
           }
         },
         error: error => {
-          const cacheEntry = this._getOrCreateCacheEntry(
-            cacheIdentifier,
-            operation,
-            queryAvailability,
-            error,
-            networkSubscription,
-          );
+          // See the comment on `next` above: do not resurrect a
+          // disposed cache entry, but do create the entry on a
+          // first-time synchronous fire.
+          let cacheEntry = this._cache.get(cacheIdentifier);
+          if (cacheEntry == null) {
+            if (entryHasBeenCreated) {
+              return;
+            }
+            cacheEntry = this._getOrCreateCacheEntry(
+              cacheIdentifier,
+              operation,
+              queryAvailability,
+              error,
+              networkSubscription,
+            );
+            entryHasBeenCreated = true;
+          }
 
           // If, this is the first thing we receive for the query,
           // before any other payload handled is error, we will cache and
@@ -562,6 +614,7 @@ class QueryResourceImpl {
           this._clearCacheEntry,
         );
         this._cache.set(cacheIdentifier, cacheEntry);
+        entryHasBeenCreated = true;
       }
     } else {
       const observerComplete = observer?.complete;

--- a/packages/relay-e2e-test/fixtures/queries/disposed-query-cache-entry.md
+++ b/packages/relay-e2e-test/fixtures/queries/disposed-query-cache-entry.md
@@ -1,10 +1,7 @@
-# BUG: a screen goes permanently blank after you leave it mid-refresh
+# A screen must not go blank after you leave it mid-refresh
 
-**This fixture records current, broken behaviour.** The snapshot below is the
-bug, not the goal. It exists so that the fix can be reviewed as a diff of the
-snapshot.
-
-The bug as a user would report it: *"If I open the profile, go back while it's
+Regression test for the zombie `QueryResource` cache entry. The bug, as a user
+would have reported it: *"If I open the profile, go back while it's
 refreshing, and open it again later, the name is just blank. No spinner, no
 error. It stays blank until I reload the page."*
 
@@ -35,8 +32,8 @@ the background" policy. Every step is an ordinary user action:
    `undefined`. There is no fetch to wait for, no error to catch, and no
    suspense to fall back to, so the screen renders blank and stays blank.
 
-Once a disposed entry stays disposed, step 6 will cache-miss, refetch, and
-render `Alice #3`. Until then the snapshot reads `(blank forever)`.
+A disposed entry now stays disposed, so step 6 cache-misses, refetches, and
+renders `Alice #3`.
 
 ## Relay Config
 
@@ -169,9 +166,8 @@ export default function TestApp() {
 
 ## Steps
 
-The last visit is the assertion, and it currently asserts the bug. When the
-zombie is fixed this becomes `wait "name = Alice #3"` and the snapshot changes
-with it.
+The last visit is the assertion. `Alice #3` means the profile refetched;
+`(blank forever)` would mean it reused a zombie and read reclaimed records.
 
 ```steps
 wait "sidebar = Alice #1"
@@ -181,5 +177,5 @@ click button "Back"
 click button "Deliver refresh"
 click button "Close sidebar"
 click button "Open profile"
-wait "(blank forever)"
+wait "name = Alice #3"
 ```

--- a/packages/relay-e2e-test/fixtures/queries/disposed-query-cache-entry.md
+++ b/packages/relay-e2e-test/fixtures/queries/disposed-query-cache-entry.md
@@ -1,0 +1,185 @@
+# BUG: a screen goes permanently blank after you leave it mid-refresh
+
+**This fixture records current, broken behaviour.** The snapshot below is the
+bug, not the goal. It exists so that the fix can be reviewed as a diff of the
+snapshot.
+
+The bug as a user would report it: *"If I open the profile, go back while it's
+refreshing, and open it again later, the name is just blank. No spinner, no
+error. It stays blank until I reload the page."*
+
+Underneath, `QueryResource` has handed the screen a **zombie** cache entry.
+
+The app has a sidebar showing the user, and a profile screen on
+`fetchPolicy: 'store-and-network'` — the usual "show what we have, refresh in
+the background" policy. Every step is an ordinary user action:
+
+1. The sidebar loads the user. The store now has the data, and the sidebar
+   holds a retain on it.
+2. The user opens the profile. It renders instantly from the store and starts a
+   background refresh. Because it rendered, `useLazyLoadQueryNode` attached a
+   permanent retain.
+3. The user goes back before the refresh lands. The effect cleanup disposes the
+   cache entry.
+4. The refresh lands. Regular (non-live) queries deliberately do **not** cancel
+   their request on dispose, so the observable is still subscribed and `next`
+   fires on the now-disposed entry. **This is the bug**: `next` calls
+   `_getOrCreateCacheEntry`, which re-inserts the disposed entry into the LRU
+   with refcount 0. No `useEffect` ever retained it, so none will ever release
+   it.
+5. The sidebar closes. It was the last retainer, so the store garbage-collects
+   the records. The zombie holds no retain, so nothing protects them.
+6. The user opens the profile again. It computes the same `cacheIdentifier`,
+   finds the zombie, and reuses it — **issuing no request at all**. The fragment
+   reader walks into the reclaimed records and `useLazyLoadQuery` returns
+   `undefined`. There is no fetch to wait for, no error to catch, and no
+   suspense to fall back to, so the screen renders blank and stays blank.
+
+Once a disposed entry stays disposed, step 6 will cache-miss, refetch, and
+render `Alice #3`. Until then the snapshot reads `(blank forever)`.
+
+## Relay Config
+
+```json title="relay.config.json"
+{
+  "src": "./",
+  "schema": "./schema.graphql",
+  "language": "typescript"
+}
+```
+
+## Server
+
+Each response is numbered so the rendered name says which request produced it.
+The first answers immediately, for the sidebar; every later one blocks on a
+gate the app opens by hand, so the fixture controls exactly when the
+outstanding refresh lands relative to the user going back.
+
+```ts title="server.ts"
+let openGate: () => void = () => {};
+const gate = new Promise<void>((resolve) => {
+  openGate = resolve;
+});
+
+/** Lets the app deliver the outstanding refresh on demand. */
+export function deliverPendingResponse(): void {
+  openGate();
+}
+
+let responsesServed = 0;
+
+/** @gqlType */
+export class User {
+  /** @gqlField */
+  name: string;
+
+  constructor(name: string) {
+    this.name = name;
+  }
+}
+
+/** @gqlQueryField */
+export async function user(): Promise<User> {
+  responsesServed++;
+  if (responsesServed > 1) {
+    await gate;
+  }
+  return new User(`Alice #${responsesServed}`);
+}
+```
+
+## App
+
+`gcReleaseBufferSize: 0` makes the collection in step 5 immediate rather than
+deferred. It changes when the records are reclaimed, not whether — any app busy
+enough to cycle the release buffer gets there on its own.
+
+```tsx title="App.tsx"
+import { Suspense, useState } from "react";
+import { RelayEnvironmentProvider, useLazyLoadQuery } from "react-relay";
+import { graphql, Environment, RecordSource, Store } from "relay-runtime";
+import { gratsNetwork } from "../GratsNetwork";
+import { deliverPendingResponse } from "./server";
+import { AppSidebarQuery } from "./__generated__/AppSidebarQuery.graphql";
+import { AppProfileQuery } from "./__generated__/AppProfileQuery.graphql";
+
+const testEnvironment = new Environment({
+  network: gratsNetwork,
+  store: new Store(new RecordSource(), { gcReleaseBufferSize: 0 }),
+});
+
+function Sidebar() {
+  const data = useLazyLoadQuery<AppSidebarQuery>(
+    graphql`
+      query AppSidebarQuery {
+        user {
+          name
+        }
+      }
+    `,
+    {},
+  );
+  return <div>sidebar = {data.user?.name}</div>;
+}
+
+function Profile() {
+  const data = useLazyLoadQuery<AppProfileQuery>(
+    graphql`
+      query AppProfileQuery {
+        user {
+          name
+        }
+      }
+    `,
+    {},
+    { fetchPolicy: "store-and-network" },
+  );
+  // `data?.` rather than `data.`: when the zombie is reused the hook returns
+  // `undefined` outright, so the ordinary `data.user` a real app would write
+  // throws `Cannot read properties of undefined`. Guarded here only so the
+  // fixture can render the symptom instead of crashing the tree.
+  return <div>name = {data?.user?.name ?? "(blank forever)"}</div>;
+}
+
+export default function TestApp() {
+  const [profileOpen, setProfileOpen] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(true);
+  return (
+    <RelayEnvironmentProvider environment={testEnvironment}>
+      <button onClick={() => setProfileOpen(true)}>Open profile</button>
+      <button onClick={() => setProfileOpen(false)}>Back</button>
+      <button onClick={() => deliverPendingResponse()}>Deliver refresh</button>
+      <button onClick={() => setSidebarOpen(false)}>Close sidebar</button>
+      {sidebarOpen ? (
+        <Suspense fallback={<div>sidebar loading</div>}>
+          <Sidebar />
+        </Suspense>
+      ) : null}
+      {profileOpen ? (
+        <Suspense fallback={<div>profile loading</div>}>
+          <Profile />
+        </Suspense>
+      ) : (
+        <div>no profile</div>
+      )}
+    </RelayEnvironmentProvider>
+  );
+}
+```
+
+## Steps
+
+The last visit is the assertion, and it currently asserts the bug. When the
+zombie is fixed this becomes `wait "name = Alice #3"` and the snapshot changes
+with it.
+
+```steps
+wait "sidebar = Alice #1"
+click button "Open profile"
+wait "name = Alice #1"
+click button "Back"
+click button "Deliver refresh"
+click button "Close sidebar"
+click button "Open profile"
+wait "(blank forever)"
+```

--- a/packages/relay-e2e-test/fixtures/queries/disposed-query-cache-entry.snap.md
+++ b/packages/relay-e2e-test/fixtures/queries/disposed-query-cache-entry.snap.md
@@ -1,0 +1,11 @@
+## Console
+
+```
+error: Warning: Relay: Expected to have been able to read non-null data for fragment `AppProfileQuery` declared in `useLazyLoadQuery()`, since fragment reference was non-null. Make sure that that `useLazyLoadQuery()`'s parent isn't holding on to and/or passing a fragment reference for data that has been deleted.
+```
+
+## HTML
+
+```html
+<button>Open profile</button><button>Back</button><button>Deliver refresh</button><button>Close sidebar</button><div>name = (blank forever)</div>
+```

--- a/packages/relay-e2e-test/fixtures/queries/disposed-query-cache-entry.snap.md
+++ b/packages/relay-e2e-test/fixtures/queries/disposed-query-cache-entry.snap.md
@@ -1,11 +1,5 @@
-## Console
-
-```
-error: Warning: Relay: Expected to have been able to read non-null data for fragment `AppProfileQuery` declared in `useLazyLoadQuery()`, since fragment reference was non-null. Make sure that that `useLazyLoadQuery()`'s parent isn't holding on to and/or passing a fragment reference for data that has been deleted.
-```
-
 ## HTML
 
 ```html
-<button>Open profile</button><button>Back</button><button>Deliver refresh</button><button>Close sidebar</button><div>name = (blank forever)</div>
+<button>Open profile</button><button>Back</button><button>Deliver refresh</button><button>Close sidebar</button><div>name = Alice #3</div>
 ```


### PR DESCRIPTION
**Demonstration, not a competing fix.** The fix commit here is @jwatzman's from #5317 — I applied it unchanged on top of the characterization test in #5405 so the effect is visible as a snapshot diff. Credit and review belong on #5317.

Stacked on #5405, so this branch contains two commits:

1. `Test: leaving a screen mid-refresh leaves a zombie QueryResource entry` — the fixture, asserting the *bug*. Same commit as #5405.
2. `Don't resurrect disposed QueryResource cache entries` — @jwatzman's fix, plus the fixture flipped to assert correct behaviour.

Look at the second commit on its own; that's the interesting diff.

### What the fix changes in the snapshot

```diff
-## Console
-
-```
-error: Warning: Relay: Expected to have been able to read non-null data for fragment
-`AppProfileQuery` declared in `useLazyLoadQuery()`, since fragment reference was
-non-null. Make sure that that `useLazyLoadQuery()`'s parent isn't holding on to
-and/or passing a fragment reference for data that has been deleted.
-```
-
 ## HTML
 
 ```html
-...<div>name = (blank forever)</div>
+...<div>name = Alice #3</div>
 ```
```

Two things go away, not one. The profile stops rendering blank, **and** Relay's warning disappears.

That warning is worth a second look. Relay already detects this corruption today — but the cause it suggests, *"`useLazyLoadQuery()`'s parent isn't holding on to and/or passing a fragment reference for data that has been deleted"*, is a red herring. Nothing is holding a stale fragment reference. The cache entry itself was resurrected after disposal, with refcount 0, and then reused. Anyone who has chased that warning has been sent to the wrong place.

### Suggested sequence

1. Land #5405 (test only, records current behaviour).
2. Rebase #5317 on top of it. Its diff then shows the snapshot flip above, which is a much stronger argument than the unit tests alone.
3. Close this PR — it exists only to show step 2's result ahead of time.

Full e2e suite is 14/14 with the fix applied.

Related: #5317, #5405, #5070.
