### PR TITLE
QueryResource: keep fetch callbacks scoped to their cache entry

### DIFF
--- a/packages/react-relay/relay-hooks/QueryResource.js
+++ b/packages/react-relay/relay-hooks/QueryResource.js
@@ -444,13 +444,17 @@ class QueryResourceImpl {
       }
     }
 
+    // Keep callbacks attached to the entry owned by this fetch. Looking up an
+    // entry by key after disposal can recreate it or update a newer entry.
+    let cacheEntry: ?QueryResourceCacheEntry = null;
+
     // NOTE: If this value is false, we will cache a promise for this
     // query, which means we will suspend here at this query root.
     // If it's true, we will cache the query resource and allow rendering to
     // continue.
     if (shouldAllowRender) {
       const queryResult = getQueryResult(operation, cacheIdentifier);
-      const cacheEntry = createCacheEntry(
+      cacheEntry = createCacheEntry(
         cacheIdentifier,
         operation,
         queryAvailability,
@@ -467,7 +471,6 @@ class QueryResourceImpl {
       fetchObservable.subscribe({
         start: subscription => {
           networkSubscription = subscription;
-          const cacheEntry = this._cache.get(cacheIdentifier);
           if (cacheEntry) {
             cacheEntry.setNetworkSubscription(networkSubscription);
           }
@@ -486,13 +489,15 @@ class QueryResourceImpl {
           }
         },
         next: () => {
-          const cacheEntry = this._getOrCreateCacheEntry(
-            cacheIdentifier,
-            operation,
-            queryAvailability,
-            queryResult,
-            networkSubscription,
-          );
+          if (cacheEntry == null) {
+            cacheEntry = this._getOrCreateCacheEntry(
+              cacheIdentifier,
+              operation,
+              queryAvailability,
+              queryResult,
+              networkSubscription,
+            );
+          }
           cacheEntry.processedPayloadsCount += 1;
           cacheEntry.setValue(queryResult);
           resolveNetworkPromise();
@@ -504,21 +509,25 @@ class QueryResourceImpl {
           }
         },
         error: error => {
-          const cacheEntry = this._getOrCreateCacheEntry(
-            cacheIdentifier,
-            operation,
-            queryAvailability,
-            error,
-            networkSubscription,
-          );
+          if (cacheEntry == null) {
+            cacheEntry = this._getOrCreateCacheEntry(
+              cacheIdentifier,
+              operation,
+              queryAvailability,
+              error,
+              networkSubscription,
+            );
+          }
+
+          const currentCacheEntry = cacheEntry;
 
           // If, this is the first thing we receive for the query,
           // before any other payload handled is error, we will cache and
           // re-throw that error later.
 
           // We will ignore errors for any incremental payloads we receive.
-          if (cacheEntry.processedPayloadsCount === 0) {
-            cacheEntry.setValue(error);
+          if (currentCacheEntry.processedPayloadsCount === 0) {
+            currentCacheEntry.setValue(error);
           } else {
             // TODO:T92030819 Remove this warning and actually throw the network error
             // To complete this task we need to have a way of precisely tracking suspendable points
@@ -532,7 +541,7 @@ class QueryResourceImpl {
           resolveNetworkPromise();
 
           networkSubscription = null;
-          cacheEntry.setNetworkSubscription(null);
+          currentCacheEntry.setNetworkSubscription(null);
           const observerError = observer?.error;
           observerError && observerError(error);
         },
@@ -540,7 +549,6 @@ class QueryResourceImpl {
           resolveNetworkPromise();
 
           networkSubscription = null;
-          const cacheEntry = this._cache.get(cacheIdentifier);
           if (cacheEntry) {
             cacheEntry.setNetworkSubscription(null);
           }
@@ -550,7 +558,6 @@ class QueryResourceImpl {
         unsubscribe: observer?.unsubscribe,
       });
 
-      let cacheEntry = this._cache.get(cacheIdentifier);
       if (!cacheEntry) {
         const networkPromise = new Promise<void>(resolve => {
           resolveNetworkPromise = resolve;
@@ -574,15 +581,15 @@ class QueryResourceImpl {
       const observerComplete = observer?.complete;
       observerComplete && observerComplete();
     }
-    const cacheEntry = this._cache.get(cacheIdentifier);
+    const resultCacheEntry = cacheEntry;
     invariant(
-      cacheEntry != null,
+      resultCacheEntry != null,
       'Relay: Expected to have cached a result when attempting to fetch query.' +
         "If you're seeing this, this is likely a bug in Relay.",
     );
     environment.__log({
       name: 'queryresource.fetch',
-      resourceID: cacheEntry.id,
+      resourceID: resultCacheEntry.id,
       operation,
       profilerContext,
       fetchPolicy,
@@ -590,7 +597,7 @@ class QueryResourceImpl {
       queryAvailability,
       shouldFetch,
     });
-    return cacheEntry;
+    return resultCacheEntry;
   }
 }
 

--- a/packages/react-relay/relay-hooks/__tests__/QueryResource-fetch-ownership-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/QueryResource-fetch-ownership-test.js
@@ -144,16 +144,19 @@ describe('QueryResource fetch ownership and GC recovery', () => {
       'partial',
     );
     resource.retain(firstResult).dispose();
+    const observer = {next: jest.fn(), complete: jest.fn()};
     const secondResult = resource.prepare(
       operation,
       fetchQuery(environment, operation),
       'store-and-network',
       'partial',
-      null,
+      observer,
       'replacement',
     );
     const retained = resource.retain(secondResult);
     expect(environment.mock.getAllOperations()).toHaveLength(1);
+    expect(observer.next).not.toHaveBeenCalled();
+    expect(observer.complete).not.toHaveBeenCalled();
 
     environment.mock.resolve(operation, {
       data: {node: {__typename: 'User', id: 'target', name: 'Shared result'}},
@@ -176,6 +179,12 @@ describe('QueryResource fetch ownership and GC recovery', () => {
         ),
       ).getValue(),
     ).toEqual(secondResult);
+    expect(observer.next).toHaveBeenCalledTimes(1);
+    expect(observer.next.mock.calls[0][0]).toMatchObject({
+      isMissingData: false,
+      data: {node: {id: 'target', name: 'Shared result'}},
+    });
+    expect(observer.complete).toHaveBeenCalledTimes(1);
     expect(environment.lookup(operation.fragment).data).toMatchObject({
       node: {name: 'Shared result'},
     });
@@ -184,14 +193,16 @@ describe('QueryResource fetch ownership and GC recovery', () => {
 
   it.each(['next', 'error'])(
     'does not overwrite a replacement entry with an older fetch %s',
-    event => {
+    async event => {
       let firstSink: ?Sink<GraphQLResponse>;
       const first = Observable.create<GraphQLResponse>(value => {
         firstSink = value;
       });
-      captureSuspense(() =>
+      const oldPending = captureSuspense(() =>
         resource.prepare(operation, first, 'network-only', 'full'),
       );
+      const oldSettled = jest.fn();
+      oldPending.then(oldSettled);
       jest.runAllTimers();
 
       let secondSink: ?Sink<GraphQLResponse>;
@@ -204,6 +215,11 @@ describe('QueryResource fetch ownership and GC recovery', () => {
       const replacement = nullthrows(
         resource.TESTS_ONLY__getCacheEntry(operation, 'network-only', 'full'),
       );
+      const replacementSettled = jest.fn();
+      pending.then(replacementSettled);
+      await Promise.resolve();
+      expect(oldSettled).not.toHaveBeenCalled();
+      expect(replacementSettled).not.toHaveBeenCalled();
 
       if (event === 'next') {
         nullthrows(firstSink).next({data: {}});
@@ -211,9 +227,62 @@ describe('QueryResource fetch ownership and GC recovery', () => {
         nullthrows(firstSink).error(new Error('Old fetch failed'));
       }
 
+      await Promise.resolve();
+      expect(oldSettled).toHaveBeenCalledTimes(1);
+      expect(replacementSettled).not.toHaveBeenCalled();
       expect(replacement.getValue()).toBe(pending);
+
       nullthrows(secondSink).next({data: {}});
-      expect(replacement.getValue()).not.toBe(pending);
+      await Promise.resolve();
+      expect(replacementSettled).toHaveBeenCalledTimes(1);
+      expect(replacement.getValue()).toMatchObject({
+        operation,
+        fragmentNode: operation.fragment.node,
+      });
+      expect(resource.prepare(operation, second, 'network-only', 'full')).toBe(
+        replacement.getValue(),
+      );
+    },
+  );
+
+  it.each(['next', 'error', 'complete'])(
+    'settles the suspended render promise after asynchronous %s',
+    async event => {
+      let sink: ?Sink<GraphQLResponse>;
+      const observable = Observable.create<GraphQLResponse>(value => {
+        sink = value;
+      });
+      const pending = captureSuspense(() =>
+        resource.prepare(operation, observable, 'network-only', 'full'),
+      );
+      const settled = jest.fn();
+      pending.then(settled);
+      await Promise.resolve();
+      expect(settled).not.toHaveBeenCalled();
+
+      const error = new Error('Asynchronous transport error');
+      if (event === 'next') {
+        nullthrows(sink).next({data: {}});
+      } else if (event === 'error') {
+        nullthrows(sink).error(error);
+      } else {
+        nullthrows(sink).complete();
+      }
+
+      // Flush Promise reactions without waiting for an unresolved promise to
+      // time out: missing wake-ups must fail at this assertion.
+      await Promise.resolve();
+      expect(settled).toHaveBeenCalledTimes(1);
+      expect(settled).toHaveBeenCalledWith(undefined);
+      if (event === 'next') {
+        expect(
+          resource.prepare(operation, observable, 'network-only', 'full'),
+        ).toMatchObject({operation, fragmentNode: operation.fragment.node});
+      } else if (event === 'error') {
+        expect(() =>
+          resource.prepare(operation, observable, 'network-only', 'full'),
+        ).toThrow(error);
+      }
     },
   );
 

--- a/packages/react-relay/relay-hooks/__tests__/QueryResource-fetch-ownership-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/QueryResource-fetch-ownership-test.js
@@ -232,78 +232,49 @@ describe('QueryResource fetch ownership and GC recovery', () => {
       expect(replacementSettled).not.toHaveBeenCalled();
       expect(replacement.getValue()).toBe(pending);
 
-      nullthrows(secondSink).next({data: {}});
+      const replacementError = new Error('Replacement fetch failed');
+      if (event === 'next') {
+        nullthrows(secondSink).next({data: {}});
+      } else {
+        nullthrows(secondSink).error(replacementError);
+      }
       await Promise.resolve();
       expect(replacementSettled).toHaveBeenCalledTimes(1);
-      expect(replacement.getValue()).toMatchObject({
-        operation,
-        fragmentNode: operation.fragment.node,
-      });
-      expect(resource.prepare(operation, second, 'network-only', 'full')).toBe(
-        replacement.getValue(),
-      );
-    },
-  );
-
-  it.each(['next', 'error', 'complete'])(
-    'settles the suspended render promise after asynchronous %s',
-    async event => {
-      let sink: ?Sink<GraphQLResponse>;
-      const observable = Observable.create<GraphQLResponse>(value => {
-        sink = value;
-      });
-      const pending = captureSuspense(() =>
-        resource.prepare(operation, observable, 'network-only', 'full'),
-      );
-      const settled = jest.fn();
-      pending.then(settled);
-      await Promise.resolve();
-      expect(settled).not.toHaveBeenCalled();
-
-      const error = new Error('Asynchronous transport error');
       if (event === 'next') {
-        nullthrows(sink).next({data: {}});
-      } else if (event === 'error') {
-        nullthrows(sink).error(error);
-      } else {
-        nullthrows(sink).complete();
-      }
-
-      // Flush Promise reactions without waiting for an unresolved promise to
-      // time out: missing wake-ups must fail at this assertion.
-      await Promise.resolve();
-      expect(settled).toHaveBeenCalledTimes(1);
-      expect(settled).toHaveBeenCalledWith(undefined);
-      if (event === 'next') {
+        expect(replacement.getValue()).toMatchObject({
+          operation,
+          fragmentNode: operation.fragment.node,
+        });
         expect(
-          resource.prepare(operation, observable, 'network-only', 'full'),
-        ).toMatchObject({operation, fragmentNode: operation.fragment.node});
-      } else if (event === 'error') {
+          resource.prepare(operation, second, 'network-only', 'full'),
+        ).toBe(replacement.getValue());
+      } else {
+        expect(replacement.getValue()).toBe(replacementError);
         expect(() =>
-          resource.prepare(operation, observable, 'network-only', 'full'),
-        ).toThrow(error);
+          resource.prepare(operation, second, 'network-only', 'full'),
+        ).toThrow(replacementError);
       }
     },
   );
 
-  it('keeps a synchronous first payload renderable', () => {
-    const observable = Observable.create<GraphQLResponse>(sink => {
-      sink.next({data: {}});
-      sink.complete();
+  it('settles the suspended render promise when a request completes without data', async () => {
+    let sink: ?Sink<GraphQLResponse>;
+    const observable = Observable.create<GraphQLResponse>(value => {
+      sink = value;
     });
-    expect(
-      resource.prepare(operation, observable, 'network-only', 'full')
-        .fragmentNode,
-    ).toBe(operation.fragment.node);
-  });
-
-  it('throws a synchronous first error instead of a pending promise', () => {
-    const error = new Error('Synchronous transport error');
-    const observable = Observable.create<GraphQLResponse>(sink =>
-      sink.error(error),
-    );
-    expect(() =>
+    const pending = captureSuspense(() =>
       resource.prepare(operation, observable, 'network-only', 'full'),
-    ).toThrow(error);
+    );
+    const settled = jest.fn();
+    pending.then(settled);
+    await Promise.resolve();
+    expect(settled).not.toHaveBeenCalled();
+
+    nullthrows(sink).complete();
+
+    // A completion without a payload cannot rely on next to wake the render.
+    await Promise.resolve();
+    expect(settled).toHaveBeenCalledTimes(1);
+    expect(settled).toHaveBeenCalledWith(undefined);
   });
 });

--- a/packages/react-relay/relay-hooks/__tests__/QueryResource-fetch-ownership-test.js
+++ b/packages/react-relay/relay-hooks/__tests__/QueryResource-fetch-ownership-test.js
@@ -1,0 +1,240 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+import type {GraphQLResponse, Sink} from 'relay-runtime';
+
+const {getQueryResourceForEnvironment} = require('../QueryResource');
+const gqlQuery = require('./__generated__/QueryResourceTest2Query.graphql');
+const invariant = require('invariant');
+const nullthrows = require('nullthrows');
+const {
+  __internal: {fetchQuery},
+  Observable,
+  RecordSource,
+  Store,
+  createOperationDescriptor,
+} = require('relay-runtime');
+const {createMockEnvironment} = require('relay-test-utils-internal');
+
+function captureSuspense(callback: () => unknown): Promise<unknown> {
+  try {
+    callback();
+  } catch (value) {
+    invariant(value instanceof Promise, 'Expected the query to suspend');
+    return value;
+  }
+  throw new Error('Expected the query to suspend');
+}
+
+describe('QueryResource fetch ownership and GC recovery', () => {
+  let environment;
+  let resource;
+  let operation;
+  let store;
+  let gcTasks: Array<() => void>;
+
+  beforeEach(() => {
+    // Exercise the normal release buffer, rather than forcing buffer size zero.
+    gcTasks = [];
+    store = new Store(new RecordSource(), {
+      gcScheduler: task => {
+        gcTasks.push(task);
+      },
+    });
+    environment = createMockEnvironment({store});
+    resource = getQueryResourceForEnvironment(environment);
+    operation = createOperationDescriptor(gqlQuery, {id: 'target'});
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+  });
+
+  it('refetches on revisit after a late payload and normal release-buffer churn', () => {
+    const result = resource.prepare(
+      operation,
+      fetchQuery(environment, operation),
+      'store-and-network',
+      'partial',
+    );
+    const retained = resource.retain(result);
+    retained.dispose();
+
+    environment.mock.resolve(operation, {
+      data: {
+        node: {__typename: 'User', id: 'target', name: 'Before navigation'},
+      },
+    });
+    expect(store.getSource().get('target')).toBeDefined();
+
+    // Ten other releases evict the target operation from the default buffer.
+    for (let index = 0; index < 10; index++) {
+      const id = 'other-' + index;
+      const other = createOperationDescriptor(gqlQuery, {id});
+      const retain = environment.retain(other);
+      environment.commitPayload(other, {
+        node: {__typename: 'User', id, name: id},
+      });
+      retain.dispose();
+    }
+    while (gcTasks.length > 0) {
+      nullthrows(gcTasks.shift())();
+    }
+    expect(store.getSource().get('target')).toBeUndefined();
+    expect(environment.check(operation).status).toBe('missing');
+
+    resource.prepare(
+      operation,
+      fetchQuery(environment, operation),
+      'store-and-network',
+      'partial',
+    );
+    expect(environment.mock.isLoading(gqlQuery, {id: 'target'})).toBe(true);
+
+    environment.mock.resolve(operation, {
+      data: {node: {__typename: 'User', id: 'target', name: 'After revisit'}},
+    });
+    expect(environment.lookup(operation.fragment).data).toMatchObject({
+      node: {name: 'After revisit'},
+    });
+  });
+
+  it.each(['next', 'error'])(
+    'does not recreate a disposed entry after late %s',
+    event => {
+      let sink: ?Sink<GraphQLResponse>;
+      const observable = Observable.create<GraphQLResponse>(value => {
+        sink = value;
+      });
+      captureSuspense(() =>
+        resource.prepare(operation, observable, 'network-only', 'full'),
+      );
+      jest.runAllTimers();
+      expect(
+        resource.TESTS_ONLY__getCacheEntry(operation, 'network-only', 'full'),
+      ).toBeUndefined();
+
+      if (event === 'next') {
+        nullthrows(sink).next({data: {}});
+      } else {
+        nullthrows(sink).error(new Error('Late error from retired fetch'));
+      }
+
+      expect(
+        resource.TESTS_ONLY__getCacheEntry(operation, 'network-only', 'full'),
+      ).toBeUndefined();
+    },
+  );
+
+  it('delivers a shared in-flight request to a separately retained entry', () => {
+    const firstResult = resource.prepare(
+      operation,
+      fetchQuery(environment, operation),
+      'store-and-network',
+      'partial',
+    );
+    resource.retain(firstResult).dispose();
+    const secondResult = resource.prepare(
+      operation,
+      fetchQuery(environment, operation),
+      'store-and-network',
+      'partial',
+      null,
+      'replacement',
+    );
+    const retained = resource.retain(secondResult);
+    expect(environment.mock.getAllOperations()).toHaveLength(1);
+
+    environment.mock.resolve(operation, {
+      data: {node: {__typename: 'User', id: 'target', name: 'Shared result'}},
+    });
+
+    expect(
+      resource.TESTS_ONLY__getCacheEntry(
+        operation,
+        'store-and-network',
+        'partial',
+      ),
+    ).toBeUndefined();
+    expect(
+      nullthrows(
+        resource.TESTS_ONLY__getCacheEntry(
+          operation,
+          'store-and-network',
+          'partial',
+          'replacement',
+        ),
+      ).getValue(),
+    ).toEqual(secondResult);
+    expect(environment.lookup(operation.fragment).data).toMatchObject({
+      node: {name: 'Shared result'},
+    });
+    retained.dispose();
+  });
+
+  it.each(['next', 'error'])(
+    'does not overwrite a replacement entry with an older fetch %s',
+    event => {
+      let firstSink: ?Sink<GraphQLResponse>;
+      const first = Observable.create<GraphQLResponse>(value => {
+        firstSink = value;
+      });
+      captureSuspense(() =>
+        resource.prepare(operation, first, 'network-only', 'full'),
+      );
+      jest.runAllTimers();
+
+      let secondSink: ?Sink<GraphQLResponse>;
+      const second = Observable.create<GraphQLResponse>(value => {
+        secondSink = value;
+      });
+      const pending = captureSuspense(() =>
+        resource.prepare(operation, second, 'network-only', 'full'),
+      );
+      const replacement = nullthrows(
+        resource.TESTS_ONLY__getCacheEntry(operation, 'network-only', 'full'),
+      );
+
+      if (event === 'next') {
+        nullthrows(firstSink).next({data: {}});
+      } else {
+        nullthrows(firstSink).error(new Error('Old fetch failed'));
+      }
+
+      expect(replacement.getValue()).toBe(pending);
+      nullthrows(secondSink).next({data: {}});
+      expect(replacement.getValue()).not.toBe(pending);
+    },
+  );
+
+  it('keeps a synchronous first payload renderable', () => {
+    const observable = Observable.create<GraphQLResponse>(sink => {
+      sink.next({data: {}});
+      sink.complete();
+    });
+    expect(
+      resource.prepare(operation, observable, 'network-only', 'full')
+        .fragmentNode,
+    ).toBe(operation.fragment.node);
+  });
+
+  it('throws a synchronous first error instead of a pending promise', () => {
+    const error = new Error('Synchronous transport error');
+    const observable = Observable.create<GraphQLResponse>(sink =>
+      sink.error(error),
+    );
+    expect(() =>
+      resource.prepare(operation, observable, 'network-only', 'full'),
+    ).toThrow(error);
+  });
+});


### PR DESCRIPTION

An in-flight request can outlive its QueryResource entry. If another entry is created under the same cache identifier before the old request delivers a result, key-based lookups in the old callbacks can update the replacement with the old request's result or error.

If a response arriving after navigation recreates a disposed cache entry, a later revisit can reuse that entry even after GC has collected the underlying data. The required fetch may never start, leaving the revisit without a path to recover that data. If a replacement entry already exists, an earlier request's success or failure can instead overwrite the new request's pending state, making a result or error from the earlier request influence rendering for the current one.

This fix makes each request's callbacks update only their own entry, allowing the required recovery fetch on revisit and protecting a new request's pending state from an earlier request's result or error. Other consumers sharing the request must continue to receive its payload, and each request's Suspense promise must still settle through its own completion path.

Keep a reference to the entry created by each `_fetchAndSaveQuery` invocation. The first synchronous payload or error can still initialize the entry. Later callbacks finish that entry without looking up or recreating a different entry by key. The request continues to deliver data to other consumers, and the existing observer notifications and suspense promise completion are preserved.

Regression coverage includes:

- Old `next` and `error` callbacks cannot overwrite a pending replacement.
- Late callbacks cannot recreate a disposed entry.
- Revisiting after a late payload and default ten-entry release-buffer churn starts a request and restores the collected data.
- A separately retained entry receives exactly one `observer.next` with the complete response snapshot and one `observer.complete` from a shared in-flight request.
- An old request settles its own Suspense promise without settling the replacement request's promise. The replacement's own success or error settles that promise, then returns the expected QueryResult or throws its own error.
- Asynchronous `next`, `error`, and `complete` each settle the Promise thrown to suspend the render. Promise reactions are checked directly, so missing wake-ups fail an assertion instead of merely timing out.
- Synchronous first success and first error are covered by the existing QueryResource suite; duplicate tests are omitted here.

Validation on the independent branch:

- Seven focused tests pass. Running them on unmodified main produces six failures and one passing completion control.
- Applying the compared facebook/relay#5317 source patch to the same baseline leaves the two replacement-entry tests failing; the other five tests pass.
- All 64 existing QueryResource tests also pass, for 71 passing tests in the focused run.
- The independent branch passes all 246 Jest suites: 3,783 tests and 164 snapshots, with 20 tests skipped. Flow reports zero errors; ESLint and Prettier pass for the changed files.
- Mutation checks: suppressing the shared consumer's `next` callback or observer completion each fails one test. Removing Promise completion from `next`, `error`, or `complete` each fails one test. These mutations were run separately from the submitted code.
- Coverage consolidation: success/error promise completion is asserted inside the replacement-entry tests, while completion without a payload remains a separate test. Rejecting initial synchronous success or error is caught by four existing tests in each mutation run. The new suite shrinks from eleven to seven cases while retaining detection of all five previously tested callback/wake-up faults.