### PR TITLE
Fix re-retained operations being swept during TTL GC

### DIFF
--- a/packages/relay-runtime/store/RelayModernStore.js
+++ b/packages/relay-runtime/store/RelayModernStore.js
@@ -423,6 +423,12 @@ class RelayModernStore implements Store {
         // there since it's retained. Remove it to maintain the invariant that
         // all release buffer entries have a refCount of 0.
         this._releaseBuffer = this._releaseBuffer.filter(_id => _id !== id);
+        if (this._shouldRetainWithinTTL_EXPERIMENTAL && this._gcRun != null) {
+          // GC may have skipped this unretained root. Reinsert the same entry
+          // so the live Map iterator revisits it without losing fetch metadata.
+          this._roots.delete(id);
+          this._roots.set(id, rootEntry);
+        }
       }
       // If we've previously retained this operation, increment the refCount
       rootEntry.refCount += 1;

--- a/packages/relay-runtime/store/__tests__/RelayModernStore-TTLGC-test.js
+++ b/packages/relay-runtime/store/__tests__/RelayModernStore-TTLGC-test.js
@@ -1,0 +1,176 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ * @oncall relay
+ */
+
+'use strict';
+
+const {
+  createOperationDescriptor,
+} = require('../RelayModernOperationDescriptor');
+const RelayModernRecord = require('../RelayModernRecord');
+const RelayModernStore = require('../RelayModernStore');
+const RelayRecordSource = require('../RelayRecordSource');
+const {ROOT_ID, ROOT_TYPE} = require('../RelayStoreUtils');
+const NodeQuery = require('./__generated__/RelayModernStoreTest8Query.graphql');
+
+const QUERY_CACHE_EXPIRATION_TIME = 1000;
+
+describe.each([0, undefined])(
+  'TTL garbage collection with release buffer size %s',
+  gcReleaseBufferSize => {
+    let currentTime: number;
+    let schedulerQueue: Array<() => void>;
+    let source;
+    let store;
+
+    function runNextScheduledJob(): void {
+      const job = schedulerQueue.shift();
+      expect(job).toBeDefined();
+      if (job == null) {
+        throw new Error('Expected a scheduled GC job');
+      }
+      job();
+    }
+
+    function runScheduledJobs(): void {
+      let jobs = 0;
+      while (schedulerQueue.length > 0) {
+        runNextScheduledJob();
+        if (++jobs > 1000) {
+          throw new Error('GC did not finish in 1000 scheduler jobs');
+        }
+      }
+    }
+
+    function writeAndRetainNode(nodeID: string) {
+      const operation = createOperationDescriptor(NodeQuery, {id: nodeID});
+      const disposable = store.retain(operation);
+      const rootRecord = RelayModernRecord.create(ROOT_ID, ROOT_TYPE);
+      RelayModernRecord.setLinkedRecordID(
+        rootRecord,
+        `node(id:"${nodeID}")`,
+        nodeID,
+      );
+      const nextSource = RelayRecordSource.create({
+        [nodeID]: {__id: nodeID, __typename: 'User', id: nodeID},
+      });
+      nextSource.set(ROOT_ID, rootRecord);
+      store.publish(nextSource);
+      store.notify(operation);
+      return {operation, disposable};
+    }
+
+    function evictFirstReleasedOperation(): void {
+      // Omitting the option exercises the default ten-entry release buffer.
+      // A zero-sized buffer has already evicted the first released operation.
+      if (gcReleaseBufferSize == null) {
+        for (let ii = 0; ii < 10; ii++) {
+          writeAndRetainNode(`buffered-${ii}`).disposable.dispose();
+        }
+      }
+    }
+
+    beforeEach(() => {
+      currentTime = 10000;
+      jest.spyOn(Date, 'now').mockImplementation(() => currentTime);
+      schedulerQueue = [];
+      source = RelayRecordSource.create();
+      store = new RelayModernStore(source, {
+        gcReleaseBufferSize,
+        gcScheduler: job => {
+          schedulerQueue.push(job);
+        },
+        queryCacheExpirationTime: QUERY_CACHE_EXPIRATION_TIME,
+        shouldRetainWithinTTL_EXPERIMENTAL: true,
+      });
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('preserves an expired operation retained after GC skipped it', () => {
+      const {operation, disposable} = writeAndRetainNode('a');
+      writeAndRetainNode('b');
+      disposable.dispose();
+      evictFirstReleasedOperation();
+      currentTime += QUERY_CACHE_EXPIRATION_TIME;
+
+      // GC skips expired A, marks retained B, and yields before sweeping.
+      runNextScheduledJob();
+      expect(source.has('a')).toBe(true);
+      expect(store.lookup(operation.fragment).isMissingData).toBe(false);
+      expect(store.check(operation).status).toBe('stale');
+      const epoch = store.getEpoch();
+
+      // Re-retaining without publishing must protect A in this same GC run.
+      const retained = store.retain(operation);
+      runScheduledJobs();
+
+      expect(source.has('a')).toBe(true);
+      expect(store.lookup(operation.fragment).isMissingData).toBe(false);
+      expect(store.check(operation).status).toBe('stale');
+      expect(store.getEpoch()).toBe(epoch);
+      expect(source.has('b')).toBe(true);
+
+      // A subsequent real release must still make A eligible for collection.
+      retained.dispose();
+      runScheduledJobs();
+      expect(source.has('a')).toBe(false);
+      expect(source.has('b')).toBe(true);
+    });
+
+    it('preserves released operations until their TTL expires', () => {
+      const {operation, disposable} = writeAndRetainNode('a');
+      writeAndRetainNode('b');
+      disposable.dispose();
+      evictFirstReleasedOperation();
+      currentTime += QUERY_CACHE_EXPIRATION_TIME - 1;
+
+      runScheduledJobs();
+
+      expect(source.has('a')).toBe(true);
+      expect(store.check(operation).status).toBe('available');
+    });
+
+    if (gcReleaseBufferSize == null) {
+      it('preserves expired operations that remain in the release buffer', () => {
+        const {operation, disposable} = writeAndRetainNode('a');
+        const {disposable: disposableB} = writeAndRetainNode('b');
+        disposable.dispose();
+        currentTime += QUERY_CACHE_EXPIRATION_TIME;
+
+        // Disposing stale B schedules GC without evicting A from the buffer.
+        disposableB.dispose();
+        runScheduledJobs();
+
+        expect(source.has('a')).toBe(true);
+        expect(store.lookup(operation.fragment).isMissingData).toBe(false);
+        expect(source.has('b')).toBe(false);
+      });
+    }
+
+    it('preserves data retained after a stale operation was disposed', () => {
+      const {operation, disposable} = writeAndRetainNode('a');
+      writeAndRetainNode('b');
+      currentTime += QUERY_CACHE_EXPIRATION_TIME;
+      // A stale release bypasses even the default release buffer.
+      disposable.dispose();
+
+      runNextScheduledJob();
+      store.retain(operation);
+      runScheduledJobs();
+
+      expect(source.has('a')).toBe(true);
+      expect(store.lookup(operation.fragment).isMissingData).toBe(false);
+      expect(store.check(operation).status).toBe('stale');
+    });
+  },
+);


### PR DESCRIPTION

With `shouldRetainWithinTTL_EXPERIMENTAL` enabled, an incremental GC pass can sweep an operation's records after the operation has been retained again.

A screen can retain a query for use again, yet a previously complete read can become `isMissingData` solely because of GC scheduling. Losing records while the caller correctly holds a retain can force the application to recover data it already had. This fix includes operations retained again while GC was yielding in the set of records to preserve, preventing their collection despite an active retain.

Keeping data in memory and treating it as fresh are separate decisions. The change preserves the existing stale status so required revalidation is not skipped, while still allowing memory to be reclaimed after the final retain is released.

The failing sequence is:

1. GC skips expired, unretained operation A, which is outside the release buffer.
2. GC marks retained operation B and yields.
3. `retain(A)` increments the existing root entry without a store write.
4. The roots iterator has already passed A, so GC sweeps its records despite the active retain.

Reinsert the existing root entry when its reference count changes from zero during an active TTL GC pass. The live Map iterator then visits it again before sweeping. Reusing the entry preserves its fetch time and invalidation epoch, and retention does not advance the store's write epoch.

The seven regression tests use public retain/dispose calls and a controllable GC scheduler. They cover both a zero-sized release buffer and actual eviction from the default ten-entry buffer, stale disposal that bypasses the buffer, TTL and release-buffer controls, freshness preservation, and collection after the final release.

Validation:

- Base `52c26aed65a496182f2fa978f9911db5be4f652d` with the new tests: four regressions fail and three controls pass.
- With this change, the new tests and existing `RelayModernStore` tests pass: 331 tests across two suites.
- Full Jest on this branch: 246 suites and 3,783 tests pass; 20 tests are skipped, and all 164 snapshots pass.
- `flow full-check --max-workers 2 --show-all-errors`: zero errors.
- Prettier and ESLint pass for both changed files.

This change preserves the existing root-metadata cleanup policy; that policy can be reviewed separately from the retained-data race.