### PR TITLE
Add failing e2e fixture: PreloadedQuery loses its TQuery for inference

### DIFF
--- a/packages/relay-e2e-test/fixtures/typechecking/preloaded-query-inference.md
+++ b/packages/relay-e2e-test/fixtures/typechecking/preloaded-query-inference.md
@@ -1,0 +1,123 @@
+# PreloadedQuery Type Inference
+
+`usePreloadedQuery` is declared as
+
+```ts
+function usePreloadedQuery<TQuery extends OperationType>(
+    gqlQuery: GraphQLTaggedNode,
+    preloadedQuery: PreloadedQuery<TQuery>,
+): TQuery['response'];
+```
+
+The first argument is an opaque `GraphQLTaggedNode`, so the only place `TQuery`
+can come from is the `PreloadedQuery<TQuery>` parameter. A component that takes
+its query reference as a prop typed `PreloadedQuery<AppTestQuery>` — the shape
+the [preloaded queries guide][guide] documents — should therefore get
+`AppTestQuery$data` back without repeating the type argument at the call site.
+
+It does not. `PreloadedQuery` is declared as a *type alias* over an anonymous
+`Readonly<{...}>`, so by the time inference runs the alias has been erased and
+there is no `PreloadedQuery<AppTestQuery>` reference left to match against
+`PreloadedQuery<TQuery>`. Structural inference is the only route left, and
+`TQuery` appears in exactly one property — `variables: VariablesOf<TQuery>` —
+behind an indexed access that TypeScript cannot invert. `TQuery` is inferred as
+`OperationType`, and `data` comes back as that type's `response`, which is
+`unknown`.
+
+Runtime is unaffected: the name renders, and the `wait` step below passes. Only
+the typecheck sees it.
+
+This regressed in v21 — the declarations Relay now ships were adapted from
+DefinitelyTyped's `@types/react-relay`, where `PreloadedQuery` was an
+`interface`. An interface is a named declaration, so a value typed
+`PreloadedQuery<AppTestQuery>` stays a reference to it and inference matches the
+two references directly, never needing to look inside. See
+[#5361](https://github.com/facebook/relay/issues/5361) and the fix proposed in
+[#5362](https://github.com/facebook/relay/pull/5362).
+
+[guide]: https://relay.dev/docs/guided-tour/rendering/queries/#rendering-queries
+
+## Relay Config
+
+```json title="relay.config.json"
+{
+  "src": "./",
+  "schema": "./schema.graphql",
+  "language": "typescript"
+}
+```
+
+## Server
+
+```ts title="server.ts"
+/** @gqlType */
+type User = {
+  /** @gqlField */
+  name: string;
+};
+
+/** @gqlQueryField */
+export function viewer(): User {
+  return { name: "Jordan" };
+}
+```
+
+## App
+
+```tsx title="App.tsx"
+import { Suspense } from "react";
+import {
+  PreloadedQuery,
+  RelayEnvironmentProvider,
+  usePreloadedQuery,
+  useQueryLoader,
+} from "react-relay";
+import { graphql, Environment } from "relay-runtime";
+import { gratsNetwork } from "../GratsNetwork";
+import { AppTestQuery } from "./__generated__/AppTestQuery.graphql";
+
+const testEnvironment = new Environment({ network: gratsNetwork });
+
+const query = graphql`
+  query AppTestQuery {
+    viewer {
+      name
+    }
+  }
+`;
+
+function NameDisplay({ queryRef }: { queryRef: PreloadedQuery<AppTestQuery> }) {
+  // No explicit type argument: `TQuery` should be inferred from `queryRef`,
+  // making `data` an `AppTestQuery$data`. It is not, so reading `viewer` is a
+  // type error.
+  const data = usePreloadedQuery(query, queryRef);
+  return <div>{data.viewer?.name}</div>;
+}
+
+function Loader() {
+  const [queryRef, loadQuery] = useQueryLoader<AppTestQuery>(query);
+  if (queryRef == null) {
+    return <button onClick={() => loadQuery({})}>Load</button>;
+  }
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <NameDisplay queryRef={queryRef} />
+    </Suspense>
+  );
+}
+
+export default function TestApp() {
+  return (
+    <RelayEnvironmentProvider environment={testEnvironment}>
+      <Loader />
+    </RelayEnvironmentProvider>
+  );
+}
+```
+
+## Steps
+
+```steps
+click button "Load"
+wait "Jordan"
+```

--- a/packages/relay-e2e-test/fixtures/typechecking/preloaded-query-inference.snap.md
+++ b/packages/relay-e2e-test/fixtures/typechecking/preloaded-query-inference.snap.md
@@ -1,0 +1,11 @@
+## Type Errors
+
+```
+template/App.tsx(27,16): error TS18046: 'data' is of type 'unknown'.
+```
+
+## HTML
+
+```html
+<div>Jordan</div>
+```


### PR DESCRIPTION
A repro-only change. Adds an e2e fixture that characterises #5361 — the v21 regression in TypeScript inference through `PreloadedQuery` — so the bug is pinned down by a test before a fix lands. #5362 proposes a fix; this PR deliberately does not change any declarations.

### The bug

`usePreloadedQuery`'s first argument is an opaque `GraphQLTaggedNode`, so `TQuery` can only be inferred from the `PreloadedQuery<TQuery>` parameter. A component that takes its query reference as a prop typed `PreloadedQuery<AppTestQuery>` — the shape the [preloaded queries guide](https://relay.dev/docs/guided-tour/rendering/queries/#rendering-queries) documents — should get `AppTestQuery$data` back without restating the type argument.

It gets `unknown`. `PreloadedQuery` is a type alias over an anonymous `Readonly<{...}>`, so the alias is erased before inference runs and there is no `PreloadedQuery<AppTestQuery>` reference left to match against `PreloadedQuery<TQuery>`. Structurally `TQuery` appears in exactly one property — `variables: VariablesOf<TQuery>` — behind an indexed access TypeScript cannot invert. `TQuery` falls back to the `OperationType` constraint, whose `response` is `unknown`.

Before v21 the declarations came from DefinitelyTyped's `@types/react-relay`, where `PreloadedQuery` was an `interface`. An interface is a named declaration, so a value typed `PreloadedQuery<AppTestQuery>` stays a reference to it and inference matches the two references directly, never needing to look inside.

### Why an e2e fixture

Runtime is unaffected, which is why nothing else catches this — the fixture renders `Jordan` and its `wait` step passes. The typecheck is the only signal, so this lands as a characterization: the `## Type Errors` section of the snapshot records the bug.

```
## Type Errors

template/App.tsx(27,16): error TS18046: 'data' is of type 'unknown'.

## HTML

<div>Jordan</div>
```

Same pattern as `fixtures/typechecking/unselected-field.md`. A fix flips the snapshot by deleting that section, which is the diff a reviewer wants to see.

### Verification

Run locally against this branch:

- As-is: full suite green, 14/14 under `--ci`. The new fixture's snapshot records the type error.
- With #5362's patch applied: the `## Type Errors` section disappears — the snapshot diff is exactly that removal — and the other 13 fixtures stay green. So the fix resolves this and regresses nothing else in the suite.

Fixes nothing on its own; #5361 stays open until a fix lands.