### PR TITLE
Support @defer and @stream in the e2e test suite

### DIFF
--- a/packages/relay-e2e-test/.llms/skills/relay-e2e-test/references/writing-fixtures.md
+++ b/packages/relay-e2e-test/.llms/skills/relay-e2e-test/references/writing-fixtures.md
@@ -130,6 +130,36 @@ Roles are [ARIA roles](https://testing-library.com/docs/queries/byrole/#api) (`b
 
 `wait` polls until a matching element appears (uses `findByText`/`findByRole`). Use it to wait for Suspense to resolve or for async data to arrive before snapshotting or interacting.
 
+## Incremental delivery (`@defer` / `@stream`)
+
+Both work with no per-fixture setup. Spread a fragment with `@defer`, or put
+`@stream(initialCount: N)` on a plural field, and the server delivers the rest
+in later payloads:
+
+```graphql
+query AppTestQuery {
+  user {
+    name
+    ...AppBioFragment @defer
+  }
+}
+```
+
+Give the deferred field an `async` resolver, or nothing is outstanding when the
+initial payload is sent.
+
+Do **not** declare the directives in a fixture. `runFixture.js` appends them to
+the generated `schema.graphql` and `GratsNetwork.ts` sets `enableDeferStream`.
+Declaring them under `schemaExtensions` is the trap: it compiles, but
+`skip_client_directives` then drops `@defer` from the printed query text, so the
+fixture passes with the deferred field silently empty.
+
+To assert on the *pending* state, have the resolver await a promise that client
+code resolves and drive it from a `steps` block; an `async` resolver alone
+settles a microtask later, so the fallback is a race. See
+`fixtures/defer/suspense-fallback.md` — server and client share a module realm,
+so `App.tsx` can import a non-schema `releaseBio()` from `./server`.
+
 ## Snapshots
 
 Snapshots are plain `.snap.md` files rather than jest's own `.snap` format, so they stay readable in review — but they follow jest's standard snapshot semantics:

--- a/packages/relay-e2e-test/GratsNetwork.ts
+++ b/packages/relay-e2e-test/GratsNetwork.ts
@@ -9,10 +9,15 @@ import { Network, Observable, GraphQLResponse } from "relay-runtime";
 import type { RelayObservable } from "relay-runtime/lib/network/RelayObservable";
 import type { AsyncExecutionResult, ExecutionResult } from "graphql";
 import type { PromiseOrValue } from "graphql/jsutils/PromiseOrValue";
-import { execute, subscribe, parse } from "graphql";
+import { execute, subscribe, parse, GraphQLSchema } from "graphql";
 import { getSchema } from "./schema";
 
-const executableSchema = getSchema();
+// graphql-js ignores `@defer`/`@stream` unless the schema sets this. It is
+// constructor-only and `toConfig()` drops it, hence the re-wrap.
+const executableSchema = new GraphQLSchema({
+  ...getSchema().toConfig(),
+  enableDeferStream: true,
+});
 
 // The async branch yields `AsyncExecutionResult`, not `ExecutionResult`: under
 // incremental delivery each payload after the first is an `ExecutionPatchResult`,
@@ -23,13 +28,22 @@ type GraphQLResult = PromiseOrValue<
   ExecutionResult | AsyncIterable<AsyncExecutionResult>
 >;
 
+// `@stream` ends with a bookkeeping-only `{hasNext: false}`, which is not a
+// `GraphQLResponse`; Relay warns "No data returned for operation". Completion
+// is signalled by the observable, so dropping it loses nothing.
+function isDeliverablePayload(value: AsyncExecutionResult): boolean {
+  return "data" in value || "errors" in value;
+}
+
 function toObservable(result: GraphQLResult): RelayObservable<GraphQLResponse> {
   return Observable.create<GraphQLResponse>((sink) => {
     (async () => {
       const resolved = await result;
       if (Symbol.asyncIterator in resolved) {
         for await (const value of resolved) {
-          sink.next(value as GraphQLResponse);
+          if (isDeliverablePayload(value)) {
+            sink.next(value as GraphQLResponse);
+          }
         }
       } else {
         sink.next(resolved as GraphQLResponse);

--- a/packages/relay-e2e-test/README.md
+++ b/packages/relay-e2e-test/README.md
@@ -55,6 +55,14 @@ yarn test:e2e --ci    # never write; a new or changed snapshot fails
 
 A new fixture's snapshot is written on a plain `yarn test:e2e`; a *changed* snapshot always fails unless `-u` is passed. Jest treats a CI environment as `--ci` automatically, so commit the generated `.snap.md` alongside its fixture.
 
+## Incremental delivery
+
+`@defer` and `@stream` work with no per-fixture setup: the suite pins graphql-js's
+`experimental-stream-defer` build, `GratsNetwork.ts` sets `enableDeferStream`, and
+the harness declares both directives on the generated schema. See the
+[writing guide](.llms/skills/relay-e2e-test/references/writing-fixtures.md#incremental-delivery-defer--stream),
+`fixtures/defer/` and `fixtures/stream/`.
+
 ## Typechecking
 
 Each fixture is typechecked with `tsc` after the Relay compiler runs, against the generated `__generated__/*.graphql.ts` artifacts and the `.d.ts` files `relay-runtime` and `react-relay` ship from this repo (wired up via generated `paths` in the fixture's tsconfig). Type errors are reported in a `## Type Errors` section of the snapshot rather than failing the test outright — see the [writing guide](.llms/skills/relay-e2e-test/references/writing-fixtures.md#type-errors).

--- a/packages/relay-e2e-test/fixtures/defer/basic.md
+++ b/packages/relay-e2e-test/fixtures/defer/basic.md
@@ -1,0 +1,113 @@
+# Deferred Fragment Spread
+
+A `@defer`red fragment spread arrives in a second payload and renders once that
+patch is normalized.
+
+Guards against a quiet failure: if `@defer` stops reaching the server, `bio`
+comes back inline but the artifact still expects a patch, so it renders empty
+rather than erroring.
+
+## Relay Config
+
+```json title="relay.config.json"
+{
+  "src": "./",
+  "schema": "./schema.graphql",
+  "language": "typescript"
+}
+```
+
+## Server
+
+`bio` is async, so it is not ready when the initial payload is sent. The harness
+declares `@defer` on the schema.
+
+```ts title="server.ts"
+/** @gqlType */
+class User {
+  /** @gqlField */
+  name: string = "Jordan";
+
+  /** @gqlField */
+  async bio(): Promise<string> {
+    return "Relay maintainer";
+  }
+}
+
+/** @gqlQueryField */
+export function user(): User {
+  return new User();
+}
+```
+
+## App
+
+```tsx title="App.tsx"
+import { Suspense } from "react";
+import {
+  RelayEnvironmentProvider,
+  useLazyLoadQuery,
+  useFragment,
+} from "react-relay";
+import { graphql, Environment } from "relay-runtime";
+import { gratsNetwork } from "../GratsNetwork";
+import { AppTestQuery } from "./__generated__/AppTestQuery.graphql";
+import { AppBioFragment$key } from "./__generated__/AppBioFragment.graphql";
+
+const testEnvironment = new Environment({ network: gratsNetwork });
+
+function Bio({ user }: { user: AppBioFragment$key }) {
+  const data = useFragment(
+    graphql`
+      fragment AppBioFragment on User {
+        bio
+      }
+    `,
+    user,
+  );
+  return <div>Bio: {data.bio}</div>;
+}
+
+function App() {
+  const data = useLazyLoadQuery<AppTestQuery>(
+    graphql`
+      query AppTestQuery {
+        user {
+          name
+          ...AppBioFragment @defer
+        }
+      }
+    `,
+    {},
+  );
+  const user = data.user;
+  if (user == null) {
+    return <div>No user</div>;
+  }
+  return (
+    <div>
+      <div>Name: {user.name}</div>
+      <Suspense fallback={<div>Loading bio...</div>}>
+        <Bio user={user} />
+      </Suspense>
+    </div>
+  );
+}
+
+export default function TestApp() {
+  return (
+    <RelayEnvironmentProvider environment={testEnvironment}>
+      <Suspense fallback={<div>Loading...</div>}>
+        <App />
+      </Suspense>
+    </RelayEnvironmentProvider>
+  );
+}
+```
+
+## Steps
+
+```steps
+wait "Name: Jordan"
+wait "Bio: Relay maintainer"
+```

--- a/packages/relay-e2e-test/fixtures/defer/basic.snap.md
+++ b/packages/relay-e2e-test/fixtures/defer/basic.snap.md
@@ -1,0 +1,5 @@
+## HTML
+
+```html
+<div><div>Name: Jordan</div><div>Bio: Relay maintainer</div></div>
+```

--- a/packages/relay-e2e-test/fixtures/defer/suspense-fallback.md
+++ b/packages/relay-e2e-test/fixtures/defer/suspense-fallback.md
@@ -1,0 +1,128 @@
+# Deferred Fragment Suspends Its Own Boundary
+
+While a `@defer`red patch is outstanding, the fragment's own `Suspense`
+boundary shows its fallback while the rest of the component has rendered.
+
+The resolver blocks until a click, so the pending state is not a race — a bare
+`async` resolver settles a microtask later and only the resolved state would be
+observable.
+
+## Relay Config
+
+```json title="relay.config.json"
+{
+  "src": "./",
+  "schema": "./schema.graphql",
+  "language": "typescript"
+}
+```
+
+## Server
+
+`releaseBio` is a plain export, not a mutation: server and client share a module
+realm, so the client can drive server timing without a second round trip.
+
+```ts title="server.ts"
+let release: () => void;
+
+const bioReady = new Promise<void>((resolve) => {
+  release = resolve;
+});
+
+/** Lets the deferred `bio` resolver finish. Not part of the schema. */
+export function releaseBio(): void {
+  release();
+}
+
+/** @gqlType */
+class User {
+  /** @gqlField */
+  name: string = "Jordan";
+
+  /** @gqlField */
+  async bio(): Promise<string> {
+    await bioReady;
+    return "Relay maintainer";
+  }
+}
+
+/** @gqlQueryField */
+export function user(): User {
+  return new User();
+}
+```
+
+## App
+
+```tsx title="App.tsx"
+import { Suspense } from "react";
+import {
+  RelayEnvironmentProvider,
+  useLazyLoadQuery,
+  useFragment,
+} from "react-relay";
+import { graphql, Environment } from "relay-runtime";
+import { gratsNetwork } from "../GratsNetwork";
+import { releaseBio } from "./server";
+import { AppTestQuery } from "./__generated__/AppTestQuery.graphql";
+import { AppBioFragment$key } from "./__generated__/AppBioFragment.graphql";
+
+const testEnvironment = new Environment({ network: gratsNetwork });
+
+function Bio({ user }: { user: AppBioFragment$key }) {
+  const data = useFragment(
+    graphql`
+      fragment AppBioFragment on User {
+        bio
+      }
+    `,
+    user,
+  );
+  return <div>Bio: {data.bio}</div>;
+}
+
+function App() {
+  const data = useLazyLoadQuery<AppTestQuery>(
+    graphql`
+      query AppTestQuery {
+        user {
+          name
+          ...AppBioFragment @defer
+        }
+      }
+    `,
+    {},
+  );
+  const user = data.user;
+  if (user == null) {
+    return <div>No user</div>;
+  }
+  return (
+    <div>
+      <div>Name: {user.name}</div>
+      <button onClick={() => releaseBio()}>Reveal bio</button>
+      <Suspense fallback={<div>Loading bio...</div>}>
+        <Bio user={user} />
+      </Suspense>
+    </div>
+  );
+}
+
+export default function TestApp() {
+  return (
+    <RelayEnvironmentProvider environment={testEnvironment}>
+      <Suspense fallback={<div>Loading...</div>}>
+        <App />
+      </Suspense>
+    </RelayEnvironmentProvider>
+  );
+}
+```
+
+## Steps
+
+```steps
+wait "Loading bio..."
+click button "Reveal bio"
+wait "Bio: Relay maintainer"
+```

--- a/packages/relay-e2e-test/fixtures/defer/suspense-fallback.snap.md
+++ b/packages/relay-e2e-test/fixtures/defer/suspense-fallback.snap.md
@@ -1,0 +1,5 @@
+## HTML
+
+```html
+<div><div>Name: Jordan</div><button>Reveal bio</button><div>Bio: Relay maintainer</div></div>
+```

--- a/packages/relay-e2e-test/fixtures/stream/list-field.md
+++ b/packages/relay-e2e-test/fixtures/stream/list-field.md
@@ -1,0 +1,138 @@
+# Streamed List Field
+
+`@stream(initialCount: 1)` on a plural field: the initial payload carries the
+first item and each later item arrives as its own patch addressed by list index
+(`path: ["user", "friends", 1]`).
+
+The generator blocks on a client-released permit between items, so each patch is
+observed on its own rather than the list appearing complete in one go.
+
+Also covers the one place `@stream` differs from `@defer`: it always ends with a
+bookkeeping-only `{hasNext: false}` payload that `GratsNetwork` has to drop.
+Forwarding it adds a `QueryResource` warning to the snapshot, so a regression
+shows up as a snapshot diff.
+
+## Relay Config
+
+```json title="relay.config.json"
+{
+  "src": "./",
+  "schema": "./schema.graphql",
+  "language": "typescript"
+}
+```
+
+## Server
+
+`friends` is an async generator, which is what lets graphql-js send items one at
+a time. `releaseNextFriend` is a plain export, not a mutation.
+
+Permits are counted rather than awaited directly, so a click that lands before
+the generator asks for the next item is remembered instead of lost.
+
+```ts title="server.ts"
+let permits = 0;
+let notify: (() => void) | null = null;
+
+/** Lets the next streamed friend through. Not part of the schema. */
+export function releaseNextFriend(): void {
+  permits++;
+  const waiter = notify;
+  notify = null;
+  waiter?.();
+}
+
+async function awaitPermit(): Promise<void> {
+  while (permits === 0) {
+    await new Promise<void>((resolve) => {
+      notify = resolve;
+    });
+  }
+  permits--;
+}
+
+/** @gqlType */
+class Friend {
+  /** @gqlField */
+  name: string;
+  constructor(name: string) {
+    this.name = name;
+  }
+}
+
+/** @gqlType */
+class User {
+  /** @gqlField */
+  name: string = "Jordan";
+
+  /** @gqlField */
+  async *friends(): AsyncIterable<Friend> {
+    yield new Friend("Bea");
+    await awaitPermit();
+    yield new Friend("Cid");
+    await awaitPermit();
+    yield new Friend("Dot");
+  }
+}
+
+/** @gqlQueryField */
+export function user(): User {
+  return new User();
+}
+```
+
+## App
+
+```tsx title="App.tsx"
+import { Suspense } from "react";
+import { RelayEnvironmentProvider, useLazyLoadQuery } from "react-relay";
+import { graphql, Environment } from "relay-runtime";
+import { gratsNetwork } from "../GratsNetwork";
+import { releaseNextFriend } from "./server";
+import { AppTestQuery } from "./__generated__/AppTestQuery.graphql";
+
+const testEnvironment = new Environment({ network: gratsNetwork });
+
+function App() {
+  const data = useLazyLoadQuery<AppTestQuery>(
+    graphql`
+      query AppTestQuery {
+        user {
+          name
+          friends @stream(initialCount: 1) {
+            name
+          }
+        }
+      }
+    `,
+    {},
+  );
+  const names = (data.user?.friends ?? []).map((f) => f?.name).join(", ");
+  return (
+    <div>
+      <div>friends = {names}</div>
+      <button onClick={() => releaseNextFriend()}>Next friend</button>
+    </div>
+  );
+}
+
+export default function TestApp() {
+  return (
+    <RelayEnvironmentProvider environment={testEnvironment}>
+      <Suspense fallback={<div>Loading...</div>}>
+        <App />
+      </Suspense>
+    </RelayEnvironmentProvider>
+  );
+}
+```
+
+## Steps
+
+```steps
+wait "friends = Bea"
+click button "Next friend"
+wait "friends = Bea, Cid"
+click button "Next friend"
+wait "friends = Bea, Cid, Dot"
+```

--- a/packages/relay-e2e-test/fixtures/stream/list-field.snap.md
+++ b/packages/relay-e2e-test/fixtures/stream/list-field.snap.md
@@ -1,0 +1,5 @@
+## HTML
+
+```html
+<div><div>friends = Bea, Cid, Dot</div><button>Next friend</button></div>
+```

--- a/packages/relay-e2e-test/src/runFixture.js
+++ b/packages/relay-e2e-test/src/runFixture.js
@@ -206,6 +206,27 @@ async function typecheck(tempDir: string): Promise<Array<string>> {
   return output.split('\n').map(line => scrubAbsolutePaths(line, tempDir));
 }
 
+/**
+ * Mirrors graphql-js's own defer/stream directives.
+ *
+ * These have to land in the *server* schema. Via `schemaExtensions` they still
+ * compile, but `skip_client_directives` then drops `@defer` from the printed
+ * query text, so no patch is ever sent and the fixture passes with its deferred
+ * field silently empty.
+ */
+const INCREMENTAL_DELIVERY_SDL = `
+directive @defer(
+  label: String
+  if: Boolean = true
+) on FRAGMENT_SPREAD | INLINE_FRAGMENT
+
+directive @stream(
+  label: String
+  initialCount: Int = 0
+  if: Boolean = true
+) on FIELD
+`;
+
 export async function runFixture(tempDir: string): Promise<Array<string>> {
   const tsconfigPath = path.join(tempDir, 'tsconfig.json');
   const relayConfigPath = path.join(tempDir, 'template', 'relay.config.json');
@@ -214,6 +235,13 @@ export async function runFixture(tempDir: string): Promise<Array<string>> {
 
   // 1. Run grats to generate template/schema.graphql + schema.ts
   await run(gratsBin, ['--tsconfig', tsconfigPath]);
+
+  // 1b. Grats has no reason to emit these, but relay-compiler rejects `@defer`
+  // as an unknown directive without them.
+  await fs.promises.appendFile(
+    path.join(tempDir, 'template', 'schema.graphql'),
+    INCREMENTAL_DELIVERY_SDL,
+  );
 
   // 2. Run relay-compiler to generate __generated__/ artifacts
   await run(relayBin, [relayConfigPath], {


### PR DESCRIPTION
Adds `@defer`/`@stream` support to the markdown-driven e2e suite, plus three fixtures covering it.

Incremental delivery did not work in these fixtures, and neither reason it did not work was loud.

### The compiler stripped `@defer` from the query text

relay-compiler does not define `@defer`/`@stream` — it reads them off the schema, and it has to be the **server** schema. Grats has no reason to emit them (they are executor-level, not part of anyone's resolvers), so `runFixture` now appends the definitions to the generated `schema.graphql` between the Grats and relay-compiler steps.

Supplying them through `schemaExtensions` instead does compile, which is the trap: `skip_client_directives` then strips the directive out of the printed query text as a client-only directive, so the server is never asked to defer. The field comes back inline while the generated artifact still holds a `Defer` node waiting for a patch that never arrives, so the field reads as missing. The fixture passes with its deferred content silently empty.

### graphql-js ignored the directive regardless

`collectFields` checks `schema._enableDeferStream` and returns before it ever looks at `@defer`. The flag only takes effect through the `GraphQLSchema` constructor and does not round-trip through `toConfig()`, so `GratsNetwork` re-wraps the Grats schema to turn it on.

### Trailing payload

`GratsNetwork` also drops graphql-js's closing `{hasNext: false}` payload, which carries neither `data` nor `errors` and so is not a `GraphQLResponse`. Relay reported it as `No data returned for operation` and logged a warning. Nothing is lost: Relay learns the request finished when the observable completes. `@defer` rarely hits this — graphql-js folds `hasNext: false` into the final patch when it knows that patch is last — but `@stream` emits the trailing payload every time.

## Fixtures

| Fixture | Covers |
|---|---|
| `defer/basic` | Deferred fragment renders once its patch is normalized |
| `defer/suspense-fallback` | Fallback is on screen while the patch is outstanding |
| `stream/list-field` | Streamed list items; the trailing-payload path |

Fixtures need no per-fixture setup now — spread with `@defer` and give the field an `async` resolver.

`defer/suspense-fallback` uses a technique worth flagging in review: an `async` resolver settles a microtask later, so asserting on the pending state would be a race. Instead `server.ts` exports a plain non-schema `releaseBio()` that a button calls, since fixture server and client share a module realm. That makes `wait "Loading bio..."` deterministic. Documented in the writing guide.

`@stream` is included because the graphql-js flag enables both; declaring only `@defer` would leave half of it enabled and untested. The stream fixture is what caught the trailing-payload bug.

## Test plan

`yarn test:e2e` — the three new fixtures pass, and the rest of the suite is unchanged by the harness edits (verified by stashing them and re-running).

Four fixtures (`errors/nested-catch-field-error{,-flag-enabled}`, `pagination/root-catch-{load-next,refetch}`) fail in my working tree, but they fail identically without these changes — unrelated in-progress local work, not caused by this PR and not touched by it.
