### PR TITLE
QueryResource: preserve replacement entries when an evicted retain is disposed

### DIFF
--- a/packages/react-relay/relay-hooks/QueryResource.js
+++ b/packages/react-relay/relay-hooks/QueryResource.js
@@ -369,7 +369,9 @@ class QueryResourceImpl {
   }
 
   _clearCacheEntry = (cacheEntry: QueryResourceCacheEntry): void => {
-    this._cache.delete(cacheEntry.cacheIdentifier);
+    if (this._cache.get(cacheEntry.cacheIdentifier) === cacheEntry) {
+      this._cache.delete(cacheEntry.cacheIdentifier);
+    }
   };
 
   _getOrCreateCacheEntry(

--- a/packages/react-relay/relay-hooks/__tests__/QueryResource-disposal-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/QueryResource-disposal-test.js
@@ -1,0 +1,79 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+import type {GraphQLResponse} from 'relay-runtime';
+
+const {getQueryResourceForEnvironment} = require('../QueryResource');
+const gqlQuery = require('./__generated__/QueryResourceTest2Query.graphql');
+const {Observable, createOperationDescriptor} = require('relay-runtime');
+const {createMockEnvironment} = require('relay-test-utils-internal');
+
+describe('QueryResource cache entry disposal', () => {
+  let resource;
+  let operation;
+
+  beforeEach(() => {
+    const environment = createMockEnvironment();
+    resource = getQueryResourceForEnvironment(environment);
+    operation = createOperationDescriptor(gqlQuery, {id: 'target'});
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it('does not delete a replacement when an evicted retained entry releases', () => {
+    const observable = Observable.create<GraphQLResponse>(() => {});
+    const firstResult = resource.prepare(
+      operation,
+      observable,
+      'store-only',
+      'full',
+    );
+    const firstRetain = resource.retain(firstResult);
+
+    // Keep the real 1000-entry cache capacity; an LRU eviction does not release
+    // the first component's independent retain.
+    for (let index = 0; index < 1000; index++) {
+      resource.prepare(
+        operation,
+        observable,
+        'store-only',
+        'full',
+        null,
+        'other-' + index,
+      );
+    }
+    const replacementResult = resource.prepare(
+      operation,
+      observable,
+      'store-only',
+      'full',
+    );
+    const replacementRetain = resource.retain(replacementResult);
+    const replacement = resource.TESTS_ONLY__getCacheEntry(
+      operation,
+      'store-only',
+      'full',
+    );
+
+    firstRetain.dispose();
+    expect(
+      resource.TESTS_ONLY__getCacheEntry(operation, 'store-only', 'full'),
+    ).toBe(replacement);
+    replacementRetain.dispose();
+    expect(
+      resource.TESTS_ONLY__getCacheEntry(operation, 'store-only', 'full'),
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
An LRU-evicted QueryResource entry can still have a permanent retain. If another render creates an entry with the same cache identifier, disposing the old retain currently deletes that replacement from the cache. The replacement's component is still mounted and retained, but subsequent prepares cannot reuse its entry.

In an application that prepares enough queries to reach the LRU capacity, components using an evicted entry and its replacement can have overlapping lifetimes. Normal cleanup of the earlier component should not break cache reuse for the current one. This fix prevents an old retain's disposal from turning the current entry into a cache miss on the next prepare().

This change makes _clearCacheEntry delete the key only if it still points to the entry being released. The replacement's own final release continues to remove it normally.

The regression uses the real 1,000-entry LRU capacity and store-only prepares. It retains the original entry, evicts it through cache pressure, retains a replacement under the same key, and disposes the original retain. It asserts that the replacement survives and that its own final disposal clears the key.

Validation against main 52c26aed65a496182f2fa978f9911db5be4f652d:

The new regression fails on unmodified main and passes with this change.
The new regression plus all 64 existing QueryResource tests pass (65 tests).
Full JavaScript suite: 246 suites, 3,777 tests pass, 20 skipped.
Flow: zero errors. TypeScript, dependency checks, ESLint, and Prettier pass.
There are no public API changes.